### PR TITLE
Default HostedServiceContainer hostname to DockerEndpoint hostname if possible

### DIFF
--- a/src/DotNet.Testcontainers.Tests/Unit/Containers/Linux/TestcontainersContainerTest.cs
+++ b/src/DotNet.Testcontainers.Tests/Unit/Containers/Linux/TestcontainersContainerTest.cs
@@ -258,6 +258,38 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Linux
         }
       }
 
+      [Theory]
+      [InlineData("npipe://./pipe/docker_engine")]
+      [InlineData("unix:/var/run/docker.sock")]
+      public async Task HostnameShouldDefaultToLocalhostIfDockerEndpointSchemeIsNotTcp(string endpoint)
+      {
+        // Given
+        var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+          .WithDockerEndpoint(endpoint);
+
+        // When
+        // Then
+        await using (var testcontainer = testcontainersBuilder.Build())
+        {
+          Assert.Equal("localhost", testcontainer.Hostname);
+        }
+      }
+
+      [Fact]
+      public async Task HostnameShouldDefaultToDockerEndpointHostnameIfDockerEndpointSchemeIsTcp()
+      {
+        // Given
+        var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+          .WithDockerEndpoint("tcp://docker:2375");
+
+        // When
+        // Then
+        await using (var testcontainer = testcontainersBuilder.Build())
+        {
+          Assert.Equal("docker", testcontainer.Hostname);
+        }
+      }
+
       [Fact]
       public async Task OutputConsumer()
       {

--- a/src/DotNet.Testcontainers.Tests/Unit/Containers/TestcontainersAccessNotPreConfiguredTest.cs
+++ b/src/DotNet.Testcontainers.Tests/Unit/Containers/TestcontainersAccessNotPreConfiguredTest.cs
@@ -26,7 +26,6 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers
       Assert.Equal(0, notPreConfigured.DefaultPort);
       Assert.Equal(0, notPreConfigured.Port);
       Assert.Equal(0, notPreConfigured.Environments.Count);
-      Assert.Equal("localhost", notPreConfigured.Hostname);
       Assert.Null(notPreConfigured.Username);
       Assert.Null(notPreConfigured.Password);
       Assert.IsAssignableFrom<OutputConsumerNull>(notPreConfigured.OutputConsumer);

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderDatabaseExtension.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderDatabaseExtension.cs
@@ -21,7 +21,6 @@ namespace DotNet.Testcontainers.Containers.Builders
         .WithWaitStrategy(configuration.WaitStrategy)
         .ConfigureContainer(container =>
         {
-          container.Hostname = configuration.Hostname;
           container.Port = configuration.Port;
           container.Database = configuration.Database;
           container.Username = configuration.Username;

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderMessageBrokerExtension.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderMessageBrokerExtension.cs
@@ -21,7 +21,6 @@ namespace DotNet.Testcontainers.Containers.Builders
         .WithWaitStrategy(configuration.WaitStrategy)
         .ConfigureContainer(container =>
         {
-          container.Hostname = configuration.Hostname;
           container.Port = configuration.Port;
           container.Username = configuration.Username;
           container.Password = configuration.Password;

--- a/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/HostedServiceConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/HostedServiceConfiguration.cs
@@ -26,8 +26,6 @@ namespace DotNet.Testcontainers.Containers.Configurations.Abstractions
 
     public int Port { get; set; }
 
-    public virtual string Hostname { get; set; } = "localhost";
-
     public virtual string Username { get; set; }
 
     public virtual string Password { get; set; }

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/CouchDbTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/CouchDbTestcontainerConfiguration.cs
@@ -21,6 +21,6 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
       set => this.Environments["COUCHDB_PASSWORD"] = value;
     }
 
-    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"curl -s 'http://{this.Hostname}:{this.DefaultPort}'");
+    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"curl -s 'http://localhost:{this.DefaultPort}'");
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/MsSqlTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/MsSqlTestcontainerConfiguration.cs
@@ -29,6 +29,6 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
       set => this.Environments["SA_PASSWORD"] = value;
     }
 
-    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"/opt/mssql-tools/bin/sqlcmd -S '{this.Hostname},{this.DefaultPort}' -U '{this.Username}' -P '{this.Password}'");
+    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"/opt/mssql-tools/bin/sqlcmd -S 'localhost,{this.DefaultPort}' -U '{this.Username}' -P '{this.Password}'");
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/MySqlTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/MySqlTestcontainerConfiguration.cs
@@ -28,6 +28,6 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
       set => this.Environments["MYSQL_PASSWORD"] = value;
     }
 
-    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"mysql --host='{this.Hostname}' --port='{this.DefaultPort}' --user='{this.Username}' --password='{this.Password}' --protocol=TCP --execute 'SHOW DATABASES;'");
+    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"mysql --host='localhost' --port='{this.DefaultPort}' --user='{this.Username}' --password='{this.Password}' --protocol=TCP --execute 'SHOW DATABASES;'");
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Configurations/Databases/PostgreSqlTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Databases/PostgreSqlTestcontainerConfiguration.cs
@@ -27,6 +27,6 @@ namespace DotNet.Testcontainers.Containers.Configurations.Databases
       set => this.Environments["POSTGRES_PASSWORD"] = value;
     }
 
-    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"pg_isready -h '{this.Hostname}' -p '{this.DefaultPort}'");
+    public override IWaitUntil WaitStrategy => new WaitUntilShellCommandsAreCompleted($"pg_isready -h 'localhost' -p '{this.DefaultPort}'");
   }
 }

--- a/src/DotNet.Testcontainers/Containers/IDockerContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/IDockerContainer.cs
@@ -32,6 +32,12 @@ namespace DotNet.Testcontainers.Containers
     [NotNull]
     string MacAddress { get; }
 
+    /// <summary>Gets the Testcontainer hostname.</summary>
+    /// <value>Returns the Docker container hostname if present or an empty string instead.</value>
+    /// <exception cref="InvalidOperationException">If container was not created.</exception>
+    [NotNull]
+    string Hostname { get; }
+
     /// <summary>
     /// Gets the public host port associated with the private container port.
     /// </summary>

--- a/src/DotNet.Testcontainers/Containers/Modules/Abstractions/HostedServiceContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Abstractions/HostedServiceContainer.cs
@@ -1,5 +1,6 @@
 namespace DotNet.Testcontainers.Containers.Modules.Abstractions
 {
+  using Configurations.Abstractions;
   using DotNet.Testcontainers.Containers.Configurations;
 
   /// <summary>
@@ -12,8 +13,6 @@ namespace DotNet.Testcontainers.Containers.Modules.Abstractions
     }
 
     public virtual int Port { get; set; }
-
-    public virtual string Hostname { get; set; }
 
     public virtual string Username { get; set; }
 

--- a/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
@@ -65,6 +65,9 @@ namespace DotNet.Testcontainers.Containers.Modules
       }
     }
 
+    /// <inheritdoc />
+    public string Hostname { get; }
+
     private TestcontainersState State
     {
       get
@@ -84,6 +87,10 @@ namespace DotNet.Testcontainers.Containers.Modules
     {
       this.client = new TestcontainersClient(configuration.Endpoint);
       this.configuration = configuration;
+
+      this.Hostname = "tcp" != this.configuration.Endpoint.Scheme
+        ? "localhost"
+        : this.configuration.Endpoint.Host;
     }
 
     public ushort GetMappedPublicPort(int privatePort)


### PR DESCRIPTION
At the moment the default value of a `HostedServiceContainer` hostname is always `localhost`. This does not make sense for Docker endpoints which are accessed via TCP. If the Docker endpoint scheme is `tcp` the default value of the `HostedServiceContainer` should be the hostname of the remote Docker endpoint.

This PR keeps `localhost` as default value if the Docker endpoint scheme is not `tcp`. Otherwise we will use the hostname of the Docker endpoint as default.

This PR makes it more easy to use Testcontainers in GitLab-CI as a pipeline job in GitLab-CI will access a _remote_ Docker daemon in most cases. If I start a Database as Testcontainer then this Database is accessible via the hostname of the remote Docker daemon.