### PR TITLE
[#232] #BUGFIX 'assemblyName: DotNet.Testcontainers; function: DockerImage'

### DIFF
--- a/src/DotNet.Testcontainers.Tests/Fixtures/ParseDockerImageFixture.cs
+++ b/src/DotNet.Testcontainers.Tests/Fixtures/ParseDockerImageFixture.cs
@@ -8,6 +8,8 @@ namespace DotNet.Testcontainers.Tests.Fixtures
     public ParseDockerImageFixture()
     {
       this.Add(new ParseDockerImageFixtureSerializable(new DockerImage("baz/foo", "bar", "1.0.0")), "baz/foo/bar:1.0.0");
+      this.Add(new ParseDockerImageFixtureSerializable(new DockerImage("baz/foo", "bar", string.Empty)), "baz/foo/bar");
+      this.Add(new ParseDockerImageFixtureSerializable(new DockerImage("baz/foo", "bar", string.Empty)), "baz/foo/bar:latest");
       this.Add(new ParseDockerImageFixtureSerializable(new DockerImage("foo", "bar", "1.0.0")), "foo/bar:1.0.0");
       this.Add(new ParseDockerImageFixtureSerializable(new DockerImage("foo", "bar", string.Empty)), "foo/bar");
       this.Add(new ParseDockerImageFixtureSerializable(new DockerImage("foo", "bar", string.Empty)), "foo/bar:latest");

--- a/src/DotNet.Testcontainers/Images/DockerImage.cs
+++ b/src/DotNet.Testcontainers/Images/DockerImage.cs
@@ -7,7 +7,7 @@ namespace DotNet.Testcontainers.Images
   /// <inheritdoc cref="IDockerImage" />
   public sealed class DockerImage : IDockerImage
   {
-    private static readonly MatchImage[] MatchImages = { new MatchImageRegistry(), new MatchImageRepositoryTag(), new MatchImageRepositoryLatest(), new MatchImageTag(), new MatchImage() };
+    private static readonly MatchImage[] MatchImages = { new MatchImageRegistryTag(), new MatchImageRegistryLatest(), new MatchImageRepositoryTag(), new MatchImageRepositoryLatest(), new MatchImageTag(), new MatchImage() };
 
     private static readonly Func<string, IDockerImage> GetDockerImage = image => MatchImages.Select(matcher => matcher.Match(image)).First(result => result != null);
 

--- a/src/DotNet.Testcontainers/Internals/Parsers/MatchImageRegistryLatest.cs
+++ b/src/DotNet.Testcontainers/Internals/Parsers/MatchImageRegistryLatest.cs
@@ -1,0 +1,16 @@
+namespace DotNet.Testcontainers.Internals.Parsers
+{
+  using DotNet.Testcontainers.Images;
+
+  internal sealed class MatchImageRegistryLatest : MatchImage
+  {
+    public MatchImageRegistryLatest() : base($@"{Part}\/{Part}\/{Part}") // Matches baz/foo/bar
+    {
+    }
+
+    protected override IDockerImage Match(params string[] matches)
+    {
+      return new DockerImage($"{matches[0]}/{matches[1]}", matches[2], string.Empty);
+    }
+  }
+}

--- a/src/DotNet.Testcontainers/Internals/Parsers/MatchImageRegistryTag.cs
+++ b/src/DotNet.Testcontainers/Internals/Parsers/MatchImageRegistryTag.cs
@@ -2,9 +2,9 @@ namespace DotNet.Testcontainers.Internals.Parsers
 {
   using DotNet.Testcontainers.Images;
 
-  internal sealed class MatchImageRegistry : MatchImage
+  internal sealed class MatchImageRegistryTag : MatchImage
   {
-    public MatchImageRegistry() : base($@"{Part}\/{Part}\/{Part}\:{Part}") // Matches baz/foo/bar:1.0.0
+    public MatchImageRegistryTag() : base($@"{Part}\/{Part}\/{Part}\:{Part}") // Matches baz/foo/bar:1.0.0
     {
     }
 


### PR DESCRIPTION
{Add missing Docker image name parser 'baz/foo/bar'.}