### PR TITLE
[#NON] #BUGFIX 'assemblyName: DotNet.Testcontainers; function: TestcontainersContainer'

### DIFF
--- a/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/HostedServiceConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/HostedServiceConfiguration.cs
@@ -28,14 +28,16 @@ namespace DotNet.Testcontainers.Containers.Configurations.Abstractions
     /// <summary>
     /// Gets the Docker image.
     /// </summary>
+    [PublicAPI]
     public string Image { get; }
 
     /// <summary>
     /// Gets the container port.
     /// </summary>
     /// <remarks>
-    /// Corresponds to the default port of the service.
+    /// Corresponds to the default port of the hosted service.
     /// </remarks>
+    [PublicAPI]
     public int DefaultPort { get; }
 
     /// <summary>

--- a/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
@@ -232,7 +232,7 @@ namespace DotNet.Testcontainers.Containers.Modules
     {
       using (var cts = new CancellationTokenSource())
       {
-        var attachOutputConsumerTask = this.client.AttachAsync(id, this.configuration.OutputConsumer, cts.Token);
+        await this.client.AttachAsync(id, this.configuration.OutputConsumer, cts.Token);
 
         var startTask = this.client.StartAsync(id, cts.Token);
 
@@ -244,7 +244,7 @@ namespace DotNet.Testcontainers.Containers.Modules
           }
         }, cts.Token);
 
-        var tasks = Task.WhenAll(attachOutputConsumerTask, startTask, waitTask);
+        var tasks = Task.WhenAll(startTask, waitTask);
 
         try
         {
@@ -252,6 +252,7 @@ namespace DotNet.Testcontainers.Containers.Modules
         }
         catch (Exception)
         {
+          // Get all thrown exceptions in tasks.
           if (tasks.Exception != null)
           {
             throw tasks.Exception;


### PR DESCRIPTION
{Fix an issue where the output consumer is not attached when the container starts.}