### PR TITLE
Feature/minor improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - 525 Read ServerURL, Username and Secret field from CredsStore response to pull private Docker images
 - 595 Implement `TestcontainersContainer.DisposeAsync` thread safe (rename `TestcontainersState` to `TestcontainersStates`)
 - 604 Do not deny all files in the Docker image tarball when a `.dockerignore` entry ends with `/`
+- 610 Do not deny all files in the Docker image tarball when a `.dockerignore` entry ends with `/*`
 
 ## [2.1.0]
 

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -86,7 +86,7 @@
 
             var tarEntry = TarEntry.CreateEntryFromFile(file);
             tarEntry.Name = relativePath;
-            tarArchive.WriteEntry(tarEntry, true);
+            tarArchive.WriteEntry(tarEntry, false);
           }
         }
       }

--- a/src/Testcontainers/Images/IgnoreFile.cs
+++ b/src/Testcontainers/Images/IgnoreFile.cs
@@ -32,6 +32,16 @@ namespace DotNet.Testcontainers.Images
         // Trim each line.
         .Select(line => line.Trim())
 
+        // Exclude files and directories.
+        .Select(line => line.TrimEnd('/'))
+
+        // Exclude files and directories.
+        .Select(line =>
+        {
+          const string filesAndDirectories = "/*";
+          return line.EndsWith(filesAndDirectories, StringComparison.InvariantCulture) ? line.Substring(0, line.Length - filesAndDirectories.Length) : line;
+        })
+
         // Remove empty line.
         .Where(line => !string.IsNullOrEmpty(line))
 

--- a/tests/Testcontainers.Tests/Fixtures/Images/IgnoreFileFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/IgnoreFileFixture.cs
@@ -9,15 +9,15 @@ namespace DotNet.Testcontainers.Tests.Fixtures
     public IgnoreFileFixture()
     {
       var logger = TestcontainersSettings.Logger;
-      var ignoreDirectory = new IgnoreFile(new[] { "bin/", "obj/" }, logger);
+      var ignoreFilesAndDirectories = new IgnoreFile(new[] { "bin/", "obj/*" }, logger);
       var ignoreNonRecursiveFiles = new IgnoreFile(new[] { "*/temp*" }, logger);
       var ignoreNonRecursiveNestedFiles = new IgnoreFile(new[] { "*/*/temp*" }, logger);
       var ignoreRecursiveFiles = new IgnoreFile(new[] { "**/*.txt" }, logger);
       var ignoreSingleCharacterFiles = new IgnoreFile(new[] { "temp?" }, logger);
       var ignoreExceptionFiles = new IgnoreFile(new[] { "*.md", "!README*.md", "README-secret.md" }, logger);
-      this.Add(ignoreDirectory, "Testcontainers.sln", true);
-      this.Add(ignoreDirectory, "bin/Debug/net6.0", false);
-      this.Add(ignoreDirectory, "obj/Debug/net6.0", false);
+      this.Add(ignoreFilesAndDirectories, "bin/Debug/net6.0", false);
+      this.Add(ignoreFilesAndDirectories, "obj/Debug/net6.0", false);
+      this.Add(ignoreFilesAndDirectories, "Testcontainers.sln", true);
       this.Add(ignoreNonRecursiveFiles, "lipsum/temp", false);
       this.Add(ignoreNonRecursiveFiles, "lipsum/temp.txt", false);
       this.Add(ignoreNonRecursiveFiles, "lipsum/lorem/temp", true);


### PR DESCRIPTION
## What does this PR do?

This pull request contains a couple of minor improvements:

- It fixes and issue where the image builder ignores all files if `.dockerignore` contains an entry with a leading `/*`.
- It aligns the hostname revolution with testcontainers-java.
- It adds another example to the demo application that runs a test in-process (access services from the CI container)

## Why is it important?

\-

## Related issues

- Relates #610