### PR TITLE
Feature/455 Added WithNetworkAliases functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To configure a container, use the `TestcontainersBuilder<TestcontainersContainer
 - `WithBindMount` binds a path of a file or directory into the container e.g. `-v, --volume .:/tmp`.
 - `WithVolumeMount` mounts a managed volume into the container e.g. `--mount type=volume,source=.,destination=/tmp`.
 - `WithNetwork` assigns a network to the container e.g. `--network="bridge"`.
+- `WithNetworkAliases` assigns a network scoped aliases  to the container e.g. `--network-alias alias`
 - `WithDockerEndpoint` sets the Docker API endpoint e.g. `-H tcp://0.0.0.0:2376`.
 - `WithRegistryAuthentication` basic authentication against a private Docker registry.
 - `WithOutputConsumer` redirects `stdout` and `stderr` to capture the container output.

--- a/src/Testcontainers/Builders/ITestcontainersBuilder.cs
+++ b/src/Testcontainers/Builders/ITestcontainersBuilder.cs
@@ -251,6 +251,22 @@ namespace DotNet.Testcontainers.Builders
     ITestcontainersBuilder<TDockerContainer> WithNetwork(IDockerNetwork dockerNetwork);
 
     /// <summary>
+    /// Assign specified network aliases to container.
+    /// </summary>
+    /// <param name="networkAliases">Set of network aliases.</param>
+    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    [PublicAPI]
+    ITestcontainersBuilder<TDockerContainer> WithNetworkAliases(params string[] networkAliases);
+
+    /// <summary>
+    /// Assign specified network aliases to container.
+    /// </summary>
+    /// <param name="networkAliases">Set of network aliases.</param>
+    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    [PublicAPI]
+    ITestcontainersBuilder<TDockerContainer> WithNetworkAliases(IEnumerable<string> networkAliases);
+
+    /// <summary>
     /// If true, the Docker daemon will remove the stopped Testcontainer automatically. Otherwise, the Testcontainer will be kept.
     /// </summary>
     /// <param name="autoRemove">True, the Docker daemon will remove the stopped Testcontainer automatically. Otherwise, the Testcontainer will be kept.</param>

--- a/src/Testcontainers/Builders/TestcontainersBuilder.cs
+++ b/src/Testcontainers/Builders/TestcontainersBuilder.cs
@@ -2,6 +2,7 @@ namespace DotNet.Testcontainers.Builders
 {
   using System;
   using System.Collections.Generic;
+  using System.Linq;
   using System.Reflection;
   using System.Threading;
   using System.Threading.Tasks;
@@ -236,6 +237,18 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
+    public ITestcontainersBuilder<TDockerContainer> WithNetworkAliases(params string[] networkAliases)
+    {
+      return this.WithNetworkAliases(networkAliases.AsEnumerable());
+    }
+
+    /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
+    public ITestcontainersBuilder<TDockerContainer> WithNetworkAliases(IEnumerable<string> networkAliases)
+    {
+      return this.MergeNewConfiguration(new TestcontainersConfiguration(networkAliases: networkAliases));
+    }
+
+    /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
     public ITestcontainersBuilder<TDockerContainer> WithAutoRemove(bool autoRemove)
     {
       return this.MergeNewConfiguration(new TestcontainersConfiguration(autoRemove: autoRemove));
@@ -321,6 +334,7 @@ namespace DotNet.Testcontainers.Builders
       var portBindings = BuildConfiguration.Combine(dockerResourceConfiguration.PortBindings, this.DockerResourceConfiguration.PortBindings);
       var mounts = BuildConfiguration.Combine(dockerResourceConfiguration.Mounts, this.DockerResourceConfiguration.Mounts);
       var networks = BuildConfiguration.Combine(dockerResourceConfiguration.Networks, this.DockerResourceConfiguration.Networks);
+      var networkAliases = BuildConfiguration.Combine(dockerResourceConfiguration.NetworkAliases, this.DockerResourceConfiguration.NetworkAliases);
 
       var dockerEndpointAuthConfig = BuildConfiguration.Combine(dockerResourceConfiguration.DockerEndpointAuthConfig, this.DockerResourceConfiguration.DockerEndpointAuthConfig);
       var dockerRegistryAuthConfig = BuildConfiguration.Combine(dockerResourceConfiguration.DockerRegistryAuthConfig, this.DockerResourceConfiguration.DockerRegistryAuthConfig);
@@ -328,7 +342,7 @@ namespace DotNet.Testcontainers.Builders
       var waitStrategies = BuildConfiguration.Combine<IEnumerable<IWaitUntil>>(dockerResourceConfiguration.WaitStrategies, this.DockerResourceConfiguration.WaitStrategies);
       var startupCallback = BuildConfiguration.Combine(dockerResourceConfiguration.StartupCallback, this.DockerResourceConfiguration.StartupCallback);
 
-      var updatedDockerResourceConfiguration = new TestcontainersConfiguration(dockerEndpointAuthConfig, dockerRegistryAuthConfig, image, name, hostname, workingDirectory, entrypoint, command, environments, labels, exposedPorts, portBindings, mounts, networks, outputConsumer, waitStrategies, startupCallback, autoRemove, privileged);
+      var updatedDockerResourceConfiguration = new TestcontainersConfiguration(dockerEndpointAuthConfig, dockerRegistryAuthConfig, image, name, hostname, workingDirectory, entrypoint, command, environments, labels, exposedPorts, portBindings, mounts, networks, networkAliases, outputConsumer, waitStrategies, startupCallback, autoRemove, privileged);
       return new TestcontainersBuilder<TDockerContainer>(updatedDockerResourceConfiguration, moduleConfiguration ?? this.mergeModuleConfiguration);
     }
 

--- a/src/Testcontainers/Clients/TestcontainersConfigurationConverter.cs
+++ b/src/Testcontainers/Clients/TestcontainersConfigurationConverter.cs
@@ -25,7 +25,13 @@ namespace DotNet.Testcontainers.Clients
       this.ExposedPorts = new ToExposedPorts().Convert(configuration.ExposedPorts)?.ToDictionary(item => item.Key, item => item.Value);
       this.PortBindings = new ToPortBindings().Convert(configuration.PortBindings)?.ToDictionary(item => item.Key, item => item.Value);
       this.Mounts = new ToMounts().Convert(configuration.Mounts)?.ToList();
-      this.Networks = new ToNetworks().Convert(configuration.Networks)?.ToDictionary(item => item.Key, item => item.Value);
+      this.Networks = new ToNetworks().Convert(configuration.Networks)?.ToDictionary(
+        network => network.Key,
+        network =>
+        {
+          network.Value.Aliases = configuration.NetworkAliases?.ToArray();
+          return network.Value;
+        });
     }
 
     public IList<string> Entrypoint { get; }

--- a/src/Testcontainers/Configurations/Containers/ITestcontainersConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ITestcontainersConfiguration.cs
@@ -84,6 +84,11 @@ namespace DotNet.Testcontainers.Configurations
     IEnumerable<IDockerNetwork> Networks { get; }
 
     /// <summary>
+    /// Gets a list of container network aliases.
+    /// </summary>
+    IEnumerable<string> NetworkAliases { get; }
+
+    /// <summary>
     /// Gets the output consumer.
     /// </summary>
     IOutputConsumer OutputConsumer { get; }

--- a/src/Testcontainers/Configurations/Containers/TestcontainersConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/TestcontainersConfiguration.cs
@@ -39,6 +39,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="portBindings">The port bindings.</param>
     /// <param name="mounts">The volumes.</param>
     /// <param name="networks">The networks.</param>
+    /// <param name="networkAliases">The container network aliases.</param>
     /// <param name="outputConsumer">The output consumer.</param>
     /// <param name="waitStrategies">The wait strategies.</param>
     /// <param name="startupCallback">The startup callback.</param>
@@ -59,6 +60,7 @@ namespace DotNet.Testcontainers.Configurations
       IReadOnlyDictionary<string, string> portBindings = null,
       IEnumerable<IMount> mounts = null,
       IEnumerable<IDockerNetwork> networks = null,
+      IEnumerable<string> networkAliases = null,
       IOutputConsumer outputConsumer = null,
       IEnumerable<IWaitUntil> waitStrategies = null,
       Func<ITestcontainersContainer, CancellationToken, Task> startupCallback = null,
@@ -80,6 +82,7 @@ namespace DotNet.Testcontainers.Configurations
       this.PortBindings = portBindings;
       this.Mounts = mounts;
       this.Networks = networks;
+      this.NetworkAliases = networkAliases;
       this.OutputConsumer = outputConsumer;
       this.WaitStrategies = waitStrategies;
       this.StartupCallback = startupCallback;
@@ -128,6 +131,9 @@ namespace DotNet.Testcontainers.Configurations
 
     /// <inheritdoc />>
     public IEnumerable<IDockerNetwork> Networks { get; }
+
+    /// <inheritdoc />>
+    public IEnumerable<string> NetworkAliases { get; }
 
     /// <inheritdoc />
     public IOutputConsumer OutputConsumer { get; }


### PR DESCRIPTION
This PR should bring new functionality `WithNetworkAliases` to `ITestcontainersBuilder<>`
```csharp
    /// <summary>
    /// Assign specified network aliases to container.
    /// </summary>
    /// <param name="networkAliases">Set of network aliases.</param>
    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
    [PublicAPI]
    ITestcontainersBuilder<TDockerContainer> WithNetworkAliases(params string[] networkAliases);

    /// <summary>
    /// Assign specified network aliases to container.
    /// </summary>
    /// <param name="networkAliases">Set of network aliases.</param>
    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
    [PublicAPI]
    ITestcontainersBuilder<TDockerContainer> WithNetworkAliases(IEnumerable<string> networkAliases);
```