### PR TITLE
Change from bash to sh to execute shell commands

### DIFF
--- a/src/DotNet.Testcontainers.Tests/Unit/Containers/Linux/TestcontainersContainerTest.cs
+++ b/src/DotNet.Testcontainers.Tests/Unit/Containers/Linux/TestcontainersContainerTest.cs
@@ -97,7 +97,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Linux
         var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
           .WithImage("alpine")
           .WithWorkingDirectory("/tmp")
-          .WithCommand("/bin/ash", "-c", "test -d /tmp && exit $? || exit $?");
+          .WithCommand("/bin/sh", "-c", "test -d /tmp && exit $? || exit $?");
 
         // When
         // Then
@@ -114,7 +114,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Linux
         // Given
         var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
           .WithImage("alpine")
-          .WithEntrypoint("/bin/ash", "-c", "exit 255");
+          .WithEntrypoint("/bin/sh", "-c", "exit 255");
 
         // When
         // Then
@@ -204,7 +204,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Linux
           .WithImage("nginx")
           .WithMount(TempDir, $"/{target}")
           .WithWaitStrategy(Wait.UntilFilesExists($"{TempDir}/{file}"))
-          .WithCommand("/bin/bash", "-c", $"hostname > /{target}/{file}");
+          .WithCommand("/bin/sh", "-c", $"hostname > /{target}/{file}");
 
         using (var testcontainer = testcontainersBuilder.Build())
         {
@@ -231,7 +231,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Linux
           .WithMount(TempDir, $"/{target}")
           .WithEnvironment("dayOfWeek", dayOfWeek)
           .WithWaitStrategy(Wait.UntilFilesExists($"{TempDir}/{file}"))
-          .WithCommand("/bin/bash", "-c", $"printf $dayOfWeek > /{target}/{file}");
+          .WithCommand("/bin/sh", "-c", $"printf $dayOfWeek > /{target}/{file}");
 
         using (var testcontainer = testcontainersBuilder.Build())
         {
@@ -268,7 +268,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Linux
           var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
             .WithImage("nginx")
             .WithOutputConsumer(output)
-            .WithCommand("/bin/bash", "-c", "hostname > /dev/stdout && hostname > /dev/stderr");
+            .WithCommand("/bin/sh", "-c", "hostname > /dev/stdout && hostname > /dev/stderr");
 
           using (var testcontainer = testcontainersBuilder.Build())
           {
@@ -313,14 +313,14 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Linux
         // Given
         var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
           .WithImage("alpine")
-          .WithCommand("/bin/ash", "-c", "tail -f /dev/null");
+          .WithCommand("/bin/sh", "-c", "tail -f /dev/null");
 
         // When
         // Then
         using (var testcontainer = testcontainersBuilder.Build())
         {
           await testcontainer.StartAsync();
-          Assert.Equal(255, await testcontainer.ExecAsync(new [] { "/bin/ash", "-c", "exit 255" }));
+          Assert.Equal(255, await testcontainer.ExecAsync(new[] { "/bin/sh", "-c", "exit 255" }));
         }
       }
     }

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/CouchDbTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/CouchDbTestcontainerConfiguration.cs
@@ -21,6 +21,6 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
       set => this.Environments["COUCHDB_PASSWORD"] = value;
     }
 
-    public override IWaitUntil WaitStrategy => new WaitUntilBashCommandsAreCompleted($"curl -s 'http://{this.Hostname}:{this.DefaultPort}'");
+    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"curl -s 'http://{this.Hostname}:{this.DefaultPort}'");
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/MsSqlTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/MsSqlTestcontainerConfiguration.cs
@@ -29,6 +29,6 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
       set => this.Environments["SA_PASSWORD"] = value;
     }
 
-    public override IWaitUntil WaitStrategy => new WaitUntilBashCommandsAreCompleted($"/opt/mssql-tools/bin/sqlcmd -S '{this.Hostname},{this.DefaultPort}' -U '{this.Username}' -P '{this.Password}'");
+    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"/opt/mssql-tools/bin/sqlcmd -S '{this.Hostname},{this.DefaultPort}' -U '{this.Username}' -P '{this.Password}'");
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/MySqlTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/MySqlTestcontainerConfiguration.cs
@@ -28,6 +28,6 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
       set => this.Environments["MYSQL_PASSWORD"] = value;
     }
 
-    public override IWaitUntil WaitStrategy => new WaitUntilBashCommandsAreCompleted($"mysql --host='{this.Hostname}' --port='{this.DefaultPort}' --user='{this.Username}' --password='{this.Password}' --protocol=TCP --execute 'SHOW DATABASES;'");
+    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"mysql --host='{this.Hostname}' --port='{this.DefaultPort}' --user='{this.Username}' --password='{this.Password}' --protocol=TCP --execute 'SHOW DATABASES;'");
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/PostgreSqlTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/PostgreSqlTestcontainerConfiguration.cs
@@ -27,6 +27,6 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
       set => this.Environments["POSTGRES_PASSWORD"] = value;
     }
 
-    public override IWaitUntil WaitStrategy => new WaitUntilBashCommandsAreCompleted($"pg_isready -h '{this.Hostname}' -p '{this.DefaultPort}'");
+    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"pg_isready -h '{this.Hostname}' -p '{this.DefaultPort}'");
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/RedisTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/RedisTestcontainerConfiguration.cs
@@ -28,6 +28,6 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
       set => throw new NotImplementedException();
     }
 
-    public override IWaitUntil WaitStrategy => new WaitUntilBashCommandsAreCompleted("redis-cli ping");
+    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted("redis-cli ping");
   }
 }

--- a/src/DotNet.Testcontainers/Containers/WaitStrategies/Wait.cs
+++ b/src/DotNet.Testcontainers/Containers/WaitStrategies/Wait.cs
@@ -11,7 +11,7 @@ namespace DotNet.Testcontainers.Containers.WaitStrategies
 
     public static IWaitUntil UntilBashCommandsAreCompleted(params string[] commands)
     {
-      return new WaitUntilBashCommandsAreCompleted(commands);
+      return new WaitUntilShellCommandsAreCompleted(commands);
     }
 
     public static IWaitUntil UntilFilesExists(params string[] files)

--- a/src/DotNet.Testcontainers/Containers/WaitStrategies/WaitUntilBashCommandsAreCompleted.cs
+++ b/src/DotNet.Testcontainers/Containers/WaitStrategies/WaitUntilBashCommandsAreCompleted.cs
@@ -18,7 +18,7 @@
     {
       await WaitStrategy.WaitUntil(() => WaitUntilContainerIsRunning.WaitStrategy.Until(endpoint, id));
 
-      var exitCodes = await Task.WhenAll(this.bashCommands.Select(command => new TestcontainersClient(endpoint).ExecAsync(id, new[] { "/bin/bash", "-c", command })).ToList());
+      var exitCodes = await Task.WhenAll(this.bashCommands.Select(command => new TestcontainersClient(endpoint).ExecAsync(id, new[] { "/bin/sh", "-c", command })).ToList());
 
       return exitCodes.All(exitCode => 0L.Equals(exitCode));
     }

--- a/src/DotNet.Testcontainers/Containers/WaitStrategies/WaitUntilPortsAreAvailable.cs
+++ b/src/DotNet.Testcontainers/Containers/WaitStrategies/WaitUntilPortsAreAvailable.cs
@@ -2,7 +2,7 @@ namespace DotNet.Testcontainers.Containers.WaitStrategies
 {
   using System.Linq;
 
-  internal class WaitUntilPortsAreAvailable : WaitUntilBashCommandsAreCompleted
+  internal class WaitUntilPortsAreAvailable : WaitUntilShellCommandsAreCompleted
   {
     public WaitUntilPortsAreAvailable(params int[] ports) :
       base(ports.Select(port => $"true && (cat /proc/net/tcp{{,6}} | awk '{{print $2}}' | grep -i :{port} || nc -vz -w 1 localhost {port} || /bin/bash -c '</dev/tcp/localhost/{port}')").ToArray())

--- a/src/DotNet.Testcontainers/Containers/WaitStrategies/WaitUntilPortsAreAvailable.cs
+++ b/src/DotNet.Testcontainers/Containers/WaitStrategies/WaitUntilPortsAreAvailable.cs
@@ -5,7 +5,7 @@ namespace DotNet.Testcontainers.Containers.WaitStrategies
   internal class WaitUntilPortsAreAvailable : WaitUntilBashCommandsAreCompleted
   {
     public WaitUntilPortsAreAvailable(params int[] ports) :
-      base(ports.Select(port => $"timeout 15 bash -c \"echo > /dev/tcp/localhost/{port}\"").ToArray())
+      base(ports.Select(port => $"true && (cat /proc/net/tcp{{,6}} | awk '{{print $2}}' | grep -i :{port} || nc -vz -w 1 localhost {port} || /bin/bash -c '</dev/tcp/localhost/{port}')").ToArray())
     {
     }
   }

--- a/src/DotNet.Testcontainers/Containers/WaitStrategies/WaitUntilShellCommandsAreCompleted.cs
+++ b/src/DotNet.Testcontainers/Containers/WaitStrategies/WaitUntilShellCommandsAreCompleted.cs
@@ -1,15 +1,15 @@
-﻿namespace DotNet.Testcontainers.Containers.WaitStrategies
+namespace DotNet.Testcontainers.Containers.WaitStrategies
 {
   using System;
   using System.Linq;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Clients;
 
-  internal class WaitUntilBashCommandsAreCompleted : IWaitUntil
+  internal class WaitUntilShellCommandsAreCompleted : IWaitUntil
   {
     private readonly string[] bashCommands;
 
-    public WaitUntilBashCommandsAreCompleted(params string[] bashCommands)
+    public WaitUntilShellCommandsAreCompleted(params string[] bashCommands)
     {
       this.bashCommands = bashCommands;
     }


### PR DESCRIPTION
- `WaitUntilBashCommandsAreCompleted.cs`: changed from `/bin/bash` to `bin/sh` - `sh` will point to the actual implementation of the shell ( bash, dash, etc.. ).

-  `WaitUntilPortsAreAvailable.cs`: changed from `timeout 15 bash -c \"echo > /dev/tcp/localhost/8080\"` to a boolean expression with some ways to try and check if the port is available (like the testcontainers-java version does): `true && (cat /proc/net/tcp{{,6}} | awk '{{print $2}}' | grep -i :{port} || nc -vz -w 1 localhost {port} || /bin/bash -c '</dev/tcp/localhost/{port}')`;

- Renamed `WaitUntilBashCommandsAreCompleted.cs` to `WaitUntilShellCommandsAreCompleted.cs`

Issue #178 