### PR TITLE
feat(#483): Added TestcontainersSettings.ResourceReaperImage property

### DIFF
--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -1,7 +1,8 @@
-﻿namespace DotNet.Testcontainers.Configurations
+namespace DotNet.Testcontainers.Configurations
 {
   using System.Runtime.InteropServices;
   using DotNet.Testcontainers.Containers;
+  using DotNet.Testcontainers.Images;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
   using Microsoft.Extensions.Logging.Abstractions;
@@ -18,6 +19,13 @@
     [PublicAPI]
     public static bool ResourceReaperEnabled { get; set; }
       = true;
+
+    /// <summary>
+    /// Gets or sets a docker image for <see cref="ResourceReaper" /> container.
+    /// </summary>
+    [PublicAPI]
+    public static IDockerImage ResourceReaperImage { get; set; }
+      = new DockerImage("ghcr.io/psanetra/ryuk:2021.12.20");
 
     /// <summary>
     /// Gets or sets a prefix that applies to every image that is pulled from Docker Hub.

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -19,8 +19,6 @@ namespace DotNet.Testcontainers.Containers
   {
     public const string ResourceReaperSessionLabel = TestcontainersClient.TestcontainersLabel + ".resource-reaper-session";
 
-    private const string RyukImage = "ghcr.io/psanetra/ryuk:2021.12.20";
-
     private const ushort RyukPort = 8080;
 
     private static readonly SemaphoreSlim DefaultLock = new SemaphoreSlim(1, 1);
@@ -42,7 +40,7 @@ namespace DotNet.Testcontainers.Containers
       this.resourceReaperContainer = new TestcontainersBuilder<TestcontainersContainer>()
         .WithDockerEndpoint(dockerEndpointAuthConfig ?? TestcontainersSettings.OS.DockerEndpointAuthConfig)
         .WithName($"testcontainers-ryuk-{sessionId:D}")
-        .WithImage(ryukImage)
+        .WithImage(ryukImage ?? TestcontainersSettings.ResourceReaperImage.FullName)
         .WithAutoRemove(true)
         .WithCleanUp(false)
         .WithExposedPort(RyukPort)
@@ -105,7 +103,7 @@ namespace DotNet.Testcontainers.Containers
 
       try
       {
-        defaultInstance = await GetAndStartNewAsync(DefaultSessionId, dockerEndpointAuthConfig, RyukImage, default, ct)
+        defaultInstance = await GetAndStartNewAsync(DefaultSessionId, dockerEndpointAuthConfig, ct: ct)
           .ConfigureAwait(false);
 
         return defaultInstance;
@@ -126,7 +124,7 @@ namespace DotNet.Testcontainers.Containers
     /// <returns>Task that completes when the <see cref="ResourceReaper" /> has been started.</returns>
     /// <remarks>If <paramref name="dockerEndpointAuthConfig" /> is null, the resource reaper will fallback to the default authentication configuration.</remarks>
     [PublicAPI]
-    public static Task<ResourceReaper> GetAndStartNewAsync(IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig = null, string ryukImage = RyukImage, TimeSpan initTimeout = default, CancellationToken ct = default)
+    public static Task<ResourceReaper> GetAndStartNewAsync(IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig = null, string ryukImage = null, TimeSpan initTimeout = default, CancellationToken ct = default)
     {
       return GetAndStartNewAsync(Guid.NewGuid(), dockerEndpointAuthConfig, ryukImage, initTimeout, ct);
     }
@@ -142,7 +140,7 @@ namespace DotNet.Testcontainers.Containers
     /// <returns>Task that completes when the <see cref="ResourceReaper" /> has been started.</returns>
     /// <remarks>If <paramref name="dockerEndpointAuthConfig" /> is null, the resource reaper will fallback to the default authentication configuration.</remarks>
     [PublicAPI]
-    public static async Task<ResourceReaper> GetAndStartNewAsync(Guid sessionId, IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig = null, string ryukImage = RyukImage, TimeSpan initTimeout = default, CancellationToken ct = default)
+    public static async Task<ResourceReaper> GetAndStartNewAsync(Guid sessionId, IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig = null, string ryukImage = null, TimeSpan initTimeout = default, CancellationToken ct = default)
     {
       var ryukInitializedTaskSource = new TaskCompletionSource<bool>();
 


### PR DESCRIPTION
Added TestcontainersSettings.ResourceReaperImage property to customize Resource Reaper image base on #483.
Same implementation as is `DockerEndpointAuthConfig`.

I have just questions if the condition in constructior `.WithImage(ryukImage ?? TestcontainersSettings.ResourceReaperImage.FullName)` should not be covered by any test?