### PR TITLE
Fix: Configuration providers provide current values

### DIFF
--- a/src/Testcontainers/Builders/EnvironmentEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/EnvironmentEndpointAuthenticationProvider.cs
@@ -1,6 +1,7 @@
-﻿namespace DotNet.Testcontainers.Builders
+namespace DotNet.Testcontainers.Builders
 {
   using System;
+  using System.Linq;
   using DotNet.Testcontainers.Configurations;
 
   /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
@@ -12,8 +13,19 @@
     /// Initializes a new instance of the <see cref="EnvironmentEndpointAuthenticationProvider" /> class.
     /// </summary>
     public EnvironmentEndpointAuthenticationProvider()
+      : this(PropertiesFileConfiguration.Instance, EnvironmentConfiguration.Instance)
     {
-      this.dockerEngine = PropertiesFileConfiguration.Instance.GetDockerHost() ?? EnvironmentConfiguration.Instance.GetDockerHost();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EnvironmentEndpointAuthenticationProvider" /> class.
+    /// </summary>
+    /// <param name="customConfigurations">A list of custom configurations.</param>
+    public EnvironmentEndpointAuthenticationProvider(params ICustomConfiguration[] customConfigurations)
+    {
+      this.dockerEngine = customConfigurations?
+        .Select(customConfiguration => customConfiguration.GetDockerHost())
+        .FirstOrDefault(dockerHost => dockerHost != null);
     }
 
     /// <inheritdoc />

--- a/tests/Testcontainers.Tests/Unit/Builders/EnvironmentEndpointAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Builders/EnvironmentEndpointAuthenticationProviderTest.cs
@@ -1,0 +1,34 @@
+namespace DotNet.Testcontainers.Tests.Unit
+{
+  using System;
+  using System.Collections.Generic;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Configurations;
+  using Xunit;
+
+  public sealed class EnvironmentEndpointAuthenticationProviderTest
+  {
+    [Theory]
+    [ClassData(typeof(AuthConfigTestData))]
+    internal void IsApplicable(EnvironmentEndpointAuthenticationProvider provider, bool expectedIsApplicable)
+    {
+      var actualIsApplicable = provider.IsApplicable();
+      Assert.Equal(expectedIsApplicable, actualIsApplicable);
+    }
+
+    private sealed class AuthConfigTestData : List<object[]>
+    {
+      public AuthConfigTestData()
+      {
+        const string dockerHost = "tcp://127.0.0.1:2375";
+        var dockerHostConfigurationWithValue = new PropertiesFileConfiguration(new[] { "docker.host=" + dockerHost });
+        var dockerHostConfigurationWithoutValue = new PropertiesFileConfiguration(Array.Empty<string>());
+        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(null), false });
+        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(Array.Empty<ICustomConfiguration>()), false });
+        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(dockerHostConfigurationWithValue), true });
+        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(dockerHostConfigurationWithoutValue), false });
+        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(dockerHostConfigurationWithoutValue, dockerHostConfigurationWithValue), true });
+      }
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Tests.Unit
+namespace DotNet.Testcontainers.Tests.Unit
 {
   using System;
   using System.Collections.Generic;
@@ -26,11 +26,10 @@
       public AuthConfigTestData()
       {
         const string dockerHost = "tcp://127.0.0.1:2375";
-        Environment.SetEnvironmentVariable("DOCKER_HOST", dockerHost);
-        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider().GetAuthConfig(), new Uri(dockerHost) });
+        var dockerHostConfiguration = new PropertiesFileConfiguration(new[] { "docker.host=" + dockerHost });
+        this.Add(new object[] { new EnvironmentEndpointAuthenticationProvider(dockerHostConfiguration).GetAuthConfig(), new Uri(dockerHost) });
         this.Add(new object[] { new NpipeEndpointAuthenticationProvider().GetAuthConfig(), new Uri("npipe://./pipe/docker_engine") });
         this.Add(new object[] { new UnixEndpointAuthenticationProvider().GetAuthConfig(), new Uri("unix:/var/run/docker.sock") });
-        Environment.SetEnvironmentVariable("DOCKER_HOST", null);
       }
     }
   }


### PR DESCRIPTION
Configuration providers provide current value from environment variables or setting file.
This is suggestion how to fix issue #576 to make test runnable nd independent on the order.