### PR TITLE
Add support for WithCreateContainerParametersModifier

### DIFF
--- a/src/Testcontainers/Builders/BuildConfiguration.cs
+++ b/src/Testcontainers/Builders/BuildConfiguration.cs
@@ -22,7 +22,7 @@ namespace DotNet.Testcontainers.Builders
     /// </summary>
     /// <param name="next">Changed configuration.</param>
     /// <param name="previous">Previous configuration.</param>
-    /// <typeparam name="T">Type of <see cref="IReadOnlyDictionary{TKey,TValue}" />.</typeparam>
+    /// <typeparam name="T">Type of <see cref="IEnumerable{T}" />.</typeparam>
     /// <returns>An updated configuration.</returns>
     public static IEnumerable<T> Combine<T>(IEnumerable<T> next, IEnumerable<T> previous)
       where T : class
@@ -35,6 +35,25 @@ namespace DotNet.Testcontainers.Builders
       {
         return next.Concat(previous).ToArray();
       }
+    }
+
+    /// <summary>
+    /// Combines all existing and new configuration changes while preserving the original order of insertion.
+    /// If there are no changes, the previous configurations are returned.
+    /// </summary>
+    /// <param name="next">Changed configuration.</param>
+    /// <param name="previous">Previous configuration.</param>
+    /// <typeparam name="T">Type of <see cref="IReadOnlyList{T}" />.</typeparam>
+    /// <returns>An updated configuration.</returns>
+    public static IReadOnlyList<T> Combine<T>(IReadOnlyList<T> next, IReadOnlyList<T> previous)
+      where T : class
+    {
+      if (next == null || previous == null)
+      {
+        return next ?? previous;
+      }
+
+      return previous.Concat(next).ToArray();
     }
 
     /// <summary>

--- a/src/Testcontainers/Builders/ITestcontainersBuilder.cs
+++ b/src/Testcontainers/Builders/ITestcontainersBuilder.cs
@@ -4,6 +4,7 @@ namespace DotNet.Testcontainers.Builders
   using System.Collections.Generic;
   using System.Threading;
   using System.Threading.Tasks;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Images;
@@ -309,6 +310,16 @@ namespace DotNet.Testcontainers.Builders
     /// <remarks>Multiple wait strategies are executed one after the other.</remarks>
     [PublicAPI]
     ITestcontainersBuilder<TDockerContainer> WithWaitStrategy(IWaitForContainerOS waitStrategy);
+
+    /// <summary>
+    /// Allow low level modifications of <see cref="CreateContainerParameters"/> after the Testcontainer configuration has been applied.
+    /// When adding multiple modifiers, they will be executed in order of insertion.
+    /// </summary>
+    /// <param name="parameterModifier">The action that is invoked for modifying the <see cref="CreateContainerParameters"/> instance.</param>
+    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    /// <remarks>Warning: This exposes the underlying Docker.DotNet API so it might change outside of our control.</remarks>
+    [PublicAPI]
+    ITestcontainersBuilder<TDockerContainer> WithCreateContainerParametersModifier(Action<CreateContainerParameters> parameterModifier);
 
     /// <summary>
     /// Sets the startup callback to invoke after the Testcontainer start.

--- a/src/Testcontainers/Builders/TestcontainersBuilder.cs
+++ b/src/Testcontainers/Builders/TestcontainersBuilder.cs
@@ -7,6 +7,7 @@ namespace DotNet.Testcontainers.Builders
   using System.Reflection;
   using System.Threading;
   using System.Threading.Tasks;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
@@ -280,6 +281,13 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
+    public ITestcontainersBuilder<TDockerContainer> WithCreateContainerParametersModifier(Action<CreateContainerParameters> parameterModifier)
+    {
+      var parameterModifiers = new[] { parameterModifier };
+      return this.MergeNewConfiguration(new TestcontainersConfiguration(parameterModifiers: parameterModifiers));
+    }
+
+    /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
     public ITestcontainersBuilder<TDockerContainer> WithStartupCallback(Func<IRunningDockerContainer, CancellationToken, Task> startupCallback)
     {
       return this.MergeNewConfiguration(new TestcontainersConfiguration(startupCallback: startupCallback));
@@ -341,9 +349,10 @@ namespace DotNet.Testcontainers.Builders
       var dockerRegistryAuthConfig = BuildConfiguration.Combine(dockerResourceConfiguration.DockerRegistryAuthConfig, this.DockerResourceConfiguration.DockerRegistryAuthConfig);
       var outputConsumer = BuildConfiguration.Combine(dockerResourceConfiguration.OutputConsumer, this.DockerResourceConfiguration.OutputConsumer);
       var waitStrategies = BuildConfiguration.Combine<IEnumerable<IWaitUntil>>(dockerResourceConfiguration.WaitStrategies, this.DockerResourceConfiguration.WaitStrategies);
+      var parameterModifiers = BuildConfiguration.Combine(dockerResourceConfiguration.ParameterModifiers, this.DockerResourceConfiguration.ParameterModifiers);
       var startupCallback = BuildConfiguration.Combine(dockerResourceConfiguration.StartupCallback, this.DockerResourceConfiguration.StartupCallback);
 
-      var updatedDockerResourceConfiguration = new TestcontainersConfiguration(dockerEndpointAuthConfig, dockerRegistryAuthConfig, image, name, hostname, workingDirectory, entrypoint, command, environments, labels, exposedPorts, portBindings, mounts, networks, networkAliases, outputConsumer, waitStrategies, startupCallback, autoRemove, privileged);
+      var updatedDockerResourceConfiguration = new TestcontainersConfiguration(dockerEndpointAuthConfig, dockerRegistryAuthConfig, image, name, hostname, workingDirectory, entrypoint, command, environments, labels, exposedPorts, portBindings, mounts, networks, networkAliases, outputConsumer, waitStrategies, parameterModifiers, startupCallback, autoRemove, privileged);
       return new TestcontainersBuilder<TDockerContainer>(updatedDockerResourceConfiguration, moduleConfiguration ?? this.mergeModuleConfiguration);
     }
 

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -177,6 +177,14 @@ namespace DotNet.Testcontainers.Clients
         NetworkingConfig = networkingConfig,
       };
 
+      if (configuration.ParameterModifiers != null)
+      {
+        foreach (var parameterModifier in configuration.ParameterModifiers)
+        {
+          parameterModifier(createParameters);
+        }
+      }
+
       var id = (await this.Docker.Containers.CreateContainerAsync(createParameters, ct)
         .ConfigureAwait(false)).ID;
 

--- a/src/Testcontainers/Configurations/Containers/ITestcontainersConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ITestcontainersConfiguration.cs
@@ -4,6 +4,7 @@ namespace DotNet.Testcontainers.Configurations
   using System.Collections.Generic;
   using System.Threading;
   using System.Threading.Tasks;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Images;
   using DotNet.Testcontainers.Networks;
@@ -97,6 +98,15 @@ namespace DotNet.Testcontainers.Configurations
     /// Gets the wait strategies.
     /// </summary>
     IEnumerable<IWaitUntil> WaitStrategies { get; }
+
+    /// <summary>
+    /// Gets the modifier callbacks for <see cref="CreateContainerParameters"/>.
+    /// </summary>
+    /// <remarks>
+    /// These actions will be executed after the remaining Testcontainer configuration has been applied on the Docker
+    /// client, but just before creating the container.
+    /// </remarks>
+    IReadOnlyList<Action<CreateContainerParameters>> ParameterModifiers { get; }
 
     /// <summary>
     /// Gets the startup callback.

--- a/src/Testcontainers/Configurations/Containers/TestcontainersConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/TestcontainersConfiguration.cs
@@ -4,6 +4,7 @@ namespace DotNet.Testcontainers.Configurations
   using System.Collections.Generic;
   using System.Threading;
   using System.Threading.Tasks;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Images;
   using DotNet.Testcontainers.Networks;
@@ -42,6 +43,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="networkAliases">The container network aliases.</param>
     /// <param name="outputConsumer">The output consumer.</param>
     /// <param name="waitStrategies">The wait strategies.</param>
+    /// <param name="parameterModifiers">The modifier callbacks for <see cref="CreateContainerParameters"/>.</param>
     /// <param name="startupCallback">The startup callback.</param>
     /// <param name="autoRemove">A value indicating whether the Testcontainer is removed by the Docker daemon or not.</param>
     /// <param name="privileged">A value indicating whether the Testcontainer has extended privileges or not.</param>
@@ -63,6 +65,7 @@ namespace DotNet.Testcontainers.Configurations
       IEnumerable<string> networkAliases = null,
       IOutputConsumer outputConsumer = null,
       IEnumerable<IWaitUntil> waitStrategies = null,
+      IReadOnlyList<Action<CreateContainerParameters>> parameterModifiers = null,
       Func<ITestcontainersContainer, CancellationToken, Task> startupCallback = null,
       bool? autoRemove = null,
       bool? privileged = null)
@@ -85,6 +88,7 @@ namespace DotNet.Testcontainers.Configurations
       this.NetworkAliases = networkAliases;
       this.OutputConsumer = outputConsumer;
       this.WaitStrategies = waitStrategies;
+      this.ParameterModifiers = parameterModifiers;
       this.StartupCallback = startupCallback;
     }
 
@@ -140,6 +144,9 @@ namespace DotNet.Testcontainers.Configurations
 
     /// <inheritdoc />
     public IEnumerable<IWaitUntil> WaitStrategies { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<Action<CreateContainerParameters>> ParameterModifiers { get; }
 
     /// <inheritdoc />
     public Func<ITestcontainersContainer, CancellationToken, Task> StartupCallback { get; }

--- a/tests/Testcontainers.Tests/Unit/Builders/BuildConfigurationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Builders/BuildConfigurationTest.cs
@@ -1,0 +1,98 @@
+﻿namespace DotNet.Testcontainers.Tests.Unit
+{
+  using System.Collections.Generic;
+  using System.Linq;
+  using DotNet.Testcontainers.Builders;
+  using Xunit;
+
+  public class BuildConfigurationTest
+  {
+    public static IEnumerable<object[]> DictionaryCombinations { get; }
+      = new[]
+      {
+        new[]
+        {
+          null,
+          null,
+          (Dictionary<string, string>)null,
+        },
+        new[]
+        {
+          null,
+          new Dictionary<string, string> { ["A"] = "A" },
+          new Dictionary<string, string> { ["A"] = "A" },
+        },
+        new[]
+        {
+          new Dictionary<string, string> { ["B"] = "B" },
+          null,
+          new Dictionary<string, string> { ["B"] = "B" },
+        },
+        new[]
+        {
+          new Dictionary<string, string> { ["A"] = "new" },
+          new Dictionary<string, string> { ["A"] = "old", ["B"] = "B" },
+          new Dictionary<string, string> { ["A"] = "new", ["B"] = "B" },
+        },
+      };
+
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData("B", null, "B")]
+    [InlineData(null, "A", "A")]
+    [InlineData("B", "A", "B")]
+    public void CombinesReferenceTypes(string next, string previous, string expected)
+    {
+      // Given
+      // When
+      var actual = BuildConfiguration.Combine(next, previous);
+
+      // Then
+      Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData(new[] { "2" }, null, new[] { "2" })]
+    [InlineData(null, new[] { "1" }, new[] { "1" })]
+    [InlineData(new[] { "2" }, new[] { "1" }, new[] { "1", "2" })]
+    [InlineData(new[] { "2", "3", "4" }, new[] { "1", "2", "3" }, new[] { "1", "2", "2", "3", "3", "4" })]
+    public void CombinesEnumerables(IEnumerable<string> next, IEnumerable<string> previous, IEnumerable<string> expected)
+    {
+      // Given
+      // When
+      var actual = BuildConfiguration.Combine(next, previous);
+
+      // Then
+      Assert.Equal(expected?.OrderBy(x => x), actual?.OrderBy(x => x));
+    }
+
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData(new[] { "2" }, null, new[] { "2" })]
+    [InlineData(null, new[] { "1" }, new[] { "1" })]
+    [InlineData(new[] { "2" }, new[] { "1" }, new[] { "1", "2" })]
+    [InlineData(new[] { "2", "3", "4" }, new[] { "1", "2", "3" }, new[] { "1", "2", "3", "2", "3", "4" })]
+    public void CombinesReadOnlyLists(IReadOnlyList<string> next, IReadOnlyList<string> previous, IReadOnlyList<string> expected)
+    {
+      // Given
+      // When
+      var actual = BuildConfiguration.Combine(next, previous);
+
+      // Then
+      Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(DictionaryCombinations))]
+    public void CombinesReadOnlyDictionaries(IReadOnlyDictionary<string, string> next, IReadOnlyDictionary<string, string> previous, IReadOnlyDictionary<string, string> expected)
+    {
+      // Given
+      // When
+      var actual = BuildConfiguration.Combine(next, previous);
+
+      // Then
+      Assert.Equal(expected, actual);
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -466,6 +466,34 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         // Then
         Assert.False(Docker.Exists(DockerResource.Container, testcontainerId));
       }
+
+      [Fact]
+      public async Task ParameterModifiers()
+      {
+        // Given
+        var expectedContainerName = Guid.NewGuid().ToString("D");
+
+        var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+          .WithImage("alpine")
+          .WithEntrypoint(KeepTestcontainersUpAndRunning.Command)
+          .WithCreateContainerParametersModifier(parameters =>
+          {
+            parameters.Name = "placeholder";
+          })
+          .WithCreateContainerParametersModifier(parameters =>
+          {
+            parameters.Name = expectedContainerName;
+          });
+
+        // When
+        await using (ITestcontainersContainer testcontainer = testcontainersBuilder.Build())
+        {
+          await testcontainer.StartAsync();
+
+          // Then
+          Assert.EndsWith(expectedContainerName, testcontainer.Name);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds a new builder method `WithCreateContainerParametersModifier()` which corresponds to [`withCreateContainerCmdModifier()` from the Java implementation](https://www.testcontainers.org/features/advanced_options/#customizing-the-container).

The purpose of this method is to gain access to low-level configuration on the Docker.DotNet client, for instance to configure Ulimits, without having to expose all of these low-level configurations through the testcontainer builder.

Merging this PR closes testcontainers#481.