### PR TITLE
DockerImageOperations.BuildAsync - Throwing meaningful exception if docker image name is not lower case

### DIFF
--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -89,6 +89,11 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<string> BuildAsync(IImageFromDockerfileConfiguration configuration, CancellationToken ct = default)
     {
+      if (configuration.Image.Name.Any(x => char.IsUpper(x)))
+      {
+        throw new ArgumentException("Repository name must be lowercase");
+      }
+
       var image = configuration.Image;
 
       ITarArchive dockerFileArchive = new DockerfileArchive(configuration.DockerfileDirectory, configuration.Dockerfile, image, this.logger);

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -89,11 +89,6 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<string> BuildAsync(IImageFromDockerfileConfiguration configuration, CancellationToken ct = default)
     {
-      if (configuration.Image.Name.Any(x => char.IsUpper(x)))
-      {
-        throw new ArgumentException("Repository name must be lowercase");
-      }
-
       var image = configuration.Image;
 
       ITarArchive dockerFileArchive = new DockerfileArchive(configuration.DockerfileDirectory, configuration.Dockerfile, image, this.logger);

--- a/src/Testcontainers/Guard.String.cs
+++ b/src/Testcontainers/Guard.String.cs
@@ -2,6 +2,7 @@ namespace DotNet.Testcontainers
 {
   using System;
   using System.Diagnostics;
+  using System.Linq;
 
   /// <summary>
   /// String preconditions.
@@ -37,6 +38,23 @@ namespace DotNet.Testcontainers
       if (argument.Value.Length == 0)
       {
         throw new ArgumentException($"{argument.Name} can not be empty.", argument.Name);
+      }
+
+      return ref argument;
+    }
+
+    /// <summary>
+    /// Ensures that an argument value doesn't have upper case characters.
+    /// </summary>
+    /// <param name="argument">String argument to validate.</param>
+    /// <returns>Reference to the Guard object that validates the argument preconditions.</returns>
+    /// <exception cref="ArgumentException">Thrown when argument has upper case characters.</exception>
+    [DebuggerStepThrough]
+    public static ref readonly ArgumentInfo<string> NotUpperCase(in this ArgumentInfo<string> argument)
+    {
+      if (argument.Value.Any(x => char.IsUpper(x)))
+      {
+        throw new ArgumentException(argument.Name, $"{argument.Name} can not have upper case characters.");
       }
 
       return ref argument;

--- a/src/Testcontainers/Images/DockerImage.cs
+++ b/src/Testcontainers/Images/DockerImage.cs
@@ -50,7 +50,8 @@ namespace DotNet.Testcontainers.Images
 
       Guard.Argument(name, nameof(name))
         .NotNull()
-        .NotEmpty();
+        .NotEmpty()
+        .NotUpperCase();
 
       Guard.Argument(tag, nameof(tag))
         .NotNull();

--- a/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
@@ -39,5 +39,19 @@ namespace DotNet.Testcontainers.Tests.Unit
       Assert.Equal(expected.Tag, dockerImage.Tag);
       Assert.Equal(expected.FullName, dockerImage.FullName);
     }
+
+    [Fact]
+    public void ShouldThrowArgumentExceptionIfImageNameHasUpperCaseCharacters()
+    {
+      Assert.Throws<ArgumentException>(() => new DockerImage("Abc"));
+      Assert.Throws<ArgumentException>(() => new DockerImage("Abc:def"));
+    }
+
+    [Fact]
+    public void ShouldNotThrowArgumentExceptionIfTagNameHasUpperCaseCharacters()
+    {
+      var exception = Record.Exception(() => new DockerImage("abc:DEF"));
+      Assert.Null(exception);
+    }
   }
 }


### PR DESCRIPTION
Currently this scenario isn't properly handled which leads to the exception with low level message that doesn't give any clues what went wrong.

![image](https://user-images.githubusercontent.com/16215158/179224345-e65478d9-040f-401d-af34-4bcb5da23878.png)

I wanted to add unit tests to this, but it will require more time than I can afford, The BuildAsync method invokes methods from static classes, so it will be necessary to create additional abstractions to make it mockable.