### PR TITLE
Throwing exception if image doesn't exist after build

### DIFF
--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -114,10 +114,10 @@ namespace DotNet.Testcontainers.Clients
         await this.Docker.Images.BuildImageFromDockerfileAsync(buildParameters, dockerFileStream, Array.Empty<AuthConfig>(), new Dictionary<string, string>(), this.traceProgress, ct)
           .ConfigureAwait(false);
 
-        bool isImageCreated = await this.ExistsWithNameAsync(image.FullName, ct).ConfigureAwait(false);
-        if (!isImageCreated)
+        var imageHasBeenCreated = await this.ExistsWithNameAsync(image.FullName, ct).ConfigureAwait(false);
+        if (!imageHasBeenCreated)
         {
-          throw new Exception($"Failed to create image {image.FullName}");
+          throw new InvalidOperationException($"Docker image {image.FullName} has not been created.");
         }
       }
 

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -113,6 +113,12 @@ namespace DotNet.Testcontainers.Clients
       {
         await this.Docker.Images.BuildImageFromDockerfileAsync(buildParameters, dockerFileStream, Array.Empty<AuthConfig>(), new Dictionary<string, string>(), this.traceProgress, ct)
           .ConfigureAwait(false);
+
+        bool isImageCreated = await this.ExistsWithNameAsync(image.FullName, ct).ConfigureAwait(false);
+        if (!isImageCreated)
+        {
+          throw new Exception($"Failed to create image {image.FullName}");
+        }
       }
 
       this.logger.DockerImageBuilt(image);


### PR DESCRIPTION
Hi
I noticed that the framework doesn't give any feedback's if image is not created. This leads to errors in the other lines of code:

"Docker.DotNet.DockerImageNotFoundException : Docker API responded with status code=NotFound, response={"message":"No such image: testcontainers:1656427318745"}"