### PR TITLE
Add KafkaTestcontainer

### DIFF
--- a/src/DotNet.Testcontainers.Tests/DotNet.Testcontainers.Tests.csproj
+++ b/src/DotNet.Testcontainers.Tests/DotNet.Testcontainers.Tests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Confluent.Kafka" Version="1.5.3" />
     <PackageReference Include="CouchbaseNetClient" Version="3.0.7" />
     <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />

--- a/src/DotNet.Testcontainers.Tests/Fixtures/Containers/Modules/AlpineFixture.cs
+++ b/src/DotNet.Testcontainers.Tests/Fixtures/Containers/Modules/AlpineFixture.cs
@@ -14,9 +14,10 @@ namespace DotNet.Testcontainers.Tests.Fixtures.Containers.Modules
     {
     }
 
-    public Task InitializeAsync()
+    public async Task InitializeAsync()
     {
-      return Task.WhenAll(this.Container.StartAsync(), this.Container.StopAsync());
+      await this.Container.StartAsync().ConfigureAwait(false);
+      await this.Container.StopAsync().ConfigureAwait(false);
     }
 
     public Task DisposeAsync()

--- a/src/DotNet.Testcontainers.Tests/Fixtures/Containers/Modules/MessageBrokers/KafkaFixture.cs
+++ b/src/DotNet.Testcontainers.Tests/Fixtures/Containers/Modules/MessageBrokers/KafkaFixture.cs
@@ -1,0 +1,30 @@
+namespace DotNet.Testcontainers.Tests.Fixtures.Containers.Modules.MessageBrokers
+{
+  using System;
+  using System.Threading;
+  using System.Threading.Tasks;
+  using Testcontainers.Containers.Builders;
+  using Testcontainers.Containers.Configurations.MessageBrokers;
+  using Testcontainers.Containers.Modules.MessageBrokers;
+  using Xunit;
+
+  public class KafkaFixture : ModuleFixture<KafkaTestcontainer>, IAsyncLifetime
+  {
+    public KafkaFixture()
+      : base(new TestcontainersBuilder<KafkaTestcontainer>()
+        .WithKafka(new KafkaTestcontainerConfiguration())
+        .Build())
+    {
+    }
+
+    public Task InitializeAsync()
+    {
+      return this.Container.StartAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+      return this.Container.DisposeAsync().AsTask();
+    }
+  }
+}

--- a/src/DotNet.Testcontainers.Tests/Unit/Containers/Unix/MessageBroker/KafkaTestcontainerTest.cs
+++ b/src/DotNet.Testcontainers.Tests/Unit/Containers/Unix/MessageBroker/KafkaTestcontainerTest.cs
@@ -1,0 +1,54 @@
+namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix.MessageBroker
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Threading.Tasks;
+  using Confluent.Kafka;
+  using Fixtures.Containers.Modules.MessageBrokers;
+  using Xunit;
+
+  public class KafkaTestcontainerTest : IClassFixture<KafkaFixture>
+  {
+    private readonly KafkaFixture kafkaFixture;
+
+    public KafkaTestcontainerTest(KafkaFixture kafkaFixture)
+    {
+      this.kafkaFixture = kafkaFixture;
+    }
+
+    [Fact]
+    public async Task StartsWorkingKafkaInstance()
+    {
+      // Given
+      // When
+      using var producer = new ProducerBuilder<string, string>(new Dictionary<string, string>()
+      {
+        { "bootstrap.servers", this.kafkaFixture.Container.BootstrapServers }
+      }).Build();
+
+      var productionReportTaskSrc = new TaskCompletionSource<DeliveryReport<string, string>>();
+
+      producer.Produce("test_topic", new Message<string, string>()
+      {
+        Value = "TestMessage"
+      }, report => productionReportTaskSrc.SetResult(report));
+
+      await productionReportTaskSrc.Task;
+
+      // Then
+      using var consumer = new ConsumerBuilder<string, string>(new Dictionary<string, string>()
+      {
+        { "bootstrap.servers", this.kafkaFixture.Container.BootstrapServers },
+        { "auto.offset.reset", "earliest" },
+        { "group.id", "test_consumer" }
+      }).Build();
+
+      consumer.Subscribe("test_topic");
+
+      var result = consumer.Consume(TimeSpan.FromSeconds(5));
+
+      Assert.NotNull(result);
+      Assert.Equal("TestMessage", result.Message.Value);
+    }
+  }
+}

--- a/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
@@ -119,6 +119,21 @@ namespace DotNet.Testcontainers.Clients
       return long.MinValue;
     }
 
+    public Task ExtractArchiveToContainerAsync(string id, string path, Stream tarStream, CancellationToken ct = default)
+    {
+      Logger.LogInformation("Copying tar stream to {path} at container {id}", path, id);
+
+      return this.Docker.Containers.ExtractArchiveToContainerAsync(
+        id,
+        new ContainerPathStatParameters()
+        {
+          Path = path,
+          AllowOverwriteDirWithFile = false
+        },
+        tarStream,
+        ct);
+    }
+
     public async Task<string> RunAsync(ITestcontainersConfiguration configuration, CancellationToken ct = default)
     {
       var converter = new TestcontainersConfigurationConverter(configuration);

--- a/src/DotNet.Testcontainers/Clients/IDockerContainerOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/IDockerContainerOperations.cs
@@ -1,6 +1,7 @@
 namespace DotNet.Testcontainers.Clients
 {
   using System.Collections.Generic;
+  using System.IO;
   using System.Threading;
   using System.Threading.Tasks;
   using Docker.DotNet.Models;
@@ -20,6 +21,8 @@ namespace DotNet.Testcontainers.Clients
     Task AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default);
 
     Task<long> ExecAsync(string id, IList<string> command, CancellationToken ct = default);
+
+    Task ExtractArchiveToContainerAsync(string id, string path, Stream tarStream, CancellationToken ct = default);
 
     Task<string> RunAsync(ITestcontainersConfiguration configuration, CancellationToken ct = default);
   }

--- a/src/DotNet.Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/DotNet.Testcontainers/Clients/ITestcontainersClient.cs
@@ -81,6 +81,19 @@ namespace DotNet.Testcontainers.Clients
     Task<long> ExecAsync(string id, IList<string> command, CancellationToken ct = default);
 
     /// <summary>
+    /// Copies a file to the container.
+    /// </summary>
+    /// <param name="id">Docker container id.</param>
+    /// <param name="filePath">Path to the file in the container.</param>
+    /// <param name="fileContent">Content of the file as bytes.</param>
+    /// <param name="accessMode">Access mode for the file.</param>
+    /// <param name="userId">Owner of the file.</param>
+    /// <param name="groupId">Group of the file.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns></returns>
+    public Task CopyFileAsync(string id, string filePath, byte[] fileContent, int accessMode, int userId, int groupId, CancellationToken ct = default);
+
+    /// <summary>
     /// Creates a container.
     /// </summary>
     /// <param name="configuration">Testcontainer configuration.</param>

--- a/src/DotNet.Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/DotNet.Testcontainers/Clients/TestcontainersClient.cs
@@ -151,15 +151,18 @@ namespace DotNet.Testcontainers.Clients
         Size = fileContent.Length
       }));
 
-      await tarOutputStream.WriteAsync(fileContent, ct);
+      await tarOutputStream.WriteAsync(fileContent, ct)
+        .ConfigureAwait(false);
 
       tarOutputStream.CloseEntry();
       tarOutputStream.Close();
-      await tarOutputStream.FlushAsync(ct);
+      await tarOutputStream.FlushAsync(ct)
+        .ConfigureAwait(false);
 
       memStream.Position = 0;
 
-      await this.containers.ExtractArchiveToContainerAsync(id, "/", memStream, ct);
+      await this.containers.ExtractArchiveToContainerAsync(id, "/", memStream, ct)
+        .ConfigureAwait(false);
     }
 
     public async Task<string> RunAsync(ITestcontainersConfiguration configuration, CancellationToken ct = default)

--- a/src/DotNet.Testcontainers/Containers/Builders/ITestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/ITestcontainersBuilder.cs
@@ -1,6 +1,8 @@
 namespace DotNet.Testcontainers.Containers.Builders
 {
   using System;
+  using System.Threading;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers.OutputConsumers;
   using DotNet.Testcontainers.Containers.WaitStrategies;
   using DotNet.Testcontainers.Images;
@@ -191,6 +193,14 @@ namespace DotNet.Testcontainers.Containers.Builders
     /// <remarks>Multiple wait strategies are executed one after the other in th…</remarks>
     [PublicAPI]
     ITestcontainersBuilder<TDockerContainer> WithWaitStrategy(IWaitForContainerOS waitStrategy);
+
+    /// <summary>
+    /// Sets a startup callback to be executed after starting the container but before executing the wait strategy.
+    /// </summary>
+    /// <param name="startupCallback">The callback function to be executed.</param>
+    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    [PublicAPI]
+    ITestcontainersBuilder<TDockerContainer> WithStartupCallback(Func<IDockerContainer, CancellationToken, Task> startupCallback);
 
     /// <summary>
     /// Builds the instance of <see cref="IDockerContainer" /> with the given configuration.

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
@@ -4,6 +4,8 @@ namespace DotNet.Testcontainers.Containers.Builders
   using System.Collections.Generic;
   using System.Linq;
   using System.Reflection;
+  using System.Threading;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Containers.Configurations;
   using DotNet.Testcontainers.Containers.OutputConsumers;
@@ -188,6 +190,12 @@ namespace DotNet.Testcontainers.Containers.Builders
     }
 
     /// <inheritdoc />
+    public ITestcontainersBuilder<TDockerContainer> WithStartupCallback(Func<IDockerContainer, CancellationToken, Task> startupCallback)
+    {
+      return Build(this, Apply(startupCallback: startupCallback));
+    }
+
+    /// <inheritdoc />
     public TDockerContainer Build()
     {
       // Create container instance.
@@ -216,6 +224,7 @@ namespace DotNet.Testcontainers.Containers.Builders
       IEnumerable<IBind> mounts = null,
       IOutputConsumer outputConsumer = null,
       IEnumerable<IWaitUntil> waitStrategies = null,
+      Func<IDockerContainer, CancellationToken, Task> startupCallback = null,
       bool cleanUp = true)
     {
       return new TestcontainersConfiguration(
@@ -233,6 +242,7 @@ namespace DotNet.Testcontainers.Containers.Builders
         mounts,
         outputConsumer,
         waitStrategies,
+        startupCallback,
         cleanUp);
     }
 
@@ -259,6 +269,7 @@ namespace DotNet.Testcontainers.Containers.Builders
       var authConfig = new[] { next.AuthConfig, previous.configuration.AuthConfig }.First(config => config != null);
       var outputConsumer = new[] { next.OutputConsumer, previous.configuration.OutputConsumer }.First(config => config != null);
       var waitStrategies = new[] { next.WaitStrategies, previous.configuration.WaitStrategies }.First(config => config != null);
+      var startupCallback = Merge(next.StartupCallback, previous.configuration.StartupCallback);
 
       var mergedConfiguration = Apply(
         endpoint,
@@ -275,6 +286,7 @@ namespace DotNet.Testcontainers.Containers.Builders
         mounts,
         outputConsumer,
         waitStrategies,
+        startupCallback,
         cleanUp);
 
       return new TestcontainersBuilder<TDockerContainer>(mergedConfiguration, moduleConfiguration ?? previous.moduleConfiguration);

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
@@ -141,14 +141,14 @@ namespace DotNet.Testcontainers.Containers.Builders
     /// <inheritdoc />
     public ITestcontainersBuilder<TDockerContainer> WithPortBinding(string port, bool assignRandomHostPort = false)
     {
-      var hostPort = assignRandomHostPort ? $"{TestcontainersNetworkService.GetAvailablePort()}" : port;
+      var hostPort = assignRandomHostPort ? null : port;
       return this.WithPortBinding(hostPort, port);
     }
 
     /// <inheritdoc />
     public ITestcontainersBuilder<TDockerContainer> WithPortBinding(string hostPort, string containerPort)
     {
-      var portBindings = new Dictionary<string, string> { { hostPort, containerPort } };
+      var portBindings = new Dictionary<string, string> { { containerPort, hostPort } };
       return Build(this, Apply(portBindings: portBindings));
     }
 

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderDatabaseExtension.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderDatabaseExtension.cs
@@ -21,7 +21,7 @@ namespace DotNet.Testcontainers.Containers.Builders
         .WithWaitStrategy(configuration.WaitStrategy)
         .ConfigureContainer(container =>
         {
-          container.Port = configuration.Port;
+          container.ContainerPort = configuration.DefaultPort;
           container.Database = configuration.Database;
           container.Username = configuration.Username;
           container.Password = configuration.Password;

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderKafkaExtension.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderKafkaExtension.cs
@@ -1,0 +1,31 @@
+namespace DotNet.Testcontainers.Containers.Builders
+{
+  using System.Linq;
+  using System.Text;
+  using System.Threading;
+  using System.Threading.Tasks;
+  using Configurations.MessageBrokers;
+  using DotNet.Testcontainers.Containers.Modules.MessageBrokers;
+
+  /// <summary>
+  /// This class applies the extended Testcontainer configurations for Kafka.
+  /// </summary>
+  public static class TestcontainersBuilderKafkaExtension
+  {
+    public static ITestcontainersBuilder<KafkaTestcontainer> WithKafka(this ITestcontainersBuilder<KafkaTestcontainer> builder, KafkaTestcontainerConfiguration configuration)
+    {
+      builder = configuration.Environments.Aggregate(builder, (current, environment) => current.WithEnvironment(environment.Key, environment.Value));
+
+      return builder
+        .WithImage(configuration.Image)
+        .WithCommand(configuration.Command)
+        .WithPortBinding(configuration.Port, configuration.DefaultPort)
+        .WithWaitStrategy(configuration.WaitStrategy)
+        .WithStartupCallback(configuration.StartupCallback)
+        .ConfigureContainer(container =>
+        {
+          container.Port = configuration.Port;
+        });
+    }
+  }
+}

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderKafkaExtension.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderKafkaExtension.cs
@@ -24,7 +24,7 @@ namespace DotNet.Testcontainers.Containers.Builders
         .WithStartupCallback(configuration.StartupCallback)
         .ConfigureContainer(container =>
         {
-          container.Port = configuration.Port;
+          container.ContainerPort = configuration.DefaultPort;
         });
     }
   }

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderMessageBrokerExtension.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilderMessageBrokerExtension.cs
@@ -21,7 +21,7 @@ namespace DotNet.Testcontainers.Containers.Builders
         .WithWaitStrategy(configuration.WaitStrategy)
         .ConfigureContainer(container =>
         {
-          container.Port = configuration.Port;
+          container.ContainerPort = configuration.DefaultPort;
           container.Username = configuration.Username;
           container.Password = configuration.Password;
         });

--- a/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/HostedServiceConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/HostedServiceConfiguration.cs
@@ -10,12 +10,7 @@ namespace DotNet.Testcontainers.Containers.Configurations.Abstractions
   /// </summary>
   public abstract class HostedServiceConfiguration
   {
-    protected HostedServiceConfiguration(string image, int defaultPort)
-      : this(image, defaultPort, defaultPort)
-    {
-    }
-
-    protected HostedServiceConfiguration(string image, int defaultPort, int port)
+    protected HostedServiceConfiguration(string image, int defaultPort, int port = 0)
     {
       this.Image = image;
       this.DefaultPort = defaultPort;

--- a/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/TestcontainerDatabaseConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/TestcontainerDatabaseConfiguration.cs
@@ -7,7 +7,7 @@ namespace DotNet.Testcontainers.Containers.Configurations.Abstractions
   /// </summary>
   public abstract class TestcontainerDatabaseConfiguration : HostedServiceConfiguration
   {
-    protected TestcontainerDatabaseConfiguration(string image, int defaultPort) : base(image, defaultPort, TestcontainersNetworkService.GetAvailablePort())
+    protected TestcontainerDatabaseConfiguration(string image, int defaultPort) : base(image, defaultPort)
     {
     }
 

--- a/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/TestcontainerMessageBrokerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/Abstractions/TestcontainerMessageBrokerConfiguration.cs
@@ -7,7 +7,7 @@ namespace DotNet.Testcontainers.Containers.Configurations.Abstractions
   /// </summary>
   public abstract class TestcontainerMessageBrokerConfiguration : HostedServiceConfiguration
   {
-    protected TestcontainerMessageBrokerConfiguration(string image, int defaultPort) : base(image, defaultPort, TestcontainersNetworkService.GetAvailablePort())
+    protected TestcontainerMessageBrokerConfiguration(string image, int defaultPort) : base(image, defaultPort)
     {
     }
   }

--- a/src/DotNet.Testcontainers/Containers/Configurations/ITestcontainersConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/ITestcontainersConfiguration.cs
@@ -2,6 +2,8 @@ namespace DotNet.Testcontainers.Containers.Configurations
 {
   using System;
   using System.Collections.Generic;
+  using System.Threading;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers.OutputConsumers;
   using DotNet.Testcontainers.Containers.WaitStrategies;
   using DotNet.Testcontainers.Images;
@@ -100,5 +102,11 @@ namespace DotNet.Testcontainers.Containers.Configurations
     /// </summary>
     [NotNull]
     IEnumerable<IWaitUntil> WaitStrategies { get; }
+
+    /// <summary>
+    /// Gets the startup callback.
+    /// This callback will be executed after starting the container, but before executing the wait strategies.
+    /// </summary>
+    public Func<IDockerContainer, CancellationToken, Task> StartupCallback { get; }
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Configurations/MessageBrokers/KafkaTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/MessageBrokers/KafkaTestcontainerConfiguration.cs
@@ -1,0 +1,72 @@
+namespace DotNet.Testcontainers.Containers.Configurations.MessageBrokers
+{
+  using System.Text;
+  using System.Threading;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Containers.Configurations.Abstractions;
+  using DotNet.Testcontainers.Containers.Modules.MessageBrokers;
+  using DotNet.Testcontainers.Containers.WaitStrategies;
+  using DotNet.Testcontainers.Services;
+  using JetBrains.Annotations;
+
+  public sealed class KafkaTestcontainerConfiguration : HostedServiceConfiguration
+  {
+    private const string KafkaImage = "confluentinc/cp-kafka:6.0.1";
+    private const int KafkaPort = 9092;
+    private const int ZookeeperPort = 2181;
+    private const int BrokerPort = 9093;
+    private const string StarterScript = "/testcontainers_start.sh";
+
+    public KafkaTestcontainerConfiguration()
+      : this(KafkaImage)
+    {
+    }
+
+    public KafkaTestcontainerConfiguration(string image)
+      : base(image, KafkaPort, TestcontainersNetworkService.GetAvailablePort())
+    {
+      // Use two listeners with different names, it will force Kafka to communicate with itself via internal
+      // listener when KAFKA_INTER_BROKER_LISTENER_NAME is set, otherwise Kafka will try to use the advertised listener
+      this.Environments.Add("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT");
+      this.Environments.Add("KAFKA_LISTENERS", $"PLAINTEXT://0.0.0.0:{this.DefaultPort},BROKER://0.0.0.0:{BrokerPort}");
+      this.Environments.Add("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER");
+      this.Environments.Add("KAFKA_BROKER_ID", "1");
+      this.Environments.Add("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1");
+      this.Environments.Add("KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS", "1");
+      this.Environments.Add("KAFKA_LOG_FLUSH_INTERVAL_MESSAGES", long.MaxValue.ToString());
+      this.Environments.Add("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0");
+      this.Environments.Add("KAFKA_ZOOKEEPER_CONNECT", $"localhost:{ZookeeperPort}");
+    }
+
+    /// <summary>
+    /// Gets the command of the container.
+    /// </summary>
+    [PublicAPI]
+    public string[] Command { get; } = { "sh", "-c", $"while [ ! -f {StarterScript} ]; do sleep 0.1; done; {StarterScript}" };
+
+    /// <summary>
+    /// A function to initialize the container after startup.
+    /// </summary>
+    [PublicAPI]
+    public async Task StartupCallback(IDockerContainer container, CancellationToken ct)
+    {
+      var kafkaContainer = (KafkaTestcontainer)container;
+
+      var startupScript = $@"#!/bin/sh
+echo 'clientPort={ZookeeperPort}' > zookeeper.properties
+echo 'dataDir=/var/lib/zookeeper/data' >> zookeeper.properties
+echo 'dataLogDir=/var/lib/zookeeper/log' >> zookeeper.properties
+zookeeper-server-start zookeeper.properties &
+export KAFKA_ADVERTISED_LISTENERS='PLAINTEXT://{kafkaContainer.Hostname}:{kafkaContainer.Port},BROKER://localhost:{BrokerPort}'
+. /etc/confluent/docker/bash-config
+/etc/confluent/docker/configure
+/etc/confluent/docker/launch
+";
+
+      await container.CopyFileAsync(StarterScript, Encoding.UTF8.GetBytes(startupScript), 0x1ff,  ct: ct);
+    }
+
+    public override IWaitForContainerOS WaitStrategy => Wait.ForUnixContainer()
+      .UntilPortIsAvailable(this.DefaultPort);
+  }
+}

--- a/src/DotNet.Testcontainers/Containers/Configurations/MessageBrokers/KafkaTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/MessageBrokers/KafkaTestcontainerConfiguration.cs
@@ -23,7 +23,7 @@ namespace DotNet.Testcontainers.Containers.Configurations.MessageBrokers
     }
 
     public KafkaTestcontainerConfiguration(string image)
-      : base(image, KafkaPort, TestcontainersNetworkService.GetAvailablePort())
+      : base(image, KafkaPort)
     {
       // Use two listeners with different names, it will force Kafka to communicate with itself via internal
       // listener when KAFKA_INTER_BROKER_LISTENER_NAME is set, otherwise Kafka will try to use the advertised listener

--- a/src/DotNet.Testcontainers/Containers/Configurations/TestcontainersConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/TestcontainersConfiguration.cs
@@ -2,6 +2,8 @@ namespace DotNet.Testcontainers.Containers.Configurations
 {
   using System;
   using System.Collections.Generic;
+  using System.Threading;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers.OutputConsumers;
   using DotNet.Testcontainers.Containers.WaitStrategies;
   using DotNet.Testcontainers.Images;
@@ -26,6 +28,7 @@ namespace DotNet.Testcontainers.Containers.Configurations
       IEnumerable<IBind> mounts,
       IOutputConsumer outputConsumer,
       IEnumerable<IWaitUntil> waitStrategies,
+      Func<IDockerContainer, CancellationToken, Task> startupCallback,
       bool cleanUp = true)
     {
       this.CleanUp  = cleanUp;
@@ -43,6 +46,7 @@ namespace DotNet.Testcontainers.Containers.Configurations
       this.Mounts  = mounts;
       this.OutputConsumer  = outputConsumer;
       this.WaitStrategies  = waitStrategies;
+      this.StartupCallback = startupCallback;
     }
 
 #pragma warning restore S107
@@ -91,5 +95,8 @@ namespace DotNet.Testcontainers.Containers.Configurations
 
     /// <inheritdoc />
     public IEnumerable<IWaitUntil> WaitStrategies { get; }
+
+    /// <inheritdoc />
+    public Func<IDockerContainer, CancellationToken, Task> StartupCallback { get; }
   }
 }

--- a/src/DotNet.Testcontainers/Containers/IDockerContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/IDockerContainer.cs
@@ -79,5 +79,17 @@ namespace DotNet.Testcontainers.Containers
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that completes when the shell command has been executed.</returns>
     Task<long> ExecAsync(IList<string> command, CancellationToken ct = default);
+
+    /// <summary>
+    /// Copies a file into the container.
+    /// </summary>
+    /// <param name="filePath">Path to the file in the container.</param>
+    /// <param name="fileContent">Content of the file as bytes.</param>
+    /// <param name="accessMode">Access mode for the file. (Default: 0600)</param>
+    /// <param name="userId">Owner of the file.</param>
+    /// <param name="groupId">Group of the file.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns></returns>
+    Task CopyFileAsync(string filePath, byte[] fileContent, int accessMode = 384, int userId = 0, int groupId = 0, CancellationToken ct = default);
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Modules/Abstractions/HostedServiceContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Abstractions/HostedServiceContainer.cs
@@ -1,5 +1,6 @@
 namespace DotNet.Testcontainers.Containers.Modules.Abstractions
 {
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers.Configurations;
 
   /// <summary>
@@ -11,7 +12,9 @@ namespace DotNet.Testcontainers.Containers.Modules.Abstractions
     {
     }
 
-    public virtual int Port { get; set; }
+    public virtual int ContainerPort { get; set; }
+
+    public int Port => this.GetMappedPublicPort(this.ContainerPort);
 
     public virtual string Username { get; set; }
 

--- a/src/DotNet.Testcontainers/Containers/Modules/Abstractions/HostedServiceContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Abstractions/HostedServiceContainer.cs
@@ -16,7 +16,5 @@ namespace DotNet.Testcontainers.Containers.Modules.Abstractions
     public virtual string Username { get; set; }
 
     public virtual string Password { get; set; }
-
-    public abstract string ConnectionString { get; }
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Modules/Abstractions/TestcontainerDatabase.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Abstractions/TestcontainerDatabase.cs
@@ -12,5 +12,7 @@ namespace DotNet.Testcontainers.Containers.Modules.Abstractions
     }
 
     public string Database { get; set; }
+
+    public abstract string ConnectionString { get; }
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Modules/MessageBrokers/KafkaTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/MessageBrokers/KafkaTestcontainer.cs
@@ -1,0 +1,14 @@
+namespace DotNet.Testcontainers.Containers.Modules.MessageBrokers
+{
+  using DotNet.Testcontainers.Containers.Modules.Abstractions;
+  using DotNet.Testcontainers.Containers.Configurations;
+
+  public sealed class KafkaTestcontainer : HostedServiceContainer
+  {
+    internal KafkaTestcontainer(ITestcontainersConfiguration configuration) : base(configuration)
+    {
+    }
+
+    public string BootstrapServers => $"{this.Hostname}:{this.Port}";
+  }
+}

--- a/src/DotNet.Testcontainers/Containers/Modules/MessageBrokers/RabbitMqTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/MessageBrokers/RabbitMqTestcontainer.cs
@@ -9,6 +9,6 @@ namespace DotNet.Testcontainers.Containers.Modules.MessageBrokers
     {
     }
 
-    public override string ConnectionString => $"amqp://{this.Username}:{this.Password}@{this.Hostname}:{this.Port}";
+    public string ConnectionString => $"amqp://{this.Username}:{this.Password}@{this.Hostname}:{this.Port}";
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
@@ -191,36 +191,14 @@ namespace DotNet.Testcontainers.Containers.Modules
       }
     }
 
-    public async Task<long> ExecAsync(IList<string> command, CancellationToken ct = default)
+    public Task<long> ExecAsync(IList<string> command, CancellationToken ct = default)
     {
-      await this.semaphoreSlim.WaitAsync(ct)
-        .ConfigureAwait(false);
-
-      try
-      {
-        return await this.client.ExecAsync(this.Id, command, ct)
-          .ConfigureAwait(false);
-      }
-      finally
-      {
-        this.semaphoreSlim.Release();
-      }
+      return this.client.ExecAsync(this.Id, command, ct);
     }
 
-    public async Task CopyFileAsync(string filePath, byte[] fileContent, int accessMode = 384, int userId = 0, int groupId = 0, CancellationToken ct = default)
+    public Task CopyFileAsync(string filePath, byte[] fileContent, int accessMode = 384, int userId = 0, int groupId = 0, CancellationToken ct = default)
     {
-      await this.semaphoreSlim.WaitAsync(ct)
-        .ConfigureAwait(false);
-
-      try
-      {
-        await this.client.CopyFileAsync(this.Id, filePath, fileContent, accessMode, userId, groupId, ct)
-          .ConfigureAwait(false);
-      }
-      finally
-      {
-        this.semaphoreSlim.Release();
-      }
+      return this.client.CopyFileAsync(this.Id, filePath, fileContent, accessMode, userId, groupId, ct);
     }
 
     public virtual async ValueTask DisposeAsync()
@@ -234,6 +212,7 @@ namespace DotNet.Testcontainers.Containers.Modules
       await cleanOrStopTask.ConfigureAwait(false);
 
       this.semaphoreSlim.Dispose();
+      this.client.Dispose();
     }
 
     private async Task<ContainerListResponse> Create(CancellationToken ct = default)
@@ -255,6 +234,11 @@ namespace DotNet.Testcontainers.Containers.Modules
         .ConfigureAwait(false);
       await this.client.StartAsync(id, ct)
         .ConfigureAwait(false);
+
+      if (this.configuration.StartupCallback != null)
+      {
+        await this.configuration.StartupCallback(this, ct);
+      }
 
       foreach (var waitStrategy in this.configuration.WaitStrategies)
       {

--- a/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
@@ -235,6 +235,9 @@ namespace DotNet.Testcontainers.Containers.Modules
       await this.client.StartAsync(id, ct)
         .ConfigureAwait(false);
 
+      this.container = await this.client.GetContainer(id, ct)
+        .ConfigureAwait(false);
+
       if (this.configuration.StartupCallback != null)
       {
         await this.configuration.StartupCallback(this, ct);

--- a/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
@@ -207,6 +207,22 @@ namespace DotNet.Testcontainers.Containers.Modules
       }
     }
 
+    public async Task CopyFileAsync(string filePath, byte[] fileContent, int accessMode = 384, int userId = 0, int groupId = 0, CancellationToken ct = default)
+    {
+      await this.semaphoreSlim.WaitAsync(ct)
+        .ConfigureAwait(false);
+
+      try
+      {
+        await this.client.CopyFileAsync(this.Id, filePath, fileContent, accessMode, userId, groupId, ct)
+          .ConfigureAwait(false);
+      }
+      finally
+      {
+        this.semaphoreSlim.Release();
+      }
+    }
+
     public virtual async ValueTask DisposeAsync()
     {
       if (!ContainerHasBeenCreatedStates.Contains(this.State))

--- a/src/DotNet.Testcontainers/Images/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/DotNet.Testcontainers/Images/Builders/ImageFromDockerfileBuilder.cs
@@ -53,11 +53,11 @@ namespace DotNet.Testcontainers.Images.Builders
     }
 
     /// <inheritdoc />
-    public Task<string> Build()
+    public async Task<string> Build()
     {
       using (var client = new TestcontainersClient())
       {
-        return client.BuildAsync(this.configuration);
+        return await client.BuildAsync(this.configuration);
       }
     }
   }

--- a/src/DotNet.Testcontainers/Images/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/DotNet.Testcontainers/Images/Builders/ImageFromDockerfileBuilder.cs
@@ -57,7 +57,8 @@ namespace DotNet.Testcontainers.Images.Builders
     {
       using (var client = new TestcontainersClient())
       {
-        return await client.BuildAsync(this.configuration);
+        return await client.BuildAsync(this.configuration)
+          .ConfigureAwait(false);
       }
     }
   }

--- a/src/DotNet.Testcontainers/Internals/Mappers/TestcontainersConfigurationConverter.cs
+++ b/src/DotNet.Testcontainers/Internals/Mappers/TestcontainersConfigurationConverter.cs
@@ -92,7 +92,9 @@ namespace DotNet.Testcontainers.Internals.Mappers
 
       public override IEnumerable<KeyValuePair<string, IList<PortBinding>>> Convert(IEnumerable<KeyValuePair<string, string>> source)
       {
-        return source?.Select(portBinding => new KeyValuePair<string, IList<PortBinding>>($"{portBinding.Value}/tcp", new List<PortBinding> { new PortBinding { HostPort = portBinding.Key } }));
+        return source?.Select(portBinding => new KeyValuePair<string, IList<PortBinding>>(
+          $"{portBinding.Key}/tcp",
+          new List<PortBinding> { new PortBinding { HostPort = portBinding.Value == "0" ? null : portBinding.Value } }));
       }
     }
   }


### PR DESCRIPTION
This PR adds a `KafkaTestcontainer`. There are a lot of changes, because the container needs to be implemented kind of hacky. Kafka needs to know on which external network interface it is reachable. Therefore it is needed to start the container before configuring Kafka via environment variables. The KafkaTestcontainer will wait after startup for a startup script to be created inside the Container. The startup script will contain the randomly assigned host port and will start the Kafka instance.

This approach is very similar to the approach, taken by the Java Testcontainers project.

This PR also adds the possibility to add a file to a `TestcontainersContainer` and fixes a possible source for issues by letting the Docker daemon decide on random port assignments instead of the client in seperate commits.