### PR TITLE
feat(#370) Added mTLS support to docker endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- 370 Add protected Docker daemon socket support (@vlaskal)
 - 421 Add Azurite module (@vlaskal)
 - 421 Add Cosmos DB Linux Emulator (@Yeseh, @ktjn)
 - 504 Add Elasticsearch module (@chertby)

--- a/Packages.props
+++ b/Packages.props
@@ -6,8 +6,10 @@
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
     <PackageReference Update="JetBrains.Annotations" Version="2022.1.0" PrivateAssets="all" />
     <PackageReference Update="Docker.DotNet" Version="3.125.12" />
+    <PackageReference Update="Docker.DotNet.X509" Version="3.125.12" />
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="3.1.26" />
+    <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />
     <PackageReference Update="SharpZipLib" Version="1.4.0" />
     <PackageReference Update="System.Text.Json" Version="4.7.2" />
     <!-- Unit and integration test dependencies: -->

--- a/src/Testcontainers/Builders/MTlsEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/MTlsEndpointAuthenticationProvider.cs
@@ -1,0 +1,95 @@
+namespace DotNet.Testcontainers.Builders
+{
+  using System;
+  using System.IO;
+  using System.Linq;
+  using System.Security.Cryptography.X509Certificates;
+  using Docker.DotNet.X509;
+  using DotNet.Testcontainers.Configurations;
+  using Org.BouncyCastle.Crypto;
+  using Org.BouncyCastle.OpenSsl;
+  using Org.BouncyCastle.Pkcs;
+  using Org.BouncyCastle.Security;
+  using Org.BouncyCastle.X509;
+
+  /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
+  internal sealed class MTlsEndpointAuthenticationProvider : TlsEndpointAuthenticationProvider
+  {
+    private static readonly X509CertificateParser CertificateParser = new X509CertificateParser();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MTlsEndpointAuthenticationProvider" /> class.
+    /// </summary>
+    public MTlsEndpointAuthenticationProvider()
+      : this(PropertiesFileConfiguration.Instance, EnvironmentConfiguration.Instance)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MTlsEndpointAuthenticationProvider" /> class.
+    /// </summary>
+    /// <param name="customConfigurations">A list of custom configurations.</param>
+    public MTlsEndpointAuthenticationProvider(params ICustomConfiguration[] customConfigurations)
+      : base(customConfigurations)
+    {
+    }
+
+    /// <inheritdoc />
+    public override bool IsApplicable()
+    {
+      var certificatesFiles = new[] { ClientCertificateFileName, ClientCertificateKeyFileName };
+      return this.TlsEnabled && this.TlsVerifyEnabled && certificatesFiles.Select(fileName => Path.Combine(this.CertificatesDirectoryPath, fileName)).All(File.Exists);
+    }
+
+    /// <inheritdoc />
+    public override IDockerEndpointAuthenticationConfiguration GetAuthConfig()
+    {
+      var credentials = new CertificateCredentials(this.GetClientCertificate());
+      credentials.ServerCertificateValidationCallback = this.ServerCertificateValidationCallback;
+      return new DockerEndpointAuthenticationConfiguration(this.DockerEngine, credentials);
+    }
+
+    /// <inheritdoc />
+    protected override X509Certificate2 GetClientCertificate()
+    {
+      var clientCertificateFilePath = Path.Combine(this.CertificatesDirectoryPath, ClientCertificateFileName);
+      var clientCertificateKeyFilePath = Path.Combine(this.CertificatesDirectoryPath, ClientCertificateKeyFileName);
+      return CreateFromPemFile(clientCertificateFilePath, clientCertificateKeyFilePath);
+    }
+
+    private static X509Certificate2 CreateFromPemFile(string certPemFilePath, string keyPemFilePath)
+    {
+      if (!File.Exists(certPemFilePath))
+      {
+        throw new FileNotFoundException(certPemFilePath);
+      }
+
+      if (!File.Exists(keyPemFilePath))
+      {
+        throw new FileNotFoundException(keyPemFilePath);
+      }
+
+      using (var keyPairStream = new StreamReader(keyPemFilePath))
+      {
+        var store = new Pkcs12StoreBuilder().Build();
+
+        var certificate = CertificateParser.ReadCertificate(File.ReadAllBytes(certPemFilePath));
+
+        var password = Guid.NewGuid().ToString("D");
+
+        var keyPair = (AsymmetricCipherKeyPair)new PemReader(keyPairStream).ReadObject();
+
+        var certificateEntry = new X509CertificateEntry(certificate);
+
+        var keyEntry = new AsymmetricKeyEntry(keyPair.Private);
+        store.SetKeyEntry(certificate.SubjectDN + "_key", keyEntry, new[] { certificateEntry });
+
+        using (var certificateStream = new MemoryStream())
+        {
+          store.Save(certificateStream, password.ToCharArray(), new SecureRandom());
+          return new X509Certificate2(Pkcs12Utilities.ConvertToDefiniteLength(certificateStream.ToArray()), password);
+        }
+      }
+    }
+  }
+}

--- a/src/Testcontainers/Builders/TlsEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/TlsEndpointAuthenticationProvider.cs
@@ -1,0 +1,115 @@
+namespace DotNet.Testcontainers.Builders
+{
+  using System;
+  using System.IO;
+  using System.Linq;
+  using System.Net;
+  using System.Net.Security;
+  using System.Security.Cryptography.X509Certificates;
+  using DotNet.Testcontainers.Configurations;
+
+  /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
+  internal class TlsEndpointAuthenticationProvider : DockerEndpointAuthenticationProvider
+  {
+    protected const string CaCertificateFileName = "ca.pem";
+
+    protected const string ClientCertificateFileName = "cert.pem";
+
+    protected const string ClientCertificateKeyFileName = "key.pem";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TlsEndpointAuthenticationProvider" /> class.
+    /// </summary>
+    public TlsEndpointAuthenticationProvider()
+      : this(PropertiesFileConfiguration.Instance, EnvironmentConfiguration.Instance)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TlsEndpointAuthenticationProvider" /> class.
+    /// </summary>
+    /// <param name="customConfigurations">A list of custom configurations.</param>
+    public TlsEndpointAuthenticationProvider(params ICustomConfiguration[] customConfigurations)
+      : this(customConfigurations
+        .OrderByDescending(item => item.GetDockerTlsVerify())
+        .ThenByDescending(item => item.GetDockerTls())
+        .DefaultIfEmpty(new PropertiesFileConfiguration(Array.Empty<string>()))
+        .First())
+    {
+    }
+
+    private TlsEndpointAuthenticationProvider(ICustomConfiguration customConfiguration)
+    {
+      this.TlsEnabled = customConfiguration.GetDockerTls() || customConfiguration.GetDockerTlsVerify();
+      this.TlsVerifyEnabled = customConfiguration.GetDockerTlsVerify();
+      this.CertificatesDirectoryPath = customConfiguration.GetDockerCertPath() ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".docker");
+      this.DockerEngine = customConfiguration.GetDockerHost() ?? new Uri("tcp://localhost:2376");
+    }
+
+    protected bool TlsEnabled { get; }
+
+    protected bool TlsVerifyEnabled { get; }
+
+    protected string CertificatesDirectoryPath { get; }
+
+    protected Uri DockerEngine { get; }
+
+    /// <inheritdoc />
+    public override bool IsApplicable()
+    {
+      return this.TlsEnabled;
+    }
+
+    /// <inheritdoc />
+    public override IDockerEndpointAuthenticationConfiguration GetAuthConfig()
+    {
+      var credentials = new TlsCredentials();
+      credentials.ServerCertificateValidationCallback = this.ServerCertificateValidationCallback;
+      return new DockerEndpointAuthenticationConfiguration(this.DockerEngine, credentials);
+    }
+
+    /// <summary>
+    /// Gets the root certificate authority (CA).
+    /// </summary>
+    /// <returns>The root certificate authority (CA).</returns>
+    protected virtual X509Certificate2 GetCaCertificate()
+    {
+      return new X509Certificate2(Path.Combine(this.CertificatesDirectoryPath, CaCertificateFileName));
+    }
+
+    /// <summary>
+    /// Gets the client certificate.
+    /// </summary>
+    /// <returns>The client certificate.</returns>
+    protected virtual X509Certificate2 GetClientCertificate()
+    {
+      return null;
+    }
+
+    /// <inheritdoc cref="ServicePointManager.ServerCertificateValidationCallback" />
+    protected virtual bool ServerCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+    {
+      switch (sslPolicyErrors)
+      {
+        case SslPolicyErrors.None:
+          return true;
+        case SslPolicyErrors.RemoteCertificateNameMismatch:
+        case SslPolicyErrors.RemoteCertificateNotAvailable:
+          return false;
+        case SslPolicyErrors.RemoteCertificateChainErrors:
+        default:
+          using (var caCertificate = this.GetCaCertificate())
+          {
+            var validationChain = new X509Chain();
+            validationChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+            validationChain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
+            validationChain.ChainPolicy.ExtraStore.Add(caCertificate);
+            validationChain.ChainPolicy.ExtraStore.AddRange(chain.ChainElements.OfType<X509ChainElement>().Select(element => element.Certificate).ToArray());
+            var isVerified = validationChain.Build(new X509Certificate2(certificate));
+            var isSignedByExpectedRoot = validationChain.ChainElements[validationChain.ChainElements.Count - 1].Certificate.RawData.SequenceEqual(caCertificate.RawData);
+            return isVerified && isSignedByExpectedRoot;
+          }
+      }
+    }
+  }
+}

--- a/src/Testcontainers/Clients/DockerSystemOperations.cs
+++ b/src/Testcontainers/Clients/DockerSystemOperations.cs
@@ -3,6 +3,7 @@ namespace DotNet.Testcontainers.Clients
   using System;
   using System.Threading;
   using System.Threading.Tasks;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using Microsoft.Extensions.Logging;
 
@@ -18,6 +19,11 @@ namespace DotNet.Testcontainers.Clients
     {
       return (await this.Docker.System.GetSystemInfoAsync(ct)
         .ConfigureAwait(false)).OperatingSystem.Contains("Windows");
+    }
+
+    public Task<VersionResponse> GetVersion(CancellationToken ct = default)
+    {
+      return this.Docker.System.GetVersionAsync(ct);
     }
   }
 }

--- a/src/Testcontainers/Clients/IDockerSystemOperations.cs
+++ b/src/Testcontainers/Clients/IDockerSystemOperations.cs
@@ -2,9 +2,12 @@ namespace DotNet.Testcontainers.Clients
 {
   using System.Threading;
   using System.Threading.Tasks;
+  using Docker.DotNet.Models;
 
   internal interface IDockerSystemOperations
   {
     Task<bool> GetIsWindowsEngineEnabled(CancellationToken ct = default);
+
+    Task<VersionResponse> GetVersion(CancellationToken ct = default);
   }
 }

--- a/src/Testcontainers/Configurations/DockerEndpointAuthenticationConfiguration.cs
+++ b/src/Testcontainers/Configurations/DockerEndpointAuthenticationConfiguration.cs
@@ -12,10 +12,15 @@
     /// Initializes a new instance of the <see cref="DockerEndpointAuthenticationConfiguration" /> struct.
     /// </summary>
     /// <param name="endpoint">The Docker API endpoint.</param>
-    public DockerEndpointAuthenticationConfiguration(Uri endpoint)
+    /// <param name="credentials">The Docker API authentication credentials.</param>
+    public DockerEndpointAuthenticationConfiguration(Uri endpoint, Credentials credentials = null)
     {
+      this.Credentials = credentials;
       this.Endpoint = endpoint;
     }
+
+    /// <inheritdoc />
+    public Credentials Credentials { get; }
 
     /// <inheritdoc />
     public Uri Endpoint { get; }
@@ -24,7 +29,7 @@
     public DockerClientConfiguration GetDockerClientConfiguration(Guid sessionId = default)
     {
       var defaultHttpRequestHeaders = new ReadOnlyDictionary<string, string>(new Dictionary<string, string> { { "x-tc-sid", sessionId.ToString("D") } });
-      return new DockerClientConfiguration(this.Endpoint, defaultHttpRequestHeaders: defaultHttpRequestHeaders);
+      return new DockerClientConfiguration(this.Endpoint, this.Credentials, defaultHttpRequestHeaders: defaultHttpRequestHeaders);
     }
   }
 }

--- a/src/Testcontainers/Configurations/IDockerEndpointAuthenticationConfiguration.cs
+++ b/src/Testcontainers/Configurations/IDockerEndpointAuthenticationConfiguration.cs
@@ -16,6 +16,12 @@
     Uri Endpoint { get; }
 
     /// <summary>
+    /// Gets the Docker API credentials.
+    /// </summary>
+    [CanBeNull]
+    Credentials Credentials { get; }
+
+    /// <summary>
     /// Gets the Docker client configuration.
     /// </summary>
     /// <param name="sessionId">The session id.</param>

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -21,7 +21,14 @@ namespace DotNet.Testcontainers.Configurations
     private static readonly IDockerImage RyukContainerImage = new DockerImage("testcontainers/ryuk:0.3.4");
 
     private static readonly IDockerEndpointAuthenticationConfiguration DockerEndpointAuthConfig =
-      new IDockerEndpointAuthenticationProvider[] { new EnvironmentEndpointAuthenticationProvider(), new NpipeEndpointAuthenticationProvider(), new UnixEndpointAuthenticationProvider() }
+      new IDockerEndpointAuthenticationProvider[]
+        {
+          new MTlsEndpointAuthenticationProvider(),
+          new TlsEndpointAuthenticationProvider(),
+          new EnvironmentEndpointAuthenticationProvider(),
+          new NpipeEndpointAuthenticationProvider(),
+          new UnixEndpointAuthenticationProvider(),
+        }
         .AsParallel()
         .Where(authProvider => authProvider.IsApplicable())
         .Where(authProvider => authProvider.IsAvailable())

--- a/src/Testcontainers/Configurations/TlsCredentials.cs
+++ b/src/Testcontainers/Configurations/TlsCredentials.cs
@@ -1,0 +1,27 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System.Net;
+  using System.Net.Http;
+  using Docker.DotNet.X509;
+  using Microsoft.Net.Http.Client;
+
+  internal sealed class TlsCredentials : CertificateCredentials
+  {
+    public TlsCredentials()
+      : base(null)
+    {
+    }
+
+    public override bool IsTlsCredentials()
+    {
+      return true;
+    }
+
+    public override HttpMessageHandler GetHandler(HttpMessageHandler innerHandler)
+    {
+      var handler = (ManagedHandler)innerHandler;
+      handler.ServerCertificateValidationCallback = this.ServerCertificateValidationCallback ?? ServicePointManager.ServerCertificateValidationCallback;
+      return handler;
+    }
+  }
+}

--- a/src/Testcontainers/Testcontainers.csproj
+++ b/src/Testcontainers/Testcontainers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
@@ -9,8 +9,10 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="Docker.DotNet" />
+    <PackageReference Include="Docker.DotNet.X509" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Portable.BouncyCastle" />
     <PackageReference Include="SharpZipLib" />
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerMTlsFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerMTlsFixture.cs
@@ -1,0 +1,27 @@
+﻿namespace DotNet.Testcontainers.Tests.Fixtures
+{
+  using System.Collections.Generic;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Containers;
+  using JetBrains.Annotations;
+
+  [UsedImplicitly]
+  public sealed class DockerMTlsFixture : ProtectDockerDaemonSocket
+  {
+    public DockerMTlsFixture()
+      : base(new TestcontainersBuilder<TestcontainersContainer>())
+    {
+    }
+
+    public override IList<string> CustomProperties
+    {
+      get
+      {
+        var customProperties = base.CustomProperties;
+        customProperties.Add("docker.tls=false");
+        customProperties.Add("docker.tls.verify=true");
+        return customProperties;
+      }
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerTlsFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerTlsFixture.cs
@@ -1,0 +1,28 @@
+﻿namespace DotNet.Testcontainers.Tests.Fixtures
+{
+  using System.Collections.Generic;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Containers;
+  using JetBrains.Annotations;
+
+  [UsedImplicitly]
+  public sealed class DockerTlsFixture : ProtectDockerDaemonSocket
+  {
+    public DockerTlsFixture()
+      : base(new TestcontainersBuilder<TestcontainersContainer>()
+        .WithCommand("--tlsverify=false"))
+    {
+    }
+
+    public override IList<string> CustomProperties
+    {
+      get
+      {
+        var customProperties = base.CustomProperties;
+        customProperties.Add("docker.tls=true");
+        customProperties.Add("docker.tls.verify=false");
+        return customProperties;
+      }
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/AzuriteFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/AzuriteFixture.cs
@@ -11,9 +11,6 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
   public static class AzuriteFixture
   {
-    // We cannot use `Path.GetTempPath()` on macOS, see: https://github.com/common-workflow-language/cwltool/issues/328.
-    private static readonly string TempDir = Environment.GetEnvironmentVariable("AGENT_TEMPDIRECTORY") ?? Directory.GetCurrentDirectory();
-
     [UsedImplicitly]
     public class AzuriteDefaultFixture : IAsyncLifetime
     {
@@ -92,7 +89,7 @@ namespace DotNet.Testcontainers.Tests.Fixtures
       public AzuriteWithCustomWorkspaceFixture()
         : base(new AzuriteTestcontainerConfiguration
         {
-          Location = Path.Combine(TempDir, Guid.NewGuid().ToString("N")),
+          Location = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("D")),
         })
       {
         if (this.Configuration.Location != null)

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
@@ -1,0 +1,71 @@
+﻿namespace DotNet.Testcontainers.Tests.Fixtures
+{
+  using System;
+  using System.Collections.Generic;
+  using System.IO;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Containers;
+  using DotNet.Testcontainers.Images;
+  using Xunit;
+
+  public abstract class ProtectDockerDaemonSocket : IAsyncLifetime
+  {
+    public const string DockerVersion = "20.10.18";
+
+    private const string CertsDirectoryName = "certs";
+
+    private const ushort TlsPort = 2376;
+
+    private readonly string hostCertsDirectoryPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("D"), CertsDirectoryName);
+
+    private readonly string containerCertsDirectoryPath = Path.Combine("/", CertsDirectoryName);
+
+    private readonly IDockerImage image = new DockerImage(string.Empty, "docker", DockerVersion + "-dind");
+
+    private readonly ITestcontainersContainer container;
+
+    protected ProtectDockerDaemonSocket(ITestcontainersBuilder<TestcontainersContainer> containerConfiguration)
+    {
+      this.container = containerConfiguration
+        .WithImage(this.image)
+        .WithPrivileged(true)
+        .WithExposedPort(TlsPort)
+        .WithPortBinding(TlsPort, true)
+        .WithBindMount(this.hostCertsDirectoryPath, this.containerCertsDirectoryPath, AccessMode.ReadWrite)
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(TlsPort))
+        .Build();
+    }
+
+    public virtual IList<string> CustomProperties
+    {
+      get
+      {
+        var customProperties = new List<string>();
+        customProperties.Add($"docker.host={this.TcpEndpoint}");
+        customProperties.Add($"docker.cert.path={Path.Combine(this.hostCertsDirectoryPath, "client")}");
+        return customProperties;
+      }
+    }
+
+    private Uri TcpEndpoint
+    {
+      get
+      {
+        return new UriBuilder("tcp", this.container.Hostname, this.container.GetMappedPublicPort(TlsPort)).Uri;
+      }
+    }
+
+    public Task InitializeAsync()
+    {
+      _ = Directory.CreateDirectory(this.hostCertsDirectoryPath);
+      return this.container.StartAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+      return this.container.DisposeAsync().AsTask();
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
@@ -2,6 +2,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 {
   using System;
   using System.Collections.Generic;
+  using System.IO;
   using System.Runtime.InteropServices;
   using DotNet.Testcontainers.Builders;
   using DotNet.Testcontainers.Configurations;
@@ -10,6 +11,22 @@ namespace DotNet.Testcontainers.Tests.Unit
   public sealed class DockerEndpointAuthenticationProviderTest
   {
     private const string DockerHost = "tcp://127.0.0.1:2375";
+
+    private const string DockerTlsHost = "tcp://127.0.0.1:2376";
+
+    private static readonly string CertificatesDirectoryPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("D"));
+
+    private static readonly ICustomConfiguration DockerHostConfiguration = new PropertiesFileConfiguration(new[] { "docker.host=" + DockerHost });
+
+    private static readonly ICustomConfiguration DockerTlsHostConfiguration = new PropertiesFileConfiguration(new[] { "docker.host=" + DockerTlsHost });
+
+    static DockerEndpointAuthenticationProviderTest()
+    {
+      _ = Directory.CreateDirectory(CertificatesDirectoryPath);
+      _ = File.Create(Path.Combine(CertificatesDirectoryPath, "ca.pem"));
+      _ = File.Create(Path.Combine(CertificatesDirectoryPath, "cert.pem"));
+      _ = File.Create(Path.Combine(CertificatesDirectoryPath, "key.pem"));
+    }
 
     [Theory]
     [ClassData(typeof(AuthProviderTestData))]
@@ -35,11 +52,20 @@ namespace DotNet.Testcontainers.Tests.Unit
       {
         var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         var defaultConfiguration = new PropertiesFileConfiguration(Array.Empty<string>());
-        var dockerHostConfiguration = new PropertiesFileConfiguration(new[] { "docker.host=" + DockerHost });
+        var dockerTlsConfiguration = new PropertiesFileConfiguration("docker.tls=true", $"docker.cert.path={CertificatesDirectoryPath}");
+        var dockerMTlsConfiguration = new PropertiesFileConfiguration("docker.tls.verify=true", $"docker.cert.path={CertificatesDirectoryPath}");
+        this.Add(new object[] { new MTlsEndpointAuthenticationProvider(defaultConfiguration), false });
+        this.Add(new object[] { new MTlsEndpointAuthenticationProvider(dockerMTlsConfiguration), true });
+        this.Add(new object[] { new MTlsEndpointAuthenticationProvider(Array.Empty<ICustomConfiguration>()), false });
+        this.Add(new object[] { new MTlsEndpointAuthenticationProvider(defaultConfiguration, dockerMTlsConfiguration), true });
+        this.Add(new object[] { new TlsEndpointAuthenticationProvider(defaultConfiguration), false });
+        this.Add(new object[] { new TlsEndpointAuthenticationProvider(dockerTlsConfiguration), true });
+        this.Add(new object[] { new TlsEndpointAuthenticationProvider(Array.Empty<ICustomConfiguration>()), false });
+        this.Add(new object[] { new TlsEndpointAuthenticationProvider(defaultConfiguration, dockerTlsConfiguration), true });
         this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(defaultConfiguration), false });
-        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(dockerHostConfiguration), true });
+        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(DockerHostConfiguration), true });
         this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(Array.Empty<ICustomConfiguration>()), false });
-        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(defaultConfiguration, dockerHostConfiguration), true });
+        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(defaultConfiguration, DockerHostConfiguration), true });
         this.Add(new object[] { new NpipeEndpointAuthenticationProvider(), isWindows });
         this.Add(new object[] { new UnixEndpointAuthenticationProvider(), !isWindows });
       }
@@ -49,8 +75,8 @@ namespace DotNet.Testcontainers.Tests.Unit
     {
       public AuthConfigTestData()
       {
-        var dockerHostConfiguration = new PropertiesFileConfiguration(new[] { "docker.host=" + DockerHost });
-        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(dockerHostConfiguration).GetAuthConfig(), new Uri(DockerHost) });
+        this.Add(new object[] { new TlsEndpointAuthenticationProvider(DockerTlsHostConfiguration).GetAuthConfig(), new Uri(DockerTlsHost) });
+        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(DockerHostConfiguration).GetAuthConfig(), new Uri(DockerHost) });
         this.Add(new object[] { new NpipeEndpointAuthenticationProvider().GetAuthConfig(), new Uri("npipe://./pipe/docker_engine") });
         this.Add(new object[] { new UnixEndpointAuthenticationProvider().GetAuthConfig(), new Uri("unix:/var/run/docker.sock") });
       }

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/ProtectDockerDaemonSocketTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/ProtectDockerDaemonSocketTest.cs
@@ -1,0 +1,69 @@
+namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
+{
+  using System;
+  using System.Linq;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Clients;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Tests.Fixtures;
+  using Microsoft.Extensions.Logging.Abstractions;
+  using Xunit;
+
+  public static class ProtectDockerDaemonSocketTest
+  {
+    private static IDockerEndpointAuthenticationConfiguration GetAuthConfig(ProtectDockerDaemonSocket protectDockerDaemonSocket)
+    {
+      var customConfiguration = new PropertiesFileConfiguration(protectDockerDaemonSocket.CustomProperties.ToArray());
+      return new IDockerEndpointAuthenticationProvider[] { new MTlsEndpointAuthenticationProvider(customConfiguration), new TlsEndpointAuthenticationProvider(customConfiguration) }.First(authProvider => authProvider.IsApplicable()).GetAuthConfig();
+    }
+
+    public sealed class MTls : IClassFixture<DockerMTlsFixture>
+    {
+      private readonly IDockerEndpointAuthenticationConfiguration authConfig;
+
+      public MTls(DockerMTlsFixture dockerMTlsFixture)
+      {
+        this.authConfig = GetAuthConfig(dockerMTlsFixture);
+      }
+
+      [Fact]
+      public async Task GetVersionReturnsVersion()
+      {
+        // Given
+        IDockerSystemOperations dockerSystemOperations = new DockerSystemOperations(Guid.Empty, this.authConfig, NullLogger.Instance);
+
+        // When
+        var version = await dockerSystemOperations.GetVersion()
+          .ConfigureAwait(false);
+
+        // Then
+        Assert.Equal(ProtectDockerDaemonSocket.DockerVersion, version.Version);
+      }
+    }
+
+    public sealed class Tls : IClassFixture<DockerTlsFixture>
+    {
+      private readonly IDockerEndpointAuthenticationConfiguration authConfig;
+
+      public Tls(DockerTlsFixture dockerTlsFixture)
+      {
+        this.authConfig = GetAuthConfig(dockerTlsFixture);
+      }
+
+      [Fact]
+      public async Task GetVersionReturnsVersion()
+      {
+        // Given
+        IDockerSystemOperations dockerSystemOperations = new DockerSystemOperations(Guid.Empty, this.authConfig, NullLogger.Instance);
+
+        // When
+        var version = await dockerSystemOperations.GetVersion()
+          .ConfigureAwait(false);
+
+        // Then
+        Assert.Equal(ProtectDockerDaemonSocket.DockerVersion, version.Version);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR add two options for docker endpoint authentication.
1. it is support of simple secured endpoint by TLS
2. it is support of client authentication via mTLS

PR contains 2 commits on for each option.

This PR is draft only to review approach of implementation.