### PR TITLE
[#356] #BUGFIX 'assemblyName: DotNet.Testcontainers; function: IDockerContainer'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Keep in mind to enable the correct Docker engine on Windows host systems to matc
 - `WithMount` mounts a volume into the container e. g. `-v, --volume .:/tmp`.
 - `WithCleanUp` removes a stopped container automatically.
 - `WithDockerEndpoint` sets the Docker API endpoint e. g. `-H tcp://0.0.0.0:2376`.
+- `WithRegistryAuthentication` basic authentication against a private Docker registry.
 - `WithOutputConsumer` redirects `stdout` and `stderr` to capture the Testcontainer output.
 - `WithWaitStrategy` sets the wait strategy to complete the Testcontainer start and indicates when it is ready.
-- `WithRegistryAuthentication` basic authentication against a private Docker registry.
+- `WithStartupCallback` sets the startup callback to invoke after the Testcontainer start.
 - `WithDockerfileDirectory` builds a Docker image based on a Dockerfile (`ImageFromDockerfileBuilder`).
 - `WithDeleteIfExists` removes the Docker image before it is rebuilt (`ImageFromDockerfileBuilder`).
 
@@ -41,12 +42,14 @@ Keep in mind to enable the correct Docker engine on Windows host systems to matc
 
 The pre-configured Testcontainers below are supported. Further examples can be found in [TestcontainersContainerTest][1] as well as in [database][2] or [message broker][3] tests.
 
+- Apache CouchDB (couchdb:2.3.1)
 - Couchbase (couchbase:6.5.1)
-- CouchDB (couchdb:2.3.1)
-- MsSql (server:2017-CU14-ubuntu)
-- MySql (mysql:8.0.18)
-- PostgreSql (postgres:11.5)
+- Microsoft SQL Server (mcr.microsoft.com/mssql/server:2017-CU14-ubuntu)
+- MySQL (mysql:8.0.18)
+- Oracle Database (wnameless/oracle-xe-11g-r2)
+- PostgreSQL (postgres:11.5)
 - Redis (redis:5.0.6)
+- Apache Kafka (confluentinc/cp-kafka:6.0.1)
 - RabbitMQ (rabbitmq:3.7.21)
 
 ## Examples

--- a/src/DotNet.Testcontainers/Containers/Builders/ITestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/ITestcontainersBuilder.cs
@@ -190,17 +190,18 @@ namespace DotNet.Testcontainers.Containers.Builders
     /// </summary>
     /// <param name="waitStrategy">Wait strategy to complete the Testcontainer start, default wait strategy implementation is <see cref="DotNet.Testcontainers.Containers.WaitStrategies.Common.UntilContainerIsRunning" />.</param>
     /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
-    /// <remarks>Multiple wait strategies are executed one after the other in th…</remarks>
+    /// <remarks>Multiple wait strategies are executed one after the other.</remarks>
     [PublicAPI]
     ITestcontainersBuilder<TDockerContainer> WithWaitStrategy(IWaitForContainerOS waitStrategy);
 
     /// <summary>
-    /// Sets the startup callback to be executed after starting the container, but before executing the wait strategy.
+    /// Sets the startup callback to invoke after the Testcontainer start.
     /// </summary>
-    /// <param name="startupCallback">The callback function to be executed.</param>
+    /// <param name="startupCallback">The callback method to invoke.</param>
     /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    /// <remarks>Is invoked once after the Testcontainer is started and before the wait strategies are executed.</remarks>
     [PublicAPI]
-    ITestcontainersBuilder<TDockerContainer> WithStartupCallback(Func<IDockerContainer, CancellationToken, Task> startupCallback);
+    ITestcontainersBuilder<TDockerContainer> WithStartupCallback(Func<IRunningDockerContainer, CancellationToken, Task> startupCallback);
 
     /// <summary>
     /// Builds the instance of <see cref="IDockerContainer" /> with the given configuration.

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
@@ -190,7 +190,7 @@ namespace DotNet.Testcontainers.Containers.Builders
     }
 
     /// <inheritdoc />
-    public ITestcontainersBuilder<TDockerContainer> WithStartupCallback(Func<IDockerContainer, CancellationToken, Task> startupCallback)
+    public ITestcontainersBuilder<TDockerContainer> WithStartupCallback(Func<IRunningDockerContainer, CancellationToken, Task> startupCallback)
     {
       return Build(this, Apply(startupCallback: startupCallback));
     }

--- a/src/DotNet.Testcontainers/Containers/Configurations/MessageBrokers/KafkaTestcontainerConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/MessageBrokers/KafkaTestcontainerConfiguration.cs
@@ -49,7 +49,7 @@ namespace DotNet.Testcontainers.Containers.Configurations.MessageBrokers
     /// <summary>
     /// Gets the startup callback.
     /// </summary>
-    public virtual Func<IDockerContainer, CancellationToken, Task> StartupCallback
+    public virtual Func<IRunningDockerContainer, CancellationToken, Task> StartupCallback
       => (container, ct) =>
       {
         var startupScript = $@"#!/bin/sh

--- a/src/DotNet.Testcontainers/Containers/IDockerContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/IDockerContainer.cs
@@ -6,7 +6,28 @@ namespace DotNet.Testcontainers.Containers
   using System.Threading.Tasks;
   using JetBrains.Annotations;
 
-  public interface IDockerContainer : IAsyncDisposable
+  public interface IDockerContainer : IRunningDockerContainer, IAsyncDisposable
+  {
+    /// <summary>
+    /// Gets the Testcontainer exit code.
+    /// </summary>
+    /// <returns>Returns the Docker container exit code.</returns>
+    Task<long> GetExitCode(CancellationToken ct = default);
+
+    /// <summary>
+    /// Starts the Testcontainer. If the image does not exist, it will be downloaded automatically. Non-existing containers are created at first start.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous start operation of a Testcontainer.</returns>
+    Task StartAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Stops the Testcontainer and removes the container automatically.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous stop operation of a Testcontainer.</returns>
+    Task StopAsync(CancellationToken ct = default);
+  }
+
+  public interface IRunningDockerContainer
   {
     /// <summary>Gets the Testcontainer id.</summary>
     /// <value>Returns the Docker container id if present or an empty string instead.</value>
@@ -55,29 +76,11 @@ namespace DotNet.Testcontainers.Containers
     ushort GetMappedPublicPort(string privatePort);
 
     /// <summary>
-    /// Gets the Testcontainer exit code.
-    /// </summary>
-    /// <returns>Returns the Docker container exit code.</returns>
-    Task<long> GetExitCode(CancellationToken ct = default);
-
-    /// <summary>
-    /// Starts the Testcontainer. If the image does not exist, it will be downloaded automatically. Non-existing containers are created at first start.
-    /// </summary>
-    /// <returns>A task that represents the asynchronous start operation of a Testcontainer.</returns>
-    Task StartAsync(CancellationToken ct = default);
-
-    /// <summary>
-    /// Stops the Testcontainer and removes the container automatically.
-    /// </summary>
-    /// <returns>A task that represents the asynchronous stop operation of a Testcontainer.</returns>
-    Task StopAsync(CancellationToken ct = default);
-
-    /// <summary>
     /// Copies a file into the container.
     /// </summary>
     /// <param name="filePath">Path to the file in the container.</param>
     /// <param name="fileContent">Content of the file as bytes.</param>
-    /// <param name="accessMode">Access mode for the file. (Default: 0600)</param>
+    /// <param name="accessMode">Access mode for the file (default: 0600).</param>
     /// <param name="userId">Owner of the file.</param>
     /// <param name="groupId">Group of the file.</param>
     /// <param name="ct">Cancellation token.</param>


### PR DESCRIPTION
{Do not expose IDockerContainer to WithStartupCallback.}