### PR TITLE
Feat: No Auth MongoDb

### DIFF
--- a/src/Testcontainers/Containers/Modules/Databases/MongoDbTestcontainer.cs
+++ b/src/Testcontainers/Containers/Modules/Databases/MongoDbTestcontainer.cs
@@ -20,6 +20,10 @@
 
     /// <inheritdoc />
     public override string ConnectionString
-      => $"mongodb://{this.Username}:{this.Password}@{this.Hostname}:{this.Port}";
+      => $"mongodb://{this.ConnectionStringAuthSegment}{this.Hostname}:{this.Port}";
+
+    internal string ConnectionStringAuthSegment => this.Username == null && this.Password == null
+      ? string.Empty
+      : $"{this.Username}:{this.Password}@";
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/NoAuthMongoDbFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/NoAuthMongoDbFixture.cs
@@ -1,0 +1,40 @@
+namespace DotNet.Testcontainers.Tests.Fixtures
+{
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Containers;
+  using MongoDB.Driver;
+
+  public sealed class NoAuthMongoDbFixture : DatabaseFixture<MongoDbTestcontainer, IMongoDatabase>
+  {
+    private readonly TestcontainerDatabaseConfiguration configuration = new MongoDbTestcontainerConfiguration { Username = null, Password = null, Database = "admin" }; // https://hub.docker.com/_/mongo
+
+    public NoAuthMongoDbFixture()
+    {
+      this.Container = new TestcontainersBuilder<MongoDbTestcontainer>()
+        .WithDatabase(this.configuration)
+        .Build();
+    }
+
+    public override async Task InitializeAsync()
+    {
+      await this.Container.StartAsync()
+        .ConfigureAwait(false);
+
+      this.Connection = new MongoClient(this.Container.ConnectionString)
+        .GetDatabase(this.Container.Database);
+    }
+
+    public override async Task DisposeAsync()
+    {
+      await this.Container.DisposeAsync()
+        .ConfigureAwait(false);
+    }
+
+    public override void Dispose()
+    {
+      this.configuration.Dispose();
+    }
+  }
+}


### PR DESCRIPTION
The MongoDb docker container supports a no-auth mode such that you don't need to specify a username or password. While it's simple enough to work around the current behavior in consumer code by using a string replacement, this change will just output a valid connection string from the beginning

Motivation comes from #538 - when running with no-auth in replica set mode, you don't need to specify a security key. Replica set mode is useful because it gives you access to Transactions.

NOTE - I was not able to run the tests locally. I got as far as `dotnet cake --target=Tests`, but I'm getting this exception:

```
Docker.DotNet.DockerImageNotFoundException : Docker API responded with status code=NotFound, response={"message":"No such image: testcontainers/ryuk:0.3.4"}
```