### PR TITLE
Virtual start and stop

### DIFF
--- a/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
@@ -130,7 +130,7 @@ namespace DotNet.Testcontainers.Containers.Modules
       return this.client.GetContainerExitCode(this.Id, ct);
     }
 
-    public async Task StartAsync(CancellationToken ct = default)
+    public virtual async Task StartAsync(CancellationToken ct = default)
     {
       await this.semaphoreSlim.WaitAsync(ct)
         .ConfigureAwait(false);
@@ -148,7 +148,7 @@ namespace DotNet.Testcontainers.Containers.Modules
       }
     }
 
-    public async Task StopAsync(CancellationToken ct = default)
+    public virtual async Task StopAsync(CancellationToken ct = default)
     {
       await this.semaphoreSlim.WaitAsync(ct)
         .ConfigureAwait(false);


### PR DESCRIPTION
In order to facilitate with #242 I came with this 2 liner PR so we can manually attempt to clean up if start fails with something like the following pseudo:

```csharp
public class AutoCleanupTestContainer : TestcontainersContainer
{
    protected AutoCleanupTestContainer(ITestcontainersConfiguration configuration)
        : base(configuration)
    { }

    public async override Task StartAsync(CancellationToken ct)
    {
    retry:
        try
        {
            await StartAsync(ct).ConfigureAwait(false);
        }
        catch (DockerApiException dockerApiException) when (dockerApiException.StatusCode == HttpStatusCode.Conflict)
        {
            // Cleanup logic
            goto retry;
        }
    }
}
```

I know this is not the full fix discussed in 242 but it may be eligible as a workaround, what do you think about it?