### PR TITLE
[#135] #EXTEND 'assemblyName: DotNet.Testcontainers; function: IDockerContainer'

### DIFF
--- a/src/DotNet.Testcontainers.Tests/Unit/Linux/TestcontainersContainerTest.cs
+++ b/src/DotNet.Testcontainers.Tests/Unit/Linux/TestcontainersContainerTest.cs
@@ -89,6 +89,24 @@ namespace DotNet.Testcontainers.Tests.Unit.Linux
       }
 
       [Fact]
+      public async Task WorkingDirectory()
+      {
+        // Given
+        var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+          .WithImage("alpine")
+          .WithWorkingDirectory("/tmp")
+          .WithCommand("/bin/ash", "-c", "test -d /tmp && exit $? || exit $?");
+
+        // When
+        // Then
+        using (var testcontainer = testcontainersBuilder.Build())
+        {
+          await testcontainer.StartAsync();
+          Assert.Equal(0, await testcontainer.GetExitCode());
+        }
+      }
+
+      [Fact]
       public async Task ExposedPorts()
       {
         // Given

--- a/src/DotNet.Testcontainers/Clients/MetaDataClientContainers.cs
+++ b/src/DotNet.Testcontainers/Clients/MetaDataClientContainers.cs
@@ -8,13 +8,13 @@ namespace DotNet.Testcontainers.Clients
 
   internal sealed class MetaDataClientContainers : DockerMetaDataClient<ContainerListResponse>
   {
-    private static readonly Lazy<DockerMetaDataClient<ContainerListResponse>> MetaDataClient = new Lazy<DockerMetaDataClient<ContainerListResponse>>(() => new MetaDataClientContainers());
+    private static readonly Lazy<MetaDataClientContainers> MetaDataClient = new Lazy<MetaDataClientContainers>(() => new MetaDataClientContainers());
 
     private MetaDataClientContainers()
     {
     }
 
-    internal static DockerMetaDataClient<ContainerListResponse> Instance { get; } = MetaDataClient.Value;
+    internal static MetaDataClientContainers Instance { get; } = MetaDataClient.Value;
 
     internal override async Task<IReadOnlyCollection<ContainerListResponse>> GetAllAsync()
     {
@@ -53,6 +53,11 @@ namespace DotNet.Testcontainers.Clients
       });
 
       return (await response).FirstOrDefault();
+    }
+
+    internal Task<long> GetExitCode(string id)
+    {
+      return Task.Run(async () => (await Docker.Containers.WaitContainerAsync(id)).StatusCode);
     }
   }
 }

--- a/src/DotNet.Testcontainers/Clients/MetaDataClientImages.cs
+++ b/src/DotNet.Testcontainers/Clients/MetaDataClientImages.cs
@@ -8,13 +8,13 @@ namespace DotNet.Testcontainers.Clients
 
   internal sealed class MetaDataClientImages : DockerMetaDataClient<ImagesListResponse>
   {
-    private static readonly Lazy<DockerMetaDataClient<ImagesListResponse>> MetaDataClient = new Lazy<DockerMetaDataClient<ImagesListResponse>>(() => new MetaDataClientImages());
+    private static readonly Lazy<MetaDataClientImages> MetaDataClient = new Lazy<MetaDataClientImages>(() => new MetaDataClientImages());
 
     private MetaDataClientImages()
     {
     }
 
-    internal static DockerMetaDataClient<ImagesListResponse> Instance { get; } = MetaDataClient.Value;
+    internal static MetaDataClientImages Instance { get; } = MetaDataClient.Value;
 
     internal override async Task<IReadOnlyCollection<ImagesListResponse>> GetAllAsync()
     {

--- a/src/DotNet.Testcontainers/Core/Containers/IDockerContainer.cs
+++ b/src/DotNet.Testcontainers/Core/Containers/IDockerContainer.cs
@@ -36,6 +36,12 @@ namespace DotNet.Testcontainers.Core.Containers
     int GetMappedPublicPort(string privatePort);
 
     /// <summary>
+    /// Gets the Testcontainer exit code.
+    /// </summary>
+    /// <returns>Returns the Docker container exit code.</returns>
+    Task<long> GetExitCode();
+
+    /// <summary>
     /// Starts the Testcontainer. If the image does not exist, it will be downloaded automatically. Non-existing containers are created at first start.
     /// </summary>
     /// <returns>A task that represents the asynchronous start operation of a Testcontainer.</returns>

--- a/src/DotNet.Testcontainers/Core/Containers/TestcontainersContainer.cs
+++ b/src/DotNet.Testcontainers/Core/Containers/TestcontainersContainer.cs
@@ -91,7 +91,7 @@ namespace DotNet.Testcontainers.Core.Containers
       return this.GetMappedPublicPort($"{privatePort}");
     }
 
-    public int  GetMappedPublicPort(string privatePort)
+    public int GetMappedPublicPort(string privatePort)
     {
       if (this.container == null)
       {
@@ -100,6 +100,11 @@ namespace DotNet.Testcontainers.Core.Containers
 
       var mappedPort = this.container.Ports.FirstOrDefault(port => $"{port.PrivatePort}".Equals(privatePort));
       return mappedPort?.PublicPort ?? 0;
+    }
+
+    public Task<long> GetExitCode()
+    {
+      return MetaDataClientContainers.Instance.GetExitCode(this.Id);
     }
 
     public async Task StartAsync()


### PR DESCRIPTION
{Add GetExitCode to IDockerContainer.}