### PR TITLE
feat(#370): Added support docker TLS endpoint

### DIFF
--- a/src/Testcontainers/Builders/TlsEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/TlsEndpointAuthenticationProvider.cs
@@ -1,0 +1,86 @@
+namespace DotNet.Testcontainers.Builders
+{
+  using System;
+  using System.IO;
+  using System.Linq;
+  using System.Net.Security;
+  using System.Security.Cryptography.X509Certificates;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Configurations.Credentials;
+
+  /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
+  internal sealed class TlsEndpointAuthenticationProvider : DockerEndpointAuthenticationProvider
+  {
+    private const string DefaultUserDockerFolderName = ".docker";
+    private const string DefaultCaCertFileName = "ca.pem";
+    private static readonly Uri DefaultTlsDockerEndpoint = new Uri("tcp://localhost:2376");
+    private static readonly string DefaultCertPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), DefaultUserDockerFolderName);
+
+    private readonly Lazy<X509Certificate2> caCertificate;
+    private readonly Uri dockerEngine;
+    private readonly bool dockerTlsEnabled;
+
+    /// <summary>
+    ///   Initializes a new instance of the <see cref="TlsEndpointAuthenticationProvider" /> class.
+    /// </summary>
+    public TlsEndpointAuthenticationProvider()
+      : this(PropertiesFileConfiguration.Instance, EnvironmentConfiguration.Instance)
+    {
+    }
+
+    /// <summary>
+    ///   Initializes a new instance of the <see cref="TlsEndpointAuthenticationProvider" /> class.
+    /// </summary>
+    /// <param name="customConfigurations">A list of custom configurations.</param>
+    public TlsEndpointAuthenticationProvider(params ICustomConfiguration[] customConfigurations)
+    {
+      var dockerCertPath = customConfigurations
+        .Select(customConfiguration => customConfiguration.GetDockerCertPath())
+        .FirstOrDefault(value => value != null) ?? DefaultCertPath;
+      var dockerCaCertFile = Path.Combine(dockerCertPath, DefaultCaCertFileName);
+
+      this.dockerEngine = customConfigurations
+        .Select(customConfiguration => customConfiguration.GetDockerHost())
+        .FirstOrDefault(value => value != null) ?? DefaultTlsDockerEndpoint;
+      this.dockerTlsEnabled = customConfigurations
+        .Select(customConfiguration => customConfiguration.GetDockerTls())
+        .Aggregate(false, (x, y) => x || y);
+      this.caCertificate = new Lazy<X509Certificate2>(() => new X509Certificate2(dockerCaCertFile));
+    }
+
+    /// <inheritdoc />
+    public override bool IsApplicable()
+    {
+      return this.dockerTlsEnabled;
+    }
+
+    /// <inheritdoc />
+    public override IDockerEndpointAuthenticationConfiguration GetAuthConfig()
+    {
+      return new DockerEndpointAuthenticationConfiguration(this.dockerEngine, new TlsCredentials(this.ServerCertificateValidationCallback));
+    }
+
+    private bool ServerCertificateValidationCallback(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+    {
+      switch (sslPolicyErrors)
+      {
+        case SslPolicyErrors.None:
+          return true;
+        case SslPolicyErrors.RemoteCertificateNotAvailable:
+        case SslPolicyErrors.RemoteCertificateNameMismatch:
+          return false;
+        case SslPolicyErrors.RemoteCertificateChainErrors:
+        default:
+          var validationChain = new X509Chain();
+          validationChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+          validationChain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
+          validationChain.ChainPolicy.ExtraStore.Add(this.caCertificate.Value);
+          validationChain.ChainPolicy.ExtraStore.AddRange(chain.ChainElements.OfType<X509ChainElement>().Select(element => element.Certificate).ToArray());
+          var isVerified = validationChain.Build(certificate as X509Certificate2 ?? new X509Certificate2(certificate));
+          var isSignedByExpectedRoot = validationChain.ChainElements[validationChain.ChainElements.Count - 1].Certificate.RawData.SequenceEqual(this.caCertificate.Value.RawData);
+          var isSuccess = isVerified && isSignedByExpectedRoot;
+          return isSuccess;
+      }
+    }
+  }
+}

--- a/src/Testcontainers/Configurations/Credentials/TlsCredentials.cs
+++ b/src/Testcontainers/Configurations/Credentials/TlsCredentials.cs
@@ -1,0 +1,31 @@
+namespace DotNet.Testcontainers.Configurations.Credentials
+{
+  using System.Net;
+  using System.Net.Http;
+  using System.Net.Security;
+  using Docker.DotNet;
+  using JetBrains.Annotations;
+  using Microsoft.Net.Http.Client;
+
+  public class TlsCredentials : Credentials
+  {
+    public TlsCredentials([CanBeNull] RemoteCertificateValidationCallback serverCertificateValidationCallback)
+    {
+      this.ServerCertificateValidationCallback = serverCertificateValidationCallback;
+    }
+
+    public RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
+
+    public override bool IsTlsCredentials()
+    {
+      return true;
+    }
+
+    public override HttpMessageHandler GetHandler(HttpMessageHandler innerHandler)
+    {
+      var handler = (ManagedHandler)innerHandler;
+      handler.ServerCertificateValidationCallback = this.ServerCertificateValidationCallback ?? ServicePointManager.ServerCertificateValidationCallback;
+      return handler;
+    }
+  }
+}

--- a/src/Testcontainers/Configurations/DockerEndpointAuthenticationConfiguration.cs
+++ b/src/Testcontainers/Configurations/DockerEndpointAuthenticationConfiguration.cs
@@ -12,10 +12,15 @@
     /// Initializes a new instance of the <see cref="DockerEndpointAuthenticationConfiguration" /> struct.
     /// </summary>
     /// <param name="endpoint">The Docker API endpoint.</param>
-    public DockerEndpointAuthenticationConfiguration(Uri endpoint)
+    /// <param name="credentials">The Docker API authentication credentials.</param>
+    public DockerEndpointAuthenticationConfiguration(Uri endpoint, Docker.DotNet.Credentials credentials = null)
     {
+      this.Credentials = credentials;
       this.Endpoint = endpoint;
     }
+
+    /// <inheritdoc />
+    public Docker.DotNet.Credentials Credentials { get; }
 
     /// <inheritdoc />
     public Uri Endpoint { get; }
@@ -24,7 +29,7 @@
     public DockerClientConfiguration GetDockerClientConfiguration(Guid sessionId = default)
     {
       var defaultHttpRequestHeaders = new ReadOnlyDictionary<string, string>(new Dictionary<string, string> { { "x-tc-sid", sessionId.ToString("D") } });
-      return new DockerClientConfiguration(this.Endpoint, defaultHttpRequestHeaders: defaultHttpRequestHeaders);
+      return new DockerClientConfiguration(this.Endpoint, this.Credentials, defaultHttpRequestHeaders: defaultHttpRequestHeaders);
     }
   }
 }

--- a/src/Testcontainers/Configurations/IDockerEndpointAuthenticationConfiguration.cs
+++ b/src/Testcontainers/Configurations/IDockerEndpointAuthenticationConfiguration.cs
@@ -16,6 +16,12 @@
     Uri Endpoint { get; }
 
     /// <summary>
+    /// Gets the Docker API authentication credentials.
+    /// </summary>
+    [CanBeNull]
+    Docker.DotNet.Credentials Credentials { get; }
+
+    /// <summary>
     /// Gets the Docker client configuration.
     /// </summary>
     /// <param name="sessionId">The session id.</param>

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -21,7 +21,13 @@ namespace DotNet.Testcontainers.Configurations
     private static readonly IDockerImage RyukContainerImage = new DockerImage("testcontainers/ryuk:0.3.4");
 
     private static readonly IDockerEndpointAuthenticationConfiguration DockerEndpointAuthConfig =
-      new IDockerEndpointAuthenticationProvider[] { new EnvironmentEndpointAuthenticationProvider(), new NpipeEndpointAuthenticationProvider(), new UnixEndpointAuthenticationProvider() }
+      new IDockerEndpointAuthenticationProvider[]
+        {
+          new TlsEndpointAuthenticationProvider(),
+          new EnvironmentEndpointAuthenticationProvider(),
+          new NpipeEndpointAuthenticationProvider(),
+          new UnixEndpointAuthenticationProvider(),
+        }
         .AsParallel()
         .Where(authProvider => authProvider.IsApplicable())
         .Where(authProvider => authProvider.IsAvailable())


### PR DESCRIPTION
This is second small increment of huge PR #548. 
This PR brings support for secure communication between client and docker daemon server API.
This PR does not contain client authentication based on certificates (mTLS) which can be switch on by option DOCKER_TLS_VERIFY.