### PR TITLE
added hostname on container creating

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Keep in mind to enable the correct Docker engine on Windows host systems to matc
 - `WithEntrypoint` specifies and overrides the `ENTRYPOINT` that will run as an executable.
 - `WithCommand` specifies and overrides the `COMMAND` instruction provided from the Dockerfile.
 - `WithName` sets the container name e. g. `--name nginx`.
+- `WithHostname` sets the container hostname e. g. `--hostname my-nginx`.
 - `WithEnvironment` sets an environment variable in the container e. g. `-e, --env "test=containers"`.
 - `WithLabel` applies metadata to a container e. g. `-l, --label dotnet.testcontainers=awesome`.
 - `WithExposedPort` exposes a port inside the container e. g. `--expose=80`.

--- a/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/DotNet.Testcontainers/Clients/DockerContainerOperations.cs
@@ -146,6 +146,7 @@ namespace DotNet.Testcontainers.Clients
         Labels = converter.Labels,
         ExposedPorts = converter.ExposedPorts,
         HostConfig = hostConfig,
+        Hostname = configuration.Hostname
       };
 
       var id = (await this.Docker.Containers.CreateContainerAsync(createParameters, ct)

--- a/src/DotNet.Testcontainers/Containers/Builders/ITestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/ITestcontainersBuilder.cs
@@ -48,6 +48,13 @@ namespace DotNet.Testcontainers.Containers.Builders
     ITestcontainersBuilder<TDockerContainer> WithName(string name);
 
     /// <summary>
+    /// Sets the hostname of the Testcontainer.
+    /// </summary>
+    /// <param name="hostname">Testcontainers name.</param>
+    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    ITestcontainersBuilder<TDockerContainer> WithHostname(string hostname);
+
+    /// <summary>
     /// Overrides the working directory of the Testcontainer for the instruction sets.
     /// </summary>
     /// <param name="workingDirectory">Working directory.</param>

--- a/src/DotNet.Testcontainers/Containers/Builders/ITestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/ITestcontainersBuilder.cs
@@ -50,7 +50,7 @@ namespace DotNet.Testcontainers.Containers.Builders
     /// <summary>
     /// Sets the hostname of the Testcontainer.
     /// </summary>
-    /// <param name="hostname">Testcontainers name.</param>
+    /// <param name="hostname">Testcontainers hostname.</param>
     /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
     ITestcontainersBuilder<TDockerContainer> WithHostname(string hostname);
 

--- a/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Containers/Builders/TestcontainersBuilder.cs
@@ -82,6 +82,12 @@ namespace DotNet.Testcontainers.Containers.Builders
     }
 
     /// <inheritdoc />
+    public ITestcontainersBuilder<TDockerContainer> WithHostname(string hostname)
+    {
+      return Build(this, Apply(hostname: hostname));
+    }
+
+    /// <inheritdoc />
     public ITestcontainersBuilder<TDockerContainer> WithWorkingDirectory(string workingDirectory)
     {
       return Build(this, Apply(workingDirectory: workingDirectory));
@@ -214,6 +220,7 @@ namespace DotNet.Testcontainers.Containers.Builders
       IAuthenticationConfiguration authConfig = null,
       IDockerImage image = null,
       string name = null,
+      string hostname = null,
       string workingDirectory = null,
       IEnumerable<string> entrypoint = null,
       IEnumerable<string> command = null,
@@ -232,6 +239,7 @@ namespace DotNet.Testcontainers.Containers.Builders
         authConfig,
         image,
         name,
+        hostname,
         workingDirectory,
         entrypoint,
         command,
@@ -257,6 +265,7 @@ namespace DotNet.Testcontainers.Containers.Builders
       var endpoint = Merge(next.Endpoint, previous.configuration.Endpoint, DockerApiEndpoint.Local);
       var image = Merge(next.Image, previous.configuration.Image);
       var name = Merge(next.Name, previous.configuration.Name);
+      var hostname = Merge(next.Hostname, previous.configuration.Hostname);
       var workingDirectory = Merge(next.WorkingDirectory, previous.configuration.WorkingDirectory);
       var entrypoint = Merge(next.Entrypoint, previous.configuration.Entrypoint);
       var command = Merge(next.Command, previous.configuration.Command);
@@ -276,6 +285,7 @@ namespace DotNet.Testcontainers.Containers.Builders
         authConfig,
         image,
         name,
+        hostname,
         workingDirectory,
         entrypoint,
         command,

--- a/src/DotNet.Testcontainers/Containers/Configurations/ITestcontainersConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/ITestcontainersConfiguration.cs
@@ -44,6 +44,12 @@ namespace DotNet.Testcontainers.Containers.Configurations
     string Name { get; }
 
     /// <summary>
+    /// Gets the hostname.
+    /// </summary>
+    [NotNull]
+    string Hostname { get; }
+
+    /// <summary>
     /// Gets the working directory.
     /// </summary>
     [NotNull]

--- a/src/DotNet.Testcontainers/Containers/Configurations/TestcontainersConfiguration.cs
+++ b/src/DotNet.Testcontainers/Containers/Configurations/TestcontainersConfiguration.cs
@@ -18,6 +18,7 @@ namespace DotNet.Testcontainers.Containers.Configurations
       IAuthenticationConfiguration authenticationConfigurations,
       IDockerImage image,
       string name,
+      string hostname,
       string workingDirectory,
       IEnumerable<string> entrypoint,
       IEnumerable<string> command,
@@ -36,6 +37,7 @@ namespace DotNet.Testcontainers.Containers.Configurations
       this.AuthConfig = authenticationConfigurations;
       this.Image  = image;
       this.Name  = name;
+      this.Hostname = hostname;
       this.WorkingDirectory  = workingDirectory;
       this.Entrypoint  = entrypoint;
       this.Command  = command;
@@ -65,6 +67,9 @@ namespace DotNet.Testcontainers.Containers.Configurations
 
     /// <inheritdoc />
     public string Name { get; }
+
+    /// <inheritdoc />
+    public string Hostname { get; }
 
     /// <inheritdoc />
     public string WorkingDirectory { get; }

--- a/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/TestcontainersContainer.cs
@@ -93,7 +93,7 @@ namespace DotNet.Testcontainers.Containers.Modules
               return "localhost";
             }
           default:
-            return this.IpAddress;
+            return this.configuration.Hostname;
         }
       }
     }


### PR DESCRIPTION
Why I need it. I need to write integration and end-to-end tests using
Kafka. Kafka needs Zookeeper. When you start them in containers you
need to configure it in some specific way. For that you need to
reference Kafka in container one time with `localhost` and another with
its hostname. If you don't know or don't control this hostname your
Kafka will be unreachable. The easiest way to accomplish this is to
set it during the container creating. Docker Compose for instance allows
to set the container internal hostname (and a Docker network hostname)
in the compose-file. Docker API allows to do it but this library for
some reason ignores this setting. I've added this missing ability.
I've seen a different approach to fix this problem in samples but it
requires some shell-scripts to run during the Kafka container startup.
It's too complex and not flexible. What if you can't (and in most cases
can't) alter your Kafka image? My way to fix this problem is much more
elegant and easy but requires to change some internals of this library.