### PR TITLE
[#129] #EXTEND 'assemblyName: DotNet.Testcontainers; function: IDockerContainer'

### DIFF
--- a/src/DotNet.Testcontainers.Tests/Unit/Linux/TestcontainersContainerTest.cs
+++ b/src/DotNet.Testcontainers.Tests/Unit/Linux/TestcontainersContainerTest.cs
@@ -112,14 +112,14 @@ namespace DotNet.Testcontainers.Tests.Unit.Linux
 
         var https = new { From = 443, To = 80 };
 
-        var nginx = new TestcontainersBuilder<TestcontainersContainer>()
+        var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
           .WithImage("nginx");
 
         // When
         // Then
         foreach (var port in new[] { http, https })
         {
-          using (var testcontainer = nginx
+          using (var testcontainer = testcontainersBuilder
             .WithPortBinding(port.From, port.To)
             .WithWaitStrategy(Wait.UntilPortsAreAvailable(port.To))
             .Build())
@@ -134,6 +134,23 @@ namespace DotNet.Testcontainers.Tests.Unit.Linux
 
             Assert.True(isAvailable, $"nginx port {port.From} is not available.");
           }
+        }
+      }
+
+      [Fact]
+      public async Task RandomHostPortBindings()
+      {
+        // Given
+        var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+          .WithImage("nginx")
+          .WithPortBinding(80, true);
+
+        // When
+        // Then
+        using (var testcontainer = testcontainersBuilder.Build())
+        {
+          await testcontainer.StartAsync();
+          Assert.NotEqual(0, testcontainer.GetMappedPublicPort(80));
         }
       }
 

--- a/src/DotNet.Testcontainers/Core/Builder/TestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Core/Builder/TestcontainersBuilder.cs
@@ -110,8 +110,7 @@ namespace DotNet.Testcontainers.Core.Builder
 
     public ITestcontainersBuilder<T> WithPortBinding(int port, bool assignRandomHostPort = false)
     {
-      var hostPort = assignRandomHostPort ? TestcontainersNetworkService.GetAvailablePort() : port;
-      return this.WithPortBinding(hostPort, port);
+      return this.WithPortBinding($"{port}", assignRandomHostPort);
     }
 
     public ITestcontainersBuilder<T> WithPortBinding(int hostPort, int containerPort)

--- a/src/DotNet.Testcontainers/Core/Containers/IDockerContainer.cs
+++ b/src/DotNet.Testcontainers/Core/Containers/IDockerContainer.cs
@@ -22,6 +22,20 @@ namespace DotNet.Testcontainers.Core.Containers
     string MacAddress { get; }
 
     /// <summary>
+    /// Gets the public host port associated with the private container port.
+    /// </summary>
+    /// <param name="privatePort">Private container port.</param>
+    /// <returns>Returns the public host port associated with the private container port.</returns>
+    int GetMappedPublicPort(int privatePort);
+
+    /// <summary>
+    /// Gets the public host port associated with the private container port.
+    /// </summary>
+    /// <param name="privatePort">Private container port.</param>
+    /// <returns>Returns the public host port associated with the private container port.</returns>
+    int GetMappedPublicPort(string privatePort);
+
+    /// <summary>
     /// Starts the Testcontainer. If the image does not exist, it will be downloaded automatically. Non-existing containers are created at first start.
     /// </summary>
     /// <returns>A task that represents the asynchronous start operation of a Testcontainer.</returns>

--- a/src/DotNet.Testcontainers/Core/Containers/TestcontainersContainer.cs
+++ b/src/DotNet.Testcontainers/Core/Containers/TestcontainersContainer.cs
@@ -66,7 +66,7 @@ namespace DotNet.Testcontainers.Core.Containers
         }
 
         var ipAddress = this.container.NetworkSettings.Networks.FirstOrDefault();
-        return ipAddress.Value == null ? string.Empty : ipAddress.Value.IPAddress;
+        return ipAddress.Value?.IPAddress ?? string.Empty;
       }
     }
 
@@ -80,11 +80,27 @@ namespace DotNet.Testcontainers.Core.Containers
         }
 
         var macAddress = this.container.NetworkSettings.Networks.FirstOrDefault();
-        return macAddress.Value == null ? string.Empty : macAddress.Value.IPAddress;
+        return macAddress.Value?.MacAddress ?? string.Empty;
       }
     }
 
     private TestcontainersConfiguration Configuration { get; }
+
+    public int GetMappedPublicPort(int privatePort)
+    {
+      return this.GetMappedPublicPort($"{privatePort}");
+    }
+
+    public int  GetMappedPublicPort(string privatePort)
+    {
+      if (this.container == null)
+      {
+        throw new InvalidOperationException("Testcontainer is not running.");
+      }
+
+      var mappedPort = this.container.Ports.FirstOrDefault(port => $"{port.PrivatePort}".Equals(privatePort));
+      return mappedPort?.PublicPort ?? 0;
+    }
 
     public async Task StartAsync()
     {


### PR DESCRIPTION
{Add GetMappedPublicPort to get the public host port associated with the private container port.}