### PR TITLE
[#399] #IMPLEMENT Helper methods for database script execution

### DIFF
--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/CouchbaseTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/CouchbaseTestcontainer.cs
@@ -1,5 +1,6 @@
 namespace DotNet.Testcontainers.Containers
 {
+  using System.Text;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
@@ -49,6 +50,19 @@ namespace DotNet.Testcontainers.Containers
     {
       var flushBucketCommand = $"yes | {CouchbaseCli} bucket-flush -c 127.0.0.1:8091 --username {this.Username} --password {this.Password} --bucket {bucket}";
       return this.ExecAsync(new[] { "/bin/sh", "-c", flushBucketCommand });
+    }
+
+    /// <summary>
+    /// Executes a N1QL script in the database container.
+    /// </summary>
+    /// <param name="scriptContent">The content of the N1QL script to be executed.</param>
+    /// <returns>Task that completes when the script has been executed.</returns>
+    public override async Task<ExecResult> ExecScriptAsync(string scriptContent)
+    {
+      var tempScriptFile = this.GetTempScriptFile();
+      await this.CopyFileAsync(tempScriptFile, Encoding.ASCII.GetBytes(scriptContent));
+      var execScriptCommand = $"cbq -user {this.Username} -password {this.Password} -file={tempScriptFile}";
+      return await this.ExecAsync(new[] { "/bin/sh", "-c", execScriptCommand });
     }
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/MsSqlTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/MsSqlTestcontainer.cs
@@ -1,5 +1,7 @@
 namespace DotNet.Testcontainers.Containers
 {
+  using System.Text;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
@@ -21,5 +23,18 @@ namespace DotNet.Testcontainers.Containers
     /// <inheritdoc />
     public override string ConnectionString
       => $"Server={this.Hostname},{this.Port};Database={this.Database};User Id={this.Username};Password={this.Password};";
+
+    /// <summary>
+    /// Executes a SQL script in the database container.
+    /// </summary>
+    /// <param name="scriptContent">The content of the SQL script to be executed.</param>
+    /// <returns>Task that completes when the script has been executed.</returns>
+    public override async Task<ExecResult> ExecScriptAsync(string scriptContent)
+    {
+      var tempScriptFile = this.GetTempScriptFile();
+      await this.CopyFileAsync(tempScriptFile, Encoding.ASCII.GetBytes(scriptContent));
+      var execScriptCommand = $"/opt/mssql-tools/bin/sqlcmd -b -r1 -S {this.Hostname} -U {this.Username} -P \"{this.Password}\" -i {tempScriptFile}";
+      return await this.ExecAsync(new[] { "/bin/sh", "-c", execScriptCommand });
+    }
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/MySqlTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/MySqlTestcontainer.cs
@@ -1,5 +1,7 @@
 namespace DotNet.Testcontainers.Containers
 {
+  using System.Text;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
@@ -21,5 +23,18 @@ namespace DotNet.Testcontainers.Containers
     /// <inheritdoc />
     public override string ConnectionString
       => $"Server={this.Hostname};Port={this.Port};Database={this.Database};Uid={this.Username};Pwd={this.Password};";
+
+    /// <summary>
+    /// Executes a SQL script in the database container.
+    /// </summary>
+    /// <param name="scriptContent">The content of the SQL script to be executed.</param>
+    /// <returns>Task that completes when the script has been executed.</returns>
+    public override async Task<ExecResult> ExecScriptAsync(string scriptContent)
+    {
+      var tempScriptFile = this.GetTempScriptFile();
+      await this.CopyFileAsync(tempScriptFile, Encoding.ASCII.GetBytes(scriptContent));
+      var execScriptCommand = $"mysql -u{this.Username} -p{this.Password} {this.Database} < {tempScriptFile}";
+      return await this.ExecAsync(new[] { "/bin/sh", "-c", execScriptCommand });
+    }
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/OracleTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/OracleTestcontainer.cs
@@ -1,5 +1,7 @@
-﻿namespace DotNet.Testcontainers.Containers
+namespace DotNet.Testcontainers.Containers
 {
+  using System.Text;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
@@ -21,5 +23,18 @@
     /// <inheritdoc />
     public override string ConnectionString
       => $"Data Source={this.Hostname}:{this.Port};User id={this.Username};Password={this.Password};";
+
+    /// <summary>
+    /// Executes a SQL script in the database container.
+    /// </summary>
+    /// <param name="scriptContent">The content of the SQL script to be executed.</param>
+    /// <returns>Task that completes when the script has been executed.</returns>
+    public override async Task<ExecResult> ExecScriptAsync(string scriptContent)
+    {
+      var tempScriptFile = this.GetTempScriptFile();
+      await this.CopyFileAsync(tempScriptFile, Encoding.ASCII.GetBytes(scriptContent));
+      var execScriptCommand = $"exit | $ORACLE_HOME/bin/sqlplus -S {this.Username}/{this.Password}@{this.Hostname} @{tempScriptFile}";
+      return await this.ExecAsync(new[] { "/bin/sh", "-c", execScriptCommand });
+    }
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/PostgreSqlTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/PostgreSqlTestcontainer.cs
@@ -1,5 +1,7 @@
 namespace DotNet.Testcontainers.Containers
 {
+  using System.Text;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
@@ -21,5 +23,18 @@ namespace DotNet.Testcontainers.Containers
     /// <inheritdoc />
     public override string ConnectionString
       => $"Server={this.Hostname};Port={this.Port};Database={this.Database};User Id={this.Username};Password={this.Password};";
+
+    /// <summary>
+    /// Executes a SQL script in the database container.
+    /// </summary>
+    /// <param name="scriptContent">The content of the SQL script to be executed.</param>
+    /// <returns>Task that completes when the script has been executed.</returns>
+    public override async Task<ExecResult> ExecScriptAsync(string scriptContent)
+    {
+      var tempScriptFile = this.GetTempScriptFile();
+      await this.CopyFileAsync(tempScriptFile, Encoding.ASCII.GetBytes(scriptContent));
+      var execScriptCommand = $"psql -U {this.Username} -d {this.Database} -a -f {tempScriptFile}";
+      return await this.ExecAsync(new[] { "/bin/sh", "-c", execScriptCommand });
+    }
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Modules/Databases/RedisTestcontainer.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/Databases/RedisTestcontainer.cs
@@ -1,6 +1,10 @@
 namespace DotNet.Testcontainers.Containers
 {
+  using System;
+  using System.Text;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Containers.Modules;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
 
@@ -21,5 +25,18 @@ namespace DotNet.Testcontainers.Containers
     /// <inheritdoc />
     public override string ConnectionString
       => $"{this.Hostname}:{this.Port}";
+
+    /// <summary>
+    /// Executes a Lua script in the database container.
+    /// </summary>
+    /// <param name="scriptContent">The content of the Lua script to be executed.</param>
+    /// <returns>Task that completes when the script has been executed.</returns>
+    public override async Task<ExecResult> ExecScriptAsync(string scriptContent)
+    {
+      var tempScriptFile = this.GetTempScriptFile();
+      await this.CopyFileAsync(tempScriptFile, Encoding.ASCII.GetBytes(scriptContent));
+      var execScriptCommand = $"redis-cli --no-raw --eval {tempScriptFile}";
+      return await this.ExecAsync(new[] { "/bin/sh", "-c", execScriptCommand });
+    }
   }
 }

--- a/src/DotNet.Testcontainers/Containers/Modules/IDatabaseScript.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/IDatabaseScript.cs
@@ -1,0 +1,19 @@
+namespace DotNet.Testcontainers.Containers.Modules
+{
+  using System.Threading.Tasks;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Define the contract for database modules that has the script execution capability.
+  /// </summary>
+  public interface IDatabaseScript
+  {
+    /// <summary>
+    /// Executes a script in the running Testcontainer.
+    /// </summary>
+    /// <param name="scriptContent">The content of the script to be executed.</param>
+    /// <returns>Task that completes when the script has been executed.</returns>
+    [PublicAPI]
+    Task<ExecResult> ExecScriptAsync(string scriptContent);
+  }
+}

--- a/src/DotNet.Testcontainers/Containers/Modules/TestcontainerDatabase.cs
+++ b/src/DotNet.Testcontainers/Containers/Modules/TestcontainerDatabase.cs
@@ -1,13 +1,17 @@
 namespace DotNet.Testcontainers.Containers
 {
+  using System;
+  using System.Text;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Containers.Modules;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
 
   /// <summary>
   /// This class represents an extended configured Testcontainer for databases.
   /// </summary>
-  public abstract class TestcontainerDatabase : HostedServiceContainer
+  public abstract class TestcontainerDatabase : HostedServiceContainer, IDatabaseScript
   {
     /// <summary>
     /// Initializes a new instance of the <see cref="TestcontainerDatabase" /> class.
@@ -30,5 +34,23 @@ namespace DotNet.Testcontainers.Containers
     /// </summary>
     [PublicAPI]
     public virtual string Database { get; set; }
+
+    public virtual string GetTempScriptFile()
+    {
+      return $"/{Guid.NewGuid():N}.tmp";
+    }
+
+    /// <summary>
+    /// Executes a bash script in the database container.
+    /// </summary>
+    /// <param name="scriptContent">The content of the bash script to be executed.</param>
+    /// <returns>Task that completes when the script has been executed.</returns>
+    public virtual async Task<ExecResult> ExecScriptAsync(string scriptContent)
+    {
+      var tempScriptFile = this.GetTempScriptFile();
+      await this.CopyFileAsync(tempScriptFile, Encoding.ASCII.GetBytes(scriptContent));
+      await this.ExecAsync(new[] { "/bin/sh", "-c", $"chmod +x {tempScriptFile}" });
+      return await this.ExecAsync(new[] { "/bin/sh", "-c", tempScriptFile });
+    }
   }
 }

--- a/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/CouchDbTestcontainerTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/CouchDbTestcontainerTest.cs
@@ -1,5 +1,6 @@
 namespace DotNet.Testcontainers.Tests.Unit
 {
+  using System.Net;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Tests.Fixtures;
   using Xunit;
@@ -26,6 +27,28 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       // Then
       Assert.True(response.IsSuccess);
+    }
+
+    [Fact]
+    public async Task ExecScriptInRunningContainer()
+    {
+      // Given
+      const string script = @"
+        #!/bin/bash
+        echo executing
+        curl -v -X PUT http://couchdb:couchdb@127.0.0.1:5984/mydatabase/ 
+        curl -v -X PUT http://couchdb:couchdb@127.0.0.1:5984/mydatabase/""001"" -d '{ "" name "" : "" MyName "" }' 
+        echo executed
+        ";
+
+      // When
+      var results = await this.couchDbFixture.Container.ExecScriptAsync(script);
+
+      // Then
+      Assert.Equal(0, results.ExitCode);
+      using var client = new WebClient();
+      var response = client.DownloadString($"{this.couchDbFixture.Container.ConnectionString}/mydatabase/001");
+      Assert.Contains("MyName", response);
     }
   }
 }

--- a/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/CouchbaseTestcontainerTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/CouchbaseTestcontainerTest.cs
@@ -233,6 +233,25 @@ namespace DotNet.Testcontainers.Tests.Unit
       Assert.Equal("Couchbase ClusterAnalyticsRamSize ram size can not be less than 1024 MB. (Parameter 'ClusterAnalyticsRamSize')", exception.Message);
     }
 
+    [Fact]
+    public async Task ExecScriptInRunningContainer()
+    {
+      // Given
+      _ = await this.couchbaseFixture.Container.CreateBucket("MyBucket")
+        .ConfigureAwait(false);
+      const string script = @"
+        CREATE PRIMARY INDEX ON `MyBucket`;
+        SELECT * FROM system:indexes;
+        ";
+
+      // When
+      var results = await this.couchbaseFixture.Container.ExecScriptAsync(script)
+        .ConfigureAwait(false);
+
+      // Then
+      Assert.Contains("MyBucket", results.Stdout);
+    }
+
     private readonly struct Customer
     {
       public Customer(string name, int age)

--- a/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/MySqlTestcontainerTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/MySqlTestcontainerTest.cs
@@ -28,5 +28,41 @@ namespace DotNet.Testcontainers.Tests.Unit
       // Then
       Assert.Equal(ConnectionState.Open, connection.State);
     }
+
+    [Fact]
+    public async Task ExecScriptInRunningContainer()
+    {
+      // Given
+      const string script = @"
+        CREATE TABLE MyTable (
+        id INT(6) UNSIGNED PRIMARY KEY,
+        name VARCHAR(30) NOT NULL
+        );
+        GO
+        INSERT INTO MyTable (id, name) VALUES (1, 'MyName');
+        GO
+        SELECT * FROM MyTable;
+        ";
+
+      // When
+      var results = await this.mySqlFixture.Container.ExecScriptAsync(script);
+
+      // Then
+      Assert.Contains("MyName", results.Stdout);
+    }
+
+    [Fact]
+    public async Task ThrowErrorInRunningContainerWithInvalidScript()
+    {
+      // Given
+      const string script = "invalid SQL command";
+
+      // When
+      var results = await this.mySqlFixture.Container.ExecScriptAsync(script);
+
+      // Then
+      Assert.NotEqual(0, results.ExitCode);
+      Assert.NotEqual(string.Empty, results.Stderr);
+    }
   }
 }

--- a/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/OracleTestcontainerTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/OracleTestcontainerTest.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Tests.Unit
+namespace DotNet.Testcontainers.Tests.Unit
 {
   using System;
   using System.Data;
@@ -50,6 +50,27 @@
     {
       var oracle = new OracleTestcontainerConfiguration();
       Assert.Throws<NotImplementedException>(() => oracle.Password = string.Empty);
+    }
+
+    [Fact]
+    public async Task ExecScriptInRunningContainer()
+    {
+      // Given
+      const string script = @"
+        CREATE TABLE MyTable (
+        id INT,
+        name VARCHAR(30) NOT NULL
+        );
+        GO
+        INSERT INTO MyTable (id, name) VALUES (1, 'MyName');
+        SELECT * FROM MyTable;
+        ";
+
+      // When
+      var results = await this.oracleFixture.Container.ExecScriptAsync(script);
+
+      // Then
+      Assert.Contains("MyName", results.Stdout);
     }
   }
 }

--- a/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/PostgreSqlTestcontainerTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/PostgreSqlTestcontainerTest.cs
@@ -28,5 +28,28 @@ namespace DotNet.Testcontainers.Tests.Unit
       // Then
       Assert.Equal(ConnectionState.Open, connection.State);
     }
+
+    [Fact]
+    public async Task ExecScriptInRunningContainer()
+    {
+      // Given
+      const string script = @"
+
+        CREATE TABLE MyTable (
+	        id serial PRIMARY KEY,
+	        name VARCHAR ( 50 ) UNIQUE NOT NULL 
+        );
+        GO
+        INSERT INTO MyTable (name) VALUES ('MyName');
+        GO
+        SELECT * FROM MyTable;
+        ";
+
+      // When
+      var results = await this.postgreSqlFixture.Container.ExecScriptAsync(script);
+
+      // Then
+      Assert.Contains("MyName", results.Stdout);
+    }
   }
 }

--- a/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/RedisTestcontainerTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/RedisTestcontainerTest.cs
@@ -1,6 +1,7 @@
 namespace DotNet.Testcontainers.Tests.Unit
 {
   using System;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Tests.Fixtures;
   using Xunit;
@@ -40,6 +41,27 @@ namespace DotNet.Testcontainers.Tests.Unit
     {
       var redis = new RedisTestcontainerConfiguration();
       Assert.Throws<NotImplementedException>(() => redis.Password = string.Empty);
+    }
+
+    [Fact]
+    public async Task ExecScriptInRunningContainer()
+    {
+      // Given
+      const string script = @"
+        -- Lua script
+        for i = 1, 5, 1 
+        do 
+           redis.call('incr', 'my-counter') 
+        end
+        local mycounter = redis.call('get', 'my-counter')
+        return mycounter
+        ";
+
+      // When
+      var results = await this.redisFixture.Container.ExecScriptAsync(script);
+
+      // Then
+      Assert.Contains("5", results.Stdout);
     }
   }
 }


### PR DESCRIPTION
Methods to run scripts against databases:

- SQL scripts for MS SQL, MySQL, Oracle, Postgre;
- Lua scripts for Redis; 
- N1QL scripts for Couchbase