### PR TITLE
Issue 153 - Update pre-configured TestContainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Keep in mind to enable the correct Docker engine on Windows host systems to matc
 The pre-configured Testcontainers below are supported. Further examples can be found in [TestcontainersContainerTest][1] as well as in [database][2] or [message broker][3] tests.
 
 - CouchDB (couchdb:2.3.1)
-- MsSql (server:2017-CU14-ubuntu)
-- MySql (mysql:8.0.15)
-- PostgreSql (postgres:11.2)
-- Redis (redis:5.0.5)
-- RabbitMQ (rabbitmq:3.7.15)
+- MsSql (server:2019-CTP3.2-ubuntu)
+- MySql (mysql:8.0.18)
+- PostgreSql (postgres:12.0)
+- Redis (redis:5.0.6)
+- RabbitMQ (rabbitmq:3.8.0)
 
 ## Examples
 

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/MsSqlTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/MsSqlTestcontainerConfiguration.cs
@@ -6,7 +6,7 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
 
   public sealed class MsSqlTestcontainerConfiguration : TestcontainerDatabaseConfiguration
   {
-    public MsSqlTestcontainerConfiguration() : base("mcr.microsoft.com/mssql/server:2017-CU14-ubuntu", 1433)
+    public MsSqlTestcontainerConfiguration() : base("mcr.microsoft.com/mssql/server:2019-CTP3.2-ubuntu", 1433)
     {
       this.Environments["ACCEPT_EULA"] = "Y";
     }

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/MySqlTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/MySqlTestcontainerConfiguration.cs
@@ -5,7 +5,7 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
 
   public sealed class MySqlTestcontainerConfiguration : TestcontainerDatabaseConfiguration
   {
-    public MySqlTestcontainerConfiguration() : base("mysql:8.0.15", 3306)
+    public MySqlTestcontainerConfiguration() : base("mysql:8.0.18", 3306)
     {
       this.Environments["MYSQL_ALLOW_EMPTY_PASSWORD"] = "yes";
     }

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/PostgreSqlTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/PostgreSqlTestcontainerConfiguration.cs
@@ -5,7 +5,7 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
 
   public sealed class PostgreSqlTestcontainerConfiguration : TestcontainerDatabaseConfiguration
   {
-    public PostgreSqlTestcontainerConfiguration() : base("postgres:11.2", 5432)
+    public PostgreSqlTestcontainerConfiguration() : base("postgres:12.0", 5432)
     {
     }
 

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/RedisTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/RedisTestcontainerConfiguration.cs
@@ -6,7 +6,7 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
 
   public sealed class RedisTestcontainerConfiguration : TestcontainerDatabaseConfiguration
   {
-    public RedisTestcontainerConfiguration() : base("redis:5.0.5", 6379)
+    public RedisTestcontainerConfiguration() : base("redis:5.0.6", 6379)
     {
     }
 

--- a/src/DotNet.Testcontainers/Containers/Configurations/MessageBrokers/RabbitMqTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/MessageBrokers/RabbitMqTestcontainerConfiguration.cs
@@ -5,7 +5,7 @@ namespace DotNet.Testcontainers.Containers.Configurations.MessageBrokers
 
   public sealed class RabbitMqTestcontainerConfiguration : TestcontainerMessageBrokerConfiguration
   {
-    public RabbitMqTestcontainerConfiguration() : base("rabbitmq:3.7.15", 5672)
+    public RabbitMqTestcontainerConfiguration() : base("rabbitmq:3.8.0", 5672)
     {
     }
 


### PR DESCRIPTION
First PR, let me know if should be done differently. 

[3] #CHANGE 'assemblyName: DotNet.Testcontainers.Containers.Configurations.Databases; function: [DbType]TestcontainerConfiguration'  
{Update the version number of base where applicable.}

CouchDB - Found to be on latest version.
MsSql - Updated to latest Server 2019 ubuntu version.
MySql - Updated from 8.0.15 -> 8.0.18.
PostGreSql - Updated to version 12.
Redis - Updated from 5.0.5 -> 5.0.6.
RabbitMQ - Updated to 3.8.0, did not update to 3.8.1 beta's or rc version.

Updated the readme to match version changes.