### PR TITLE
feat(#618): Match .dockerignore entry * to all files and directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - 594 Add `IDockerContainer.GetLogs`
 - 601 Add `ITestcontainersBuilder<TDockerContainer>.WithImagePullPolicy` (@BenasB)
 - 616 Add `ITestcontainersBuilder<TDockerContainer>.WithMacAddress` (@seb1992)
+- 618 Match `.dockerignore` entry `*` to all files and directories
 
 ### Changed
 

--- a/src/Testcontainers/Images/IgnoreFile.cs
+++ b/src/Testcontainers/Images/IgnoreFile.cs
@@ -32,6 +32,12 @@ namespace DotNet.Testcontainers.Images
         // Trim each line.
         .Select(line => line.Trim())
 
+        // Remove empty line.
+        .Where(line => !string.IsNullOrEmpty(line))
+
+        // Remove comment.
+        .Where(line => !line.StartsWith("#", StringComparison.Ordinal))
+
         // Exclude files and directories.
         .Select(line => line.TrimEnd('/'))
 
@@ -42,11 +48,8 @@ namespace DotNet.Testcontainers.Images
           return line.EndsWith(filesAndDirectories, StringComparison.InvariantCulture) ? line.Substring(0, line.Length - filesAndDirectories.Length) : line;
         })
 
-        // Remove empty line.
-        .Where(line => !string.IsNullOrEmpty(line))
-
-        // Remove comment.
-        .Where(line => !line.StartsWith("#", StringComparison.Ordinal))
+        // Exclude all files and directories (https://github.com/testcontainers/testcontainers-dotnet/issues/618).
+        .Select(line => "*".Equals(line, StringComparison.OrdinalIgnoreCase) ? "**" : line)
 
         // Check if the pattern contains an optional prefix ("!"), which negates the pattern.
         .Aggregate(new List<KeyValuePair<string, bool>>(), (lines, line) =>

--- a/tests/Testcontainers.Tests/Fixtures/Images/IgnoreFileFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/IgnoreFileFixture.cs
@@ -10,14 +10,18 @@ namespace DotNet.Testcontainers.Tests.Fixtures
     {
       var logger = TestcontainersSettings.Logger;
       var ignoreFilesAndDirectories = new IgnoreFile(new[] { "bin/", "obj/*" }, logger);
+      var ignoreAllFilesAndDirectories = new IgnoreFile(new[] { "*", "!README*.md" }, logger);
       var ignoreNonRecursiveFiles = new IgnoreFile(new[] { "*/temp*" }, logger);
       var ignoreNonRecursiveNestedFiles = new IgnoreFile(new[] { "*/*/temp*" }, logger);
       var ignoreRecursiveFiles = new IgnoreFile(new[] { "**/*.txt" }, logger);
       var ignoreSingleCharacterFiles = new IgnoreFile(new[] { "temp?" }, logger);
       var ignoreExceptionFiles = new IgnoreFile(new[] { "*.md", "!README*.md", "README-secret.md" }, logger);
-      this.Add(ignoreFilesAndDirectories, "bin/Debug/net6.0", false);
-      this.Add(ignoreFilesAndDirectories, "obj/Debug/net6.0", false);
-      this.Add(ignoreFilesAndDirectories, "Testcontainers.sln", true);
+      this.Add(ignoreFilesAndDirectories, "bin/Debug", false);
+      this.Add(ignoreFilesAndDirectories, "obj/Debug", false);
+      this.Add(ignoreFilesAndDirectories, "README.md", true);
+      this.Add(ignoreAllFilesAndDirectories, "bin/Debug", false);
+      this.Add(ignoreAllFilesAndDirectories, "obj/Debug", false);
+      this.Add(ignoreAllFilesAndDirectories, "README.md", true);
       this.Add(ignoreNonRecursiveFiles, "lipsum/temp", false);
       this.Add(ignoreNonRecursiveFiles, "lipsum/temp.txt", false);
       this.Add(ignoreNonRecursiveFiles, "lipsum/lorem/temp", true);


### PR DESCRIPTION
## What does this PR do?

Extends the `IgnoreFile` implementation to support a single `*` character that matches (ignores) all files and directories. The glob pattern matching `*` matchs everything except slashes. That behavior is different from the `.dockerignore` file.

## Why is it important?

To align with the Docker CLI.

## Related issues

- Closes #618
