### PR TITLE
[428] #EXTEND 'assemblyName: DotNet.Testcontainers; function: Build'

### DIFF
--- a/src/DotNet.Testcontainers/Builders/TestcontainersBuilder.cs
+++ b/src/DotNet.Testcontainers/Builders/TestcontainersBuilder.cs
@@ -297,6 +297,11 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc />
     public TDockerContainer Build()
     {
+      if (this.configuration.Image is null)
+      {
+        throw new ArgumentNullException(nameof(this.configuration.Image));
+      }
+
 #pragma warning disable S3011
 
       // Create container instance.

--- a/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -457,6 +457,15 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         // Then
         Assert.False(Docker.Exists(DockerResource.Container, testcontainerId));
       }
+
+      [Fact]
+      public async Task ShouldThrowArgumentNullExceptionWhenBuildContainerWithoutImage()
+      {
+        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+        {
+          await using var testContainer = new TestcontainersBuilder<TestcontainersContainer>().Build();
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
{Throwing more specific null exception when Build is called on a container builder where there is no image specified.}