### PR TITLE
fix(#541) :Allow custom Database-name in MsSqlTestcontainerConfiguration

### DIFF
--- a/src/Testcontainers/Configurations/Modules/Databases/MsSqlTestcontainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Modules/Databases/MsSqlTestcontainerConfiguration.cs
@@ -8,9 +8,11 @@ namespace DotNet.Testcontainers.Configurations
   [PublicAPI]
   public class MsSqlTestcontainerConfiguration : TestcontainerDatabaseConfiguration
   {
+    internal const string DefaultDatabase = "master";
     private const string MsSqlImage = "mcr.microsoft.com/mssql/server:2017-CU28-ubuntu-16.04";
 
     private const int MsSqlPort = 1433;
+    private string database = DefaultDatabase;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MsSqlTestcontainerConfiguration" /> class.
@@ -33,8 +35,8 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     public override string Database
     {
-      get => "master";
-      set => throw new NotImplementedException();
+      get => this.database;
+      set => this.database = value;
     }
 
     /// <inheritdoc />

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/MsSqlFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/MsSqlFixture.cs
@@ -9,7 +9,7 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
   public sealed class MsSqlFixture : DatabaseFixture<MsSqlTestcontainer, DbConnection>
   {
-    private readonly TestcontainerDatabaseConfiguration configuration = new MsSqlTestcontainerConfiguration { Password = "yourStrong(!)Password" }; // https://hub.docker.com/r/microsoft/mssql-server-linux/.
+    private readonly TestcontainerDatabaseConfiguration configuration = new MsSqlTestcontainerConfiguration { Database = "db", Password = "yourStrong(!)Password" }; // https://hub.docker.com/r/microsoft/mssql-server-linux/.
 
     public MsSqlFixture()
     {

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/MsSqlTestcontainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/MsSqlTestcontainerTest.cs
@@ -32,13 +32,6 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [Fact]
-    public void CannotSetDatabase()
-    {
-      var mssql = new MsSqlTestcontainerConfiguration();
-      Assert.Throws<NotImplementedException>(() => mssql.Database = string.Empty);
-    }
-
-    [Fact]
     public void CannotSetUsername()
     {
       var mssql = new MsSqlTestcontainerConfiguration();


### PR DESCRIPTION
#541 Allow custom Database-name in MsSqlTestcontainerConfiguration (creating database using SQL script execution)

I analyzed
1)  https://hub.docker.com/_/microsoft-mssql-server
2) https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-docker-container-configure?view=sql-server-ver16&pivots=cs1-bash
3) https://docs.microsoft.com/en-us/sql/linux/quickstart-install-connect-docker?view=sql-server-ver16&pivots=cs1-bash
and found that Microsoft didn't provide customization using environment variables, so I created pull request with running SQL script if database name is not equal to 'master'. 