### PR TITLE
#IMPLEMENT 'assemblyName: DotNet.Testcontainers; function: WithEnvironment

### DIFF
--- a/src/DotNet.Testcontainers/Builders/ITestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Builders/ITestcontainersBuilder.cs
@@ -1,6 +1,7 @@
 namespace DotNet.Testcontainers.Builders
 {
   using System;
+  using System.Collections.Generic;
   using System.Threading;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
@@ -88,6 +89,14 @@ namespace DotNet.Testcontainers.Builders
     /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
     [PublicAPI]
     ITestcontainersBuilder<TDockerContainer> WithEnvironment(string name, string value);
+
+    /// <summary>
+    /// Adds the values in the dictionary  as environment variables to the Testcontainer.
+    /// </summary>
+    /// <param name="values">A dictionary containing the environment variables.</param>
+    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    [PublicAPI]
+    ITestcontainersBuilder<TDockerContainer> WithEnvironment(Dictionary<string, string> values);
 
     /// <summary>
     /// Adds user-defined metadata to the Testcontainer.

--- a/src/DotNet.Testcontainers/Builders/TestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Builders/TestcontainersBuilder.cs
@@ -126,6 +126,12 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
+    public ITestcontainersBuilder<TDockerContainer> WithEnvironment(Dictionary<string, string> values)
+    {
+      return Build(this, Apply(environments: values));
+    }
+
+    /// <inheritdoc />
     public ITestcontainersBuilder<TDockerContainer> WithLabel(string name, string value)
     {
       var labels = new Dictionary<string, string> { { name, value } };


### PR DESCRIPTION
{Add WithEnvironment override that accepts a dictionary of environment variables.}