### PR TITLE
fix(#640): Elasticsearch tests run without system level setup

### DIFF
--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/ElasticsearchFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/ElasticsearchFixture.cs
@@ -16,6 +16,7 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
     public ElasticsearchFixture()
     {
+      this.configuration.Environments.Add("node.store.allow_mmap", false.ToString());
       this.Container = new TestcontainersBuilder<ElasticsearchTestcontainer>()
         .WithDatabase(this.configuration)
         .Build();


### PR DESCRIPTION
PR which makes all Elasticsearch tests run-able on any docker engine. It uses option number `iii` from bug #640. 
It also does not affect default setup of Elasticsearch configuration to prevent any breaking change introduction.