### PR TITLE
[#NON] #REVIEW 'assemblyName: DotNet.Testcontainers; function: TestcontainersContainer'

### DIFF
--- a/src/DotNet.Testcontainers/Containers/TestcontainersContainer.cs
+++ b/src/DotNet.Testcontainers/Containers/TestcontainersContainer.cs
@@ -232,11 +232,8 @@ namespace DotNet.Testcontainers.Containers
         return;
       }
 
-      // TODO: Workaround until we have a Windows Docker image of Ryuk
-      var isWindowsEngineEnabled = await this.client.GetIsWindowsEngineEnabled()
-        .ConfigureAwait(false);
-
-      if (isWindowsEngineEnabled && !Guid.Empty.ToString("D").Equals(this.configuration.Labels[ResourceReaper.ResourceReaperSessionLabel], StringComparison.OrdinalIgnoreCase))
+      // If someone calls `DisposeAsync`, we can immediately remove the container. We don't need to wait for the Resource Reaper.
+      if (!Guid.Empty.ToString("D").Equals(this.configuration.Labels[ResourceReaper.ResourceReaperSessionLabel], StringComparison.OrdinalIgnoreCase))
       {
         await this.CleanUpAsync()
           .ConfigureAwait(false);
@@ -342,7 +339,7 @@ namespace DotNet.Testcontainers.Containers
       {
         try
         {
-          // Unfortunately, the method incl. `cancellationToken` is not available at .NET Standard 2.0, 2.1.
+          // Unfortunately, the method incl. `cancellationToken` is not available in .NET Standard 2.0 and 2.1.
           _ = Dns.GetHostEntry(hostName);
           return hostName;
         }

--- a/tests/DotNet.Testcontainers.Tests/Fixtures/Containers/Unix/NetworkFixture.cs
+++ b/tests/DotNet.Testcontainers.Tests/Fixtures/Containers/Unix/NetworkFixture.cs
@@ -1,5 +1,6 @@
 ﻿namespace DotNet.Testcontainers.Tests.Fixtures
 {
+  using System;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Builders;
   using DotNet.Testcontainers.Configurations;
@@ -11,7 +12,7 @@
     public IDockerNetwork Network { get; }
       = new TestcontainersNetworkBuilder()
         .WithDriver(NetworkDriver.Bridge)
-        .WithName("test-network")
+        .WithName(Guid.NewGuid().ToString("D"))
         .Build();
 
     public Task InitializeAsync()

--- a/tests/DotNet.Testcontainers.Tests/Fixtures/Containers/Unix/VolumeFixture.cs
+++ b/tests/DotNet.Testcontainers.Tests/Fixtures/Containers/Unix/VolumeFixture.cs
@@ -9,24 +9,23 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
   public sealed class VolumeFixture : IAsyncLifetime
   {
+    private readonly Guid sessionId = Guid.NewGuid();
+
     private readonly IDockerVolume volume;
 
     public VolumeFixture()
     {
-      var sessionId = Guid.NewGuid();
-      var name = $"testcontainers-volume-{sessionId:D}";
       this.volume = new TestcontainersVolumeBuilder()
-        .WithName(name)
-        .WithResourceReaperSessionId(sessionId)
+        .WithName(this.SessionId.ToString("D"))
+        .WithResourceReaperSessionId(this.SessionId)
         .Build();
-
-      this.SessionId = sessionId;
-      this.Name = name;
     }
 
-    public Guid SessionId { get; }
+    public Guid SessionId
+      => this.sessionId;
 
-    public string Name { get; }
+    public string Name
+      => this.volume.Name;
 
     public Task InitializeAsync()
     {
@@ -35,8 +34,7 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
     public Task DisposeAsync()
     {
-      // The ResourceReaper will take care of the remaining resources.
-      return Task.CompletedTask;
+      return this.volume.DeleteAsync();
     }
   }
 }

--- a/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -430,6 +430,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
           .WithImage("alpine")
           .WithAutoRemove(false)
+          .WithCleanUp(false)
           .WithEntrypoint(KeepTestcontainersUpAndRunning.Command);
 
         // When
@@ -452,6 +453,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
           .WithImage("alpine")
           .WithAutoRemove(true)
+          .WithCleanUp(false)
           .WithEntrypoint(KeepTestcontainersUpAndRunning.Command);
 
         // When


### PR DESCRIPTION
{It's necessary to dispose a container immediately, if someone deletes a network or volume manually.}