### PR TITLE
chore: Upgrade .NET to Latest: 6.0.400 #559

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.300",
+    "version": "6.0.400",
     "rollForward": "latestPatch"
   }
 }


### PR DESCRIPTION
**Upgrade .NET to 6.0.400**
The current version is locked to an outdated version of .NET that is no longer secured.
There have been many security patches since then.

**To Reproduce**
Steps to reproduce the behavior:
1. run `dotnet cake --target=Build`
```
$ dotnet cake --target=Build
The command could not be loaded, possibly because:
  * You intended to execute a .NET application:
      The application 'cake' does not exist.
  * You intended to execute a .NET SDK command:
      A compatible .NET SDK was not found.

Requested SDK version: 6.0.300
global.json file: C:\resources\testcontainers-dotnet\global.json

Installed SDKs:
6.0.201 [C:\Program Files\dotnet\sdk]
6.0.400 [C:\Program Files\dotnet\sdk]
```
