### PR TITLE
[#196] #BUGFIX 'assemblyName: DotNet.Testcontainers; function WaitUntilContainerIsRunning'

### DIFF
--- a/src/DotNet.Testcontainers.Tests/Unit/Containers/TestcontainersAccessNotPreConfiguredTest.cs
+++ b/src/DotNet.Testcontainers.Tests/Unit/Containers/TestcontainersAccessNotPreConfiguredTest.cs
@@ -28,7 +28,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers
       Assert.Equal(0, notPreConfigured.Environments.Count);
       Assert.Null(notPreConfigured.Username);
       Assert.Null(notPreConfigured.Password);
-      Assert.IsAssignableFrom<OutputConsumerNull>(notPreConfigured.OutputConsumer);
+      Assert.IsAssignableFrom<DoNotConsumeStdoutOrStderr>(notPreConfigured.OutputConsumer);
       Assert.IsAssignableFrom<IWaitUntil>(notPreConfigured.WaitStrategy);
     }
   }

--- a/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
@@ -83,7 +83,7 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default)
     {
-      if (outputConsumer is null || outputConsumer is OutputConsumerNull)
+      if (outputConsumer is null || outputConsumer is DoNotConsumeStdoutOrStderr)
       {
         return;
       }

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
@@ -199,7 +199,7 @@ namespace DotNet.Testcontainers.Containers.Builders
         exposedPorts,
         portBindings,
         mounts,
-        outputConsumer ?? OutputConsumerNull.Consumer,
+        outputConsumer ?? DoNotConsumeStdoutOrStderr.OutputConsumer,
         waitStrategy ?? WaitUntilContainerIsRunning.WaitStrategy,
         cleanUp);
     }
@@ -223,7 +223,7 @@ namespace DotNet.Testcontainers.Containers.Builders
       var exposedPorts = Merge(next.ExposedPorts, previous.configuration.ExposedPorts);
       var portBindings = Merge(next.PortBindings, previous.configuration.PortBindings);
       var mounts = Merge(next.Mounts, previous.configuration.Mounts);
-      var outputConsumer = Merge(next.OutputConsumer, previous.configuration.OutputConsumer, OutputConsumerNull.Consumer);
+      var outputConsumer = Merge(next.OutputConsumer, previous.configuration.OutputConsumer, DoNotConsumeStdoutOrStderr.OutputConsumer);
       var waitStrategy = Merge(next.WaitStrategy, previous.configuration.WaitStrategy, WaitUntilContainerIsRunning.WaitStrategy);
 
       var mergedConfigurations = Apply(

--- a/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/HostedServiceConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/HostedServiceConfiguration.cs
@@ -32,7 +32,7 @@ namespace DotNet.Testcontainers.Containers.Configurations.Abstractions
 
     public virtual IDictionary<string, string> Environments { get; } = new Dictionary<string, string>();
 
-    public virtual IOutputConsumer OutputConsumer => OutputConsumerNull.Consumer;
+    public virtual IOutputConsumer OutputConsumer => DoNotConsumeStdoutOrStderr.OutputConsumer;
 
     public virtual IWaitUntil WaitStrategy => Wait.UntilContainerIsRunning();
   }

--- a/src/DotNet.Testcontainers/Containers/OutputConsumers/DoNotConsumeStdoutOrStderr.cs
+++ b/src/DotNet.Testcontainers/Containers/OutputConsumers/DoNotConsumeStdoutOrStderr.cs
@@ -2,11 +2,11 @@ namespace DotNet.Testcontainers.Containers.OutputConsumers
 {
   using System.IO;
 
-  public class OutputConsumerNull : IOutputConsumer
+  public class DoNotConsumeStdoutOrStderr : IOutputConsumer
   {
-    public static readonly IOutputConsumer Consumer = new OutputConsumerNull();
+    public static readonly IOutputConsumer OutputConsumer = new DoNotConsumeStdoutOrStderr();
 
-    private OutputConsumerNull()
+    private DoNotConsumeStdoutOrStderr()
     {
     }
 

--- a/src/DotNet.Testcontainers/Containers/WaitStrategies/WaitUntilContainerIsRunning.cs
+++ b/src/DotNet.Testcontainers/Containers/WaitStrategies/WaitUntilContainerIsRunning.cs
@@ -1,6 +1,7 @@
 namespace DotNet.Testcontainers.Containers.WaitStrategies
 {
   using System;
+  using System.Linq;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Containers.Modules;
@@ -9,7 +10,7 @@ namespace DotNet.Testcontainers.Containers.WaitStrategies
   {
     public static readonly IWaitUntil WaitStrategy = new WaitUntilContainerIsRunning();
 
-    private static readonly string StateRunning = TestcontainersState.Running.ToString();
+    private static readonly TestcontainersState[] ContainerHasBeenRunningStates = { TestcontainersState.Running, TestcontainersState.Exited };
 
     private WaitUntilContainerIsRunning()
     {
@@ -18,7 +19,8 @@ namespace DotNet.Testcontainers.Containers.WaitStrategies
     public async Task<bool> Until(Uri endpoint, string id)
     {
       var container = await new TestcontainersClient(endpoint).GetContainer(id);
-      return string.Equals(StateRunning, container?.State, StringComparison.OrdinalIgnoreCase);
+      var state = (TestcontainersState)Enum.Parse(typeof(TestcontainersState), container.State, true);
+      return ContainerHasBeenRunningStates.Contains(state);
     }
   }
 }

--- a/src/DotNet.Testcontainers/DotNet.Testcontainers.csproj
+++ b/src/DotNet.Testcontainers/DotNet.Testcontainers.csproj
@@ -4,7 +4,7 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>  
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />  
     <PackageReference Include="Docker.DotNet" Version="3.125.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.1" />


### PR DESCRIPTION
{Fix container state race condition if the main process immediately exits.}