### PR TITLE
Feature/242 label each container to cleanup at next start

### DIFF
--- a/src/DotNet.Testcontainers.Tests/Unit/GitHub.cs
+++ b/src/DotNet.Testcontainers.Tests/Unit/GitHub.cs
@@ -1,0 +1,17 @@
+namespace DotNet.Testcontainers.Tests.Unit
+{
+  using System;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Clients;
+  using Xunit;
+
+  public class GitHub
+  {
+    [Fact]
+    public Task PullRequest361()
+    {
+      Assert.NotEqual(Guid.Empty, new TestcontainersSession().Id);
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
@@ -27,6 +27,13 @@ namespace DotNet.Testcontainers.Clients
         .ConfigureAwait(false)).ToArray();
     }
 
+    public async Task<IEnumerable<ContainerListResponse>> GetOrphanedObjects(CancellationToken ct = default)
+    {
+      var filters = new FilterByProperty { { "label", $"{TestcontainersClient.TestcontainersCleanUpLabel}=true" }, { "status", "exited" } };
+      return (await this.Docker.Containers.ListContainersAsync(new ContainersListParameters { All = true, Filters = filters }, ct)
+        .ConfigureAwait(false)).ToArray();
+    }
+
     public Task<ContainerListResponse> ByIdAsync(string id, CancellationToken ct = default)
     {
       return this.ByPropertyAsync("id", id, ct);
@@ -39,7 +46,8 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<ContainerListResponse> ByPropertyAsync(string property, string value, CancellationToken ct = default)
     {
-      return (await this.Docker.Containers.ListContainersAsync(new ContainersListParameters { All = true, Filters = new FilterByProperty(property, value) }, ct)
+      var filters = new FilterByProperty(property, value);
+      return (await this.Docker.Containers.ListContainersAsync(new ContainersListParameters { All = true, Filters = filters }, ct)
         .ConfigureAwait(false)).FirstOrDefault();
     }
 

--- a/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
@@ -29,7 +29,17 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<IEnumerable<ContainerListResponse>> GetOrphanedObjects(CancellationToken ct = default)
     {
-      var filters = new FilterByProperty { { "label", $"{TestcontainersClient.TestcontainersCleanUpLabel}=true" }, { "status", "exited" } };
+      // TODO: Create TestcontainersSession only once.
+      var session = new TestcontainersSession().Id.ToString();
+
+      // TODO: create FilterByProperty only once. Set correct filter.
+      var filters = new FilterByProperty
+      {
+        {"label", $"{TestcontainersClient.TestcontainersSessionLabel}={session}"},
+        {"label", $"{TestcontainersClient.TestcontainersCleanUpLabel}=true"},
+        {"status", "exited"}
+      };
+
       return (await this.Docker.Containers.ListContainersAsync(new ContainersListParameters { All = true, Filters = filters }, ct)
         .ConfigureAwait(false)).ToArray();
     }

--- a/src/DotNet.Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/DockerImageOperations.cs
@@ -24,6 +24,12 @@ namespace DotNet.Testcontainers.Clients
         .ConfigureAwait(false)).ToArray();
     }
 
+    public Task<IEnumerable<ImagesListResponse>> GetOrphanedObjects(CancellationToken ct = default)
+    {
+      IEnumerable<ImagesListResponse> images = Array.Empty<ImagesListResponse>();
+      return Task.FromResult(images);
+    }
+
     public async Task<ImagesListResponse> ByIdAsync(string id, CancellationToken ct = default)
     {
       return (await this.GetAllAsync(ct)
@@ -37,7 +43,8 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<ImagesListResponse> ByPropertyAsync(string property, string value, CancellationToken ct = default)
     {
-      return (await this.Docker.Images.ListImagesAsync(new ImagesListParameters { All = true, Filters = new FilterByProperty(property, value) }, ct)
+      var filters = new FilterByProperty(property, value);
+      return (await this.Docker.Images.ListImagesAsync(new ImagesListParameters { All = true, Filters = filters }, ct)
         .ConfigureAwait(false)).FirstOrDefault();
     }
 

--- a/src/DotNet.Testcontainers/Clients/FilterByProperty.cs
+++ b/src/DotNet.Testcontainers/Clients/FilterByProperty.cs
@@ -1,12 +1,23 @@
 ﻿namespace DotNet.Testcontainers.Clients
 {
+  using System.Collections.Concurrent;
   using System.Collections.Generic;
 
-  internal sealed class FilterByProperty : Dictionary<string, IDictionary<string, bool>>
+  internal sealed class FilterByProperty : ConcurrentDictionary<string, IDictionary<string, bool>>
   {
+    public FilterByProperty()
+    {
+    }
+
     public FilterByProperty(string property, string value)
     {
-      this.Add(property, new Dictionary<string, bool> { { value, true } });
+      this.Add(property, value);
+    }
+
+    public void Add(string property, string value)
+    {
+      var values = this.GetOrAdd(property, key => new Dictionary<string, bool>());
+      values[value] = true;
     }
   }
 }

--- a/src/DotNet.Testcontainers/Clients/IHasListOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/IHasListOperations.cs
@@ -8,6 +8,8 @@ namespace DotNet.Testcontainers.Clients
   {
     Task<IEnumerable<T>> GetAllAsync(CancellationToken ct = default);
 
+    Task<IEnumerable<T>> GetOrphanedObjects(CancellationToken ct = default);
+
     Task<T> ByIdAsync(string id, CancellationToken ct = default);
 
     Task<T> ByNameAsync(string name, CancellationToken ct = default);

--- a/src/DotNet.Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/DotNet.Testcontainers/Clients/TestcontainersClient.cs
@@ -21,6 +21,8 @@ namespace DotNet.Testcontainers.Clients
 
     public const string TestcontainersCleanUpLabel = TestcontainersLabel + ".cleanUp";
 
+    public const string TestcontainersSessionLabel = TestcontainersLabel + ".session";
+
     private readonly string osRootDirectory = Path.GetPathRoot(typeof(ITestcontainersClient).Assembly.Location);
 
     private readonly Uri endpoint;
@@ -175,7 +177,7 @@ namespace DotNet.Testcontainers.Clients
       // Killing or canceling the test process will prevent the cleanup.
       // Remove labeled, orphaned containers from previous runs.
       var removeOrphanedContainersTasks = (await this.containers.GetOrphanedObjects(ct)
-        .ConfigureAwait(false))
+          .ConfigureAwait(false))
         .Select(container => this.containers.RemoveAsync(container.ID, ct));
 
       if (!await this.images.ExistsWithNameAsync(configuration.Image.FullName, ct)

--- a/src/DotNet.Testcontainers/Clients/TestcontainersSession.cs
+++ b/src/DotNet.Testcontainers/Clients/TestcontainersSession.cs
@@ -1,0 +1,78 @@
+namespace DotNet.Testcontainers.Clients
+{
+  using System;
+  using System.IO;
+  using System.IO.MemoryMappedFiles;
+  using System.Threading;
+
+  internal sealed class TestcontainersSession : IDisposable
+  {
+    // TODO: Use proper name.
+    private const string mutexName = "FOO";
+
+    private const string mapName = "BAR";
+
+    private readonly MemoryMappedFile sharedMemoryMappedFile;
+
+    public TestcontainersSession()
+    {
+      using (var mutex = new Mutex(false, mutexName))
+      {
+        bool isMutexAcquired;
+
+        try
+        {
+          isMutexAcquired = mutex.WaitOne(TimeSpan.FromSeconds(30));
+        }
+        catch (AbandonedMutexException)
+        {
+          isMutexAcquired = true;
+        }
+
+        if (!isMutexAcquired)
+        {
+          throw new TimeoutException(string.Empty);
+        }
+
+        var guidBytes = Guid.NewGuid().ToByteArray();
+
+        try
+        {
+          // If the memory mapped file exists read the shared session id.
+          this.sharedMemoryMappedFile = MemoryMappedFile.OpenExisting(mapName);
+          using (var accessor = this.sharedMemoryMappedFile.CreateViewAccessor())
+          {
+            accessor.ReadArray(0, guidBytes, 0, guidBytes.Length);
+          }
+        }
+        catch (FileNotFoundException)
+        {
+          // Otherwise, create new memory mapped file and session id.
+          this.sharedMemoryMappedFile = MemoryMappedFile.CreateNew(mapName, guidBytes.Length);
+          using (var accessor = this.sharedMemoryMappedFile.CreateViewAccessor())
+          {
+            accessor.WriteArray(0, guidBytes, 0, guidBytes.Length);
+          }
+        }
+        finally
+        {
+          this.Id = new Guid(guidBytes);
+          mutex.ReleaseMutex();
+        }
+      }
+    }
+
+    ~TestcontainersSession()
+    {
+      this.Dispose();
+    }
+
+    public Guid Id { get; }
+
+    public void Dispose()
+    {
+      this.sharedMemoryMappedFile.Dispose();
+      GC.SuppressFinalize(this);
+    }
+  }
+}

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
@@ -2,6 +2,7 @@ namespace DotNet.Testcontainers.Containers.Builders
 {
   using System;
   using System.Collections.Generic;
+  using System.Collections.ObjectModel;
   using System.Linq;
   using System.Reflection;
   using System.Threading;
@@ -42,10 +43,11 @@ namespace DotNet.Testcontainers.Containers.Builders
     public TestcontainersBuilder() : this(
       Apply(
         authConfig: new AuthenticationConfiguration(),
+        labels: new DefaultLabels(),
         outputConsumer: Consume.DoNotConsumeStdoutAndStderr(),
         waitStrategies: Wait.ForUnixContainer().Build(),
         startupCallback: (container, ct) => Task.CompletedTask),
-      testcontainer => { })
+      _ => { })
     {
     }
 
@@ -162,7 +164,8 @@ namespace DotNet.Testcontainers.Containers.Builders
     /// <inheritdoc />
     public ITestcontainersBuilder<TDockerContainer> WithCleanUp(bool cleanUp)
     {
-      return Build(this, Apply(cleanUp: cleanUp));
+      return Build(this, Apply(cleanUp: cleanUp))
+        .WithLabel(TestcontainersClient.TestcontainersCleanUpLabel, cleanUp.ToString().ToLowerInvariant());
     }
 
     /// <inheritdoc />
@@ -343,6 +346,17 @@ namespace DotNet.Testcontainers.Containers.Builders
       else
       {
         return next.Concat(previous.Where(item => !next.Keys.Contains(item.Key))).ToDictionary(item => item.Key, item => item.Value);
+      }
+    }
+
+    private sealed class DefaultLabels : ReadOnlyDictionary<string, string>
+    {
+      public DefaultLabels() : base(new Dictionary<string, string>
+      {
+        { TestcontainersClient.TestcontainersLabel, "true"},
+        { TestcontainersClient.TestcontainersCleanUpLabel, "true" }
+      })
+      {
       }
     }
   }

--- a/src/DotNet.Testcontainers/Containers/Configurations/AuthenticationConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/AuthenticationConfiguration.cs
@@ -4,7 +4,7 @@ namespace DotNet.Testcontainers.Containers.Configurations
 
   /// <inheritdoc cref="IAuthenticationConfiguration" />
   /// <remarks>In the future, we will replace this class. Instead, we will use the local Docker credentials.</remarks>
-  internal class AuthenticationConfiguration : IAuthenticationConfiguration
+  internal readonly struct AuthenticationConfiguration : IAuthenticationConfiguration
   {
     /// <summary>
     /// Creates a <see cref="AuthenticationConfiguration" />.


### PR DESCRIPTION
@ilmax I added the first part to clean orphaned containers from previous runs. The idea is to label each container and remove the remaining ones in the next run. Until now, this will only cover containers with the status `exited`. If a container is still running, we don’t know if it is created from another test process.

I'll try to cover that in the next commit. We can probably assign a kind of session id to each container, to identify multiple processes.