### PR TITLE
Implement WithImagePullPolicy 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Keep in mind to enable the correct Docker engine on Windows host systems to matc
 To configure a container, use the `TestcontainersBuilder<TestcontainersContainer>` builder, that provides:
 
 - `WithImage` specifies an `IMAGE[:TAG]` to derive the container from.
+- `WithImagePullPolicy` specifies an image pull policy used to determine if the image should be pulled when starting the container e. g. `--pull "always"|"missing"|"never"`.
 - `WithWorkingDirectory` specifies and overrides the `WORKDIR` for the instruction sets.
 - `WithEntrypoint` specifies and overrides the `ENTRYPOINT` that will run as an executable.
 - `WithCommand` specifies and overrides the `COMMAND` instruction provided from the Dockerfile.
@@ -110,7 +111,7 @@ await using (var testcontainers = testcontainersBuilder.Build())
 }
 ```
 
-Here is an example of a pre-configured container. In the example, Testcontainers starts a PostgreSQL database in a [xUnit.net][xunit] test and executes a SQL query.
+Here is an example of a pre-configured container. In the example,  Testcontainers starts a PostgreSQL database in a [xUnit.net][xunit] test and executes a SQL query.
 
 ```csharp
 public sealed class PostgreSqlTest : IAsyncLifetime
@@ -171,7 +172,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Authors
 
-- **Andre Hofmeister** - _Initial work_ - [HofmeisterAn](https://github.com/HofmeisterAn/)
+* **Andre Hofmeister** - *Initial work* - [HofmeisterAn](https://github.com/HofmeisterAn/)
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ await using (var testcontainers = testcontainersBuilder.Build())
 }
 ```
 
-Here is an example of a pre-configured container. In the example,  Testcontainers starts a PostgreSQL database in a [xUnit.net][xunit] test and executes a SQL query.
+Here is an example of a pre-configured container. In the example, Testcontainers starts a PostgreSQL database in a [xUnit.net][xunit] test and executes a SQL query.
 
 ```csharp
 public sealed class PostgreSqlTest : IAsyncLifetime
@@ -171,7 +171,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Authors
 
-* **Andre Hofmeister** - *Initial work* - [HofmeisterAn](https://github.com/HofmeisterAn/)
+- **Andre Hofmeister** - _Initial work_ - [HofmeisterAn](https://github.com/HofmeisterAn/)
 
 ## Thanks
 

--- a/src/Testcontainers/Builders/ITestcontainersBuilder.cs
+++ b/src/Testcontainers/Builders/ITestcontainersBuilder.cs
@@ -45,6 +45,14 @@ namespace DotNet.Testcontainers.Builders
     ITestcontainersBuilder<TDockerContainer> WithImage(IDockerImage image);
 
     /// <summary>
+    /// Sets the image pull policy, which is used to determine if the image should be pulled before starting the container.
+    /// </summary>
+    /// <param name="imagePullPolicy">The image pull policy that determines if the image should be pulled.</param>
+    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    [PublicAPI]
+    ITestcontainersBuilder<TDockerContainer> WithImagePullPolicy(Func<ImagesListResponse, bool> imagePullPolicy);
+
+    /// <summary>
     /// Sets the name of the Testcontainer.
     /// </summary>
     /// <param name="name">Testcontainers name.</param>

--- a/src/Testcontainers/Builders/TestcontainersBuilder.cs
+++ b/src/Testcontainers/Builders/TestcontainersBuilder.cs
@@ -57,7 +57,8 @@ namespace DotNet.Testcontainers.Builders
           waitStrategies: Wait.ForUnixContainer().Build(),
           startupCallback: (_, ct) => Task.CompletedTask,
           autoRemove: false,
-          privileged: false),
+          privileged: false,
+          imagePullPolicy: PullPolicy.Missing),
         _ => { })
     {
     }
@@ -91,6 +92,12 @@ namespace DotNet.Testcontainers.Builders
     public ITestcontainersBuilder<TDockerContainer> WithImage(IDockerImage image)
     {
       return this.MergeNewConfiguration(new TestcontainersConfiguration(image: PrependHubImageNamePrefix(image)));
+    }
+
+    /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
+    public ITestcontainersBuilder<TDockerContainer> WithImagePullPolicy(Func<ImagesListResponse, bool> imagePullPolicy)
+    {
+      return this.MergeNewConfiguration(new TestcontainersConfiguration(imagePullPolicy: imagePullPolicy));
     }
 
     /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
@@ -348,6 +355,7 @@ namespace DotNet.Testcontainers.Builders
 
       var image = BuildConfiguration.Combine(dockerResourceConfiguration.Image, this.DockerResourceConfiguration.Image);
       var name = BuildConfiguration.Combine(dockerResourceConfiguration.Name, this.DockerResourceConfiguration.Name);
+      var imagePullPolicy = BuildConfiguration.Combine(dockerResourceConfiguration.ImagePullPolicy, this.DockerResourceConfiguration.ImagePullPolicy);
       var hostname = BuildConfiguration.Combine(dockerResourceConfiguration.Hostname, this.DockerResourceConfiguration.Hostname);
       var workingDirectory = BuildConfiguration.Combine(dockerResourceConfiguration.WorkingDirectory, this.DockerResourceConfiguration.WorkingDirectory);
       var entrypoint = BuildConfiguration.Combine(dockerResourceConfiguration.Entrypoint, this.DockerResourceConfiguration.Entrypoint);
@@ -367,7 +375,7 @@ namespace DotNet.Testcontainers.Builders
       var parameterModifiers = BuildConfiguration.Combine(dockerResourceConfiguration.ParameterModifiers, this.DockerResourceConfiguration.ParameterModifiers);
       var startupCallback = BuildConfiguration.Combine(dockerResourceConfiguration.StartupCallback, this.DockerResourceConfiguration.StartupCallback);
 
-      var updatedDockerResourceConfiguration = new TestcontainersConfiguration(dockerEndpointAuthConfig, dockerRegistryAuthConfig, image, name, hostname, workingDirectory, entrypoint, command, environments, labels, exposedPorts, portBindings, mounts, networks, networkAliases, outputConsumer, waitStrategies, parameterModifiers, startupCallback, autoRemove, privileged);
+      var updatedDockerResourceConfiguration = new TestcontainersConfiguration(dockerEndpointAuthConfig, dockerRegistryAuthConfig, image, imagePullPolicy, name, hostname, workingDirectory, entrypoint, command, environments, labels, exposedPorts, portBindings, mounts, networks, networkAliases, outputConsumer, waitStrategies, parameterModifiers, startupCallback, autoRemove, privileged);
       return new TestcontainersBuilder<TDockerContainer>(updatedDockerResourceConfiguration, this.mergeModuleConfiguration);
     }
 

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -259,8 +259,10 @@ namespace DotNet.Testcontainers.Clients
           .ConfigureAwait(false);
       }
 
-      if (!await this.images.ExistsWithNameAsync(configuration.Image.FullName, ct)
-        .ConfigureAwait(false))
+      var cachedImage = await this.images.ByNameAsync(configuration.Image.FullName, ct)
+        .ConfigureAwait(false);
+
+      if (configuration.ImagePullPolicy(cachedImage))
       {
         var authConfig = default(DockerRegistryAuthenticationConfiguration).Equals(configuration.DockerRegistryAuthConfig)
           ? this.registryAuthenticationProvider.GetAuthConfig(configuration.Image.GetHostname()) : configuration.DockerRegistryAuthConfig;

--- a/src/Testcontainers/Configurations/Containers/ITestcontainersConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ITestcontainersConfiguration.cs
@@ -35,6 +35,14 @@ namespace DotNet.Testcontainers.Configurations
     IDockerImage Image { get; }
 
     /// <summary>
+    /// Gets the policy determining if an image should be pulled when creating the container.
+    /// </summary>
+    /// <remarks>
+    /// Allows the user to decide based on the cached image (if it's possible to retrieve one).
+    /// </remarks>
+    Func<ImagesListResponse, bool> ImagePullPolicy { get; }
+
+    /// <summary>
     /// Gets the name.
     /// </summary>
     string Name { get; }

--- a/src/Testcontainers/Configurations/Containers/TestcontainersConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/TestcontainersConfiguration.cs
@@ -29,6 +29,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="dockerEndpointAuthenticationConfiguration">The Docker endpoint authentication configuration.</param>
     /// <param name="dockerRegistryAuthenticationConfiguration">The Docker registry authentication configuration.</param>
     /// <param name="image">The Docker image.</param>
+    /// <param name="imagePullPolicy">The Docker image pull policy.</param>
     /// <param name="name">The name.</param>
     /// <param name="hostname">The hostname.</param>
     /// <param name="workingDirectory">The working directory.</param>
@@ -51,6 +52,7 @@ namespace DotNet.Testcontainers.Configurations
       IDockerEndpointAuthenticationConfiguration dockerEndpointAuthenticationConfiguration = null,
       IDockerRegistryAuthenticationConfiguration dockerRegistryAuthenticationConfiguration = null,
       IDockerImage image = null,
+      Func<ImagesListResponse, bool> imagePullPolicy = null,
       string name = null,
       string hostname = null,
       string workingDirectory = null,
@@ -75,6 +77,7 @@ namespace DotNet.Testcontainers.Configurations
       this.Privileged = privileged;
       this.DockerRegistryAuthConfig = dockerRegistryAuthenticationConfiguration;
       this.Image = image;
+      this.ImagePullPolicy = imagePullPolicy;
       this.Name = name;
       this.Hostname = hostname;
       this.WorkingDirectory = workingDirectory;
@@ -105,6 +108,9 @@ namespace DotNet.Testcontainers.Configurations
 
     /// <inheritdoc />
     public IDockerImage Image { get; }
+
+    /// <inheritdoc />
+    public Func<ImagesListResponse, bool> ImagePullPolicy { get; }
 
     /// <inheritdoc />
     public string Name { get; }

--- a/src/Testcontainers/Images/PullPolicy.cs
+++ b/src/Testcontainers/Images/PullPolicy.cs
@@ -1,0 +1,44 @@
+namespace DotNet.Testcontainers.Images
+{
+  using System;
+  using Docker.DotNet.Models;
+
+  public static class PullPolicy
+  {
+    /// <summary>
+    /// Gets the policy of never pulling the image.
+    /// </summary>
+    public static Func<ImagesListResponse, bool> Never
+    {
+      get
+      {
+        return _ => false;
+      }
+    }
+
+    /// <summary>
+    /// Gets the policy of pulling the image if it's not cached.
+    /// </summary>
+    /// <remarks>
+    /// This is the default behavior.
+    /// </remarks>
+    public static Func<ImagesListResponse, bool> Missing
+    {
+      get
+      {
+        return cachedImage => cachedImage != null;
+      }
+    }
+
+    /// <summary>
+    /// Gets the policy of always pulling the image.
+    /// </summary>
+    public static Func<ImagesListResponse, bool> Always
+    {
+      get
+      {
+        return _ => true;
+      }
+    }
+  }
+}

--- a/src/Testcontainers/Images/PullPolicy.cs
+++ b/src/Testcontainers/Images/PullPolicy.cs
@@ -26,7 +26,7 @@ namespace DotNet.Testcontainers.Images
     {
       get
       {
-        return cachedImage => cachedImage != null;
+        return cachedImage => cachedImage == null;
       }
     }
 

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -7,12 +7,13 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
   using System.Net.Http;
   using System.Text;
   using System.Threading.Tasks;
-  using Docker.DotNet;
   using DotNet.Testcontainers.Builders;
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
+  using DotNet.Testcontainers.Images;
   using DotNet.Testcontainers.Tests.Fixtures;
+  using global::Docker.DotNet;
   using Xunit;
 
   public static class TestcontainersContainerTest
@@ -497,17 +498,17 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         // Given
         // An image that actually exists but was not used/pulled previously
         // If this image is cached/pulled before, this test will fail
-        var previouslyUnusedImage = "alpine:edge";
+        var uncachedImage = "alpine:edge";
 
         // When
         var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
-          .WithImage(previouslyUnusedImage)
+          .WithImage(uncachedImage)
           .WithImagePullPolicy(PullPolicy.Never);
 
         // Then
         await using (ITestcontainersContainer testcontainer = testcontainersBuilder.Build())
         {
-          Assert.ThrowsAsync<DockerImageNotFoundException>(() => testcontainer.StartAsync());
+          await Assert.ThrowsAsync<DockerImageNotFoundException>(() => testcontainer.StartAsync());
         }
       }
     }

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -497,7 +497,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         // Given
         // An image that actually exists but was not used/pulled previously
         // If this image is cached/pulled before, this test will fail
-        var uncachedImage = "alpine:edge";
+        const string uncachedImage = "alpine:edge";
 
         // When
         var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -13,7 +13,6 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Images;
   using DotNet.Testcontainers.Tests.Fixtures;
-  using global::Docker.DotNet;
   using Xunit;
 
   public static class TestcontainersContainerTest
@@ -508,7 +507,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         // Then
         await using (ITestcontainersContainer testcontainer = testcontainersBuilder.Build())
         {
-          await Assert.ThrowsAsync<DockerImageNotFoundException>(() => testcontainer.StartAsync());
+          await Assert.ThrowsAnyAsync<Exception>(() => testcontainer.StartAsync());
         }
       }
     }

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -7,6 +7,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
   using System.Net.Http;
   using System.Text;
   using System.Threading.Tasks;
+  using Docker.DotNet;
   using DotNet.Testcontainers.Builders;
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Configurations;
@@ -487,6 +488,26 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         {
           await testcontainer.StartAsync();
           Assert.EndsWith(name, testcontainer.Name);
+        }
+      }
+
+      [Fact]
+      public async Task PullPolicyNever()
+      {
+        // Given
+        // An image that actually exists but was not used/pulled previously
+        // If this image is cached/pulled before, this test will fail
+        var previouslyUnusedImage = "alpine:edge";
+
+        // When
+        var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
+          .WithImage(previouslyUnusedImage)
+          .WithImagePullPolicy(PullPolicy.Never);
+
+        // Then
+        await using (ITestcontainersContainer testcontainer = testcontainersBuilder.Build())
+        {
+          Assert.ThrowsAsync<DockerImageNotFoundException>(() => testcontainer.StartAsync());
         }
       }
     }


### PR DESCRIPTION
Trying to implement `WithImagePullPolicy` mentioned in #601. I tried to keep similar functionality to the [Java counterpart](https://www.testcontainers.org/features/advanced_options/#image-pull-policy) where you can write a custom policy depending on the information about the cached image (e. g. policy that pulls the image if the currently cached image's  `Created` property is 3 days old). Of course there's still the presets `PullPolicy.Never`, `PullPolicy.Missing` (default) and `PullPolicy.Always` like with `docker run` argument `--pull`.

I am not sure how I should proceed with tests – ideally I would want to for example test if `PullPolicy.Never` is working, so I would need to somehow delete the image if it's cached/pulled, but I am not sure how to do that, since I can't access the Docker.DotNet client underneath. Any suggestions appreciated.

How is this looking @HofmeisterAn ?