### PR TITLE
fix build in the current version of VS

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "3.1.100",
-    "rollForward": "latestPatch"
-  }
-}


### PR DESCRIPTION
If I open the solution in VS2019 of the current version all around of
the code I see missing references to string, Guid and similar staff. If
I delete global.json from the root the problem is fixed immediately.
Seams like this file isn't required anymore because the only thing it
does it pinpoints solution projects to an old version of .NET Core.
There was a problem with version incompatibility between used by VS and
the latest .NET Core for that moment but isn't an issue anymore.
May be you need it to build on Azure or something else I don't know.
Fill free to reject if you really need it.