### PR TITLE
Fix ResourceReaper connection to non-localhost

### DIFF
--- a/src/DotNet.Testcontainers/Containers/ResourceReaper.cs
+++ b/src/DotNet.Testcontainers/Containers/ResourceReaper.cs
@@ -223,15 +223,13 @@ namespace DotNet.Testcontainers.Containers
     /// <param name="ct">The cancellation token to cancel the <see cref="ResourceReaper" /> initialization. This will not cancel the maintained connection.</param>
     private async Task MaintainRyukConnection(TaskCompletionSource<bool> ryukInitializedTaskSource, CancellationToken ct)
     {
-      var endpoint = new IPEndPoint(IPAddress.Loopback, this.resourceReaperContainer.GetMappedPublicPort(RyukPort));
-
       while (!this.maintainConnectionCts.IsCancellationRequested && (!ct.IsCancellationRequested || ryukInitializedTaskSource.Task.IsCompleted))
       {
         using (var tcpClient = new TcpClient())
         {
           try
           {
-            tcpClient.Connect(endpoint);
+            tcpClient.Connect(this.resourceReaperContainer.Hostname, this.resourceReaperContainer.GetMappedPublicPort(RyukPort));
 
             var stream = tcpClient.GetStream();
 
@@ -307,11 +305,11 @@ namespace DotNet.Testcontainers.Containers
           }
           catch (SocketException e)
           {
-            this.resourceReaperContainer.Logger.CanNotConnectToResourceReaper(endpoint, e);
+            this.resourceReaperContainer.Logger.CanNotConnectToResourceReaper(e);
           }
           catch (Exception e)
           {
-            this.resourceReaperContainer.Logger.LostConnectionToResourceReaper(endpoint, e);
+            this.resourceReaperContainer.Logger.LostConnectionToResourceReaper(e);
           }
           finally
           {

--- a/src/DotNet.Testcontainers/Logging.cs
+++ b/src/DotNet.Testcontainers/Logging.cs
@@ -60,11 +60,11 @@
     private static readonly Action<ILogger, string, Exception> _DeleteDockerVolume
       = LoggerMessage.Define<string>(LogLevel.Information, default, "Delete Docker volume {Name}");
 
-    private static readonly Action<ILogger, EndPoint, Exception> _CanNotConnectToResourceReaper
-      = LoggerMessage.Define<EndPoint>(LogLevel.Error, default, "Can not connect to resource reaper at {ResourceReaper}");
+    private static readonly Action<ILogger, Exception> _CanNotConnectToResourceReaper
+      = LoggerMessage.Define(LogLevel.Error, default, "Can not connect to resource reaper");
 
-    private static readonly Action<ILogger, EndPoint, Exception> _LostConnectionToResourceReaper
-      = LoggerMessage.Define<EndPoint>(LogLevel.Error, default, "Lost connection to resource reaper at {ResourceReaper}");
+    private static readonly Action<ILogger, Exception> _LostConnectionToResourceReaper
+      = LoggerMessage.Define(LogLevel.Error, default, "Lost connection to resource reaper");
 
     public static void Progress(this ILogger logger, string message)
     {
@@ -146,14 +146,14 @@
       _DeleteDockerVolume(logger, name, null);
     }
 
-    public static void CanNotConnectToResourceReaper(this ILogger logger, EndPoint resourceReaper, Exception exception)
+    public static void CanNotConnectToResourceReaper(this ILogger logger, Exception exception)
     {
-      _CanNotConnectToResourceReaper(logger, resourceReaper, null);
+      _CanNotConnectToResourceReaper(logger, exception);
     }
 
-    public static void LostConnectionToResourceReaper(this ILogger logger, EndPoint resourceReaper, Exception exception)
+    public static void LostConnectionToResourceReaper(this ILogger logger, Exception exception)
     {
-      _LostConnectionToResourceReaper(logger, resourceReaper, null);
+      _LostConnectionToResourceReaper(logger, exception);
     }
   }
 }

--- a/src/DotNet.Testcontainers/Logging.cs
+++ b/src/DotNet.Testcontainers/Logging.cs
@@ -3,7 +3,6 @@
   using System;
   using System.Collections.Generic;
   using System.Diagnostics.CodeAnalysis;
-  using System.Net;
   using System.Text.RegularExpressions;
   using DotNet.Testcontainers.Images;
   using Microsoft.Extensions.Logging;
@@ -60,11 +59,11 @@
     private static readonly Action<ILogger, string, Exception> _DeleteDockerVolume
       = LoggerMessage.Define<string>(LogLevel.Information, default, "Delete Docker volume {Name}");
 
-    private static readonly Action<ILogger, Exception> _CanNotConnectToResourceReaper
-      = LoggerMessage.Define(LogLevel.Error, default, "Can not connect to resource reaper");
+    private static readonly Action<ILogger, string, ushort, Exception> _CanNotConnectToResourceReaper
+      = LoggerMessage.Define<string, ushort>(LogLevel.Error, default, "Can not connect to resource reaper at {Host}:{Port}");
 
-    private static readonly Action<ILogger, Exception> _LostConnectionToResourceReaper
-      = LoggerMessage.Define(LogLevel.Error, default, "Lost connection to resource reaper");
+    private static readonly Action<ILogger, string, ushort, Exception> _LostConnectionToResourceReaper
+      = LoggerMessage.Define<string, ushort>(LogLevel.Error, default, "Lost connection to resource reaper at {Host}:{Port}");
 
     public static void Progress(this ILogger logger, string message)
     {
@@ -146,14 +145,14 @@
       _DeleteDockerVolume(logger, name, null);
     }
 
-    public static void CanNotConnectToResourceReaper(this ILogger logger, Exception exception)
+    public static void CanNotConnectToResourceReaper(this ILogger logger, string host, ushort port)
     {
-      _CanNotConnectToResourceReaper(logger, exception);
+      _CanNotConnectToResourceReaper(logger, host, port, null);
     }
 
-    public static void LostConnectionToResourceReaper(this ILogger logger, Exception exception)
+    public static void LostConnectionToResourceReaper(this ILogger logger, string host, ushort port)
     {
-      _LostConnectionToResourceReaper(logger, exception);
+      _LostConnectionToResourceReaper(logger, host, port, null);
     }
   }
 }


### PR DESCRIPTION
This PR fixes the ResourceReaper to be able to connect to Ryuk when it is not available on localhost.

Related discussion: https://github.com/HofmeisterAn/dotnet-testcontainers/discussions/423#discussioncomment-2179011