### PR TITLE
[#470] #BUGFIX 'assemblyName: DotNet.Testcontainers; function: Docker…

### DIFF
--- a/src/DotNet.Testcontainers/Images/DockerImage.cs
+++ b/src/DotNet.Testcontainers/Images/DockerImage.cs
@@ -91,7 +91,7 @@ namespace DotNet.Testcontainers.Images
     /// <inheritdoc />
     public string GetHostname()
     {
-      var firstSegmentOfRepository = this.Repository.Split('/').First();
+      var firstSegmentOfRepository = (this.hubImageNamePrefix ?? this.Repository).Split('/').First();
       return firstSegmentOfRepository.IndexOfAny(new[] { '.', ':' }) >= 0 ? firstSegmentOfRepository : null;
     }
   }

--- a/tests/DotNet.Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
+++ b/tests/DotNet.Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
@@ -33,8 +33,19 @@
     [InlineData("myregistry.azurecr.io/baz:foo/bar:1.0.0", "myregistry.azurecr.io")]
     public void GetHostnameFromDockerImage(string dockerImageName, string hostname)
     {
-      IDockerImage image = new DockerImage(dockerImageName);
+      var image = new DockerImage(dockerImageName);
       Assert.Equal(hostname, image.GetHostname());
+    }
+
+    [Theory]
+    [InlineData("", "docker",  "stable")]
+    [InlineData("fedora", "httpd",  "1.0")]
+    [InlineData("foo/bar", "baz",  "1.0.0")]
+    public void GetsHostnameOfPrefixWhenPrefixIsConfigured(string repository, string name, string tag)
+    {
+      var prefix = "myregistry.azurecr.io";
+      var image = new DockerImage(repository, name, tag, prefix);
+      Assert.Equal(prefix, image.GetHostname());
     }
 
     [Fact]


### PR DESCRIPTION
…Image'

{Consider hostname of image prefix when configured.}