### PR TITLE
fix(#648): Always include .dockerignore and Dockerfile files in tarball if they exist

### DIFF
--- a/src/Testcontainers/Images/DockerIgnoreFile.cs
+++ b/src/Testcontainers/Images/DockerIgnoreFile.cs
@@ -1,5 +1,6 @@
 ﻿namespace DotNet.Testcontainers.Images
 {
+  using System.Collections.Generic;
   using System.IO;
   using System.Linq;
   using Microsoft.Extensions.Logging;
@@ -9,6 +10,8 @@
   /// </summary>
   internal sealed class DockerIgnoreFile : IgnoreFile
   {
+    private const string NegatedDockerFileGlob = "!Dockerfile";
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerIgnoreFile" /> class.
     /// </summary>
@@ -16,7 +19,7 @@
     /// <param name="dockerIgnoreFile">.dockerignore file name.</param>
     /// <param name="logger">The logger.</param>
     public DockerIgnoreFile(string dockerIgnoreFileDirectory, string dockerIgnoreFile, ILogger logger)
-      : this(new DirectoryInfo(dockerIgnoreFileDirectory), dockerIgnoreFile, logger)
+      : this(dockerIgnoreFileDirectory, dockerIgnoreFile, logger, new FileSystem())
     {
     }
 
@@ -26,13 +29,33 @@
     /// <param name="dockerIgnoreFileDirectory">Directory that contains all docker configuration files.</param>
     /// <param name="dockerIgnoreFile">.dockerignore file name.</param>
     /// <param name="logger">The logger.</param>
-    public DockerIgnoreFile(DirectoryInfo dockerIgnoreFileDirectory, string dockerIgnoreFile, ILogger logger)
-      : base(
-        dockerIgnoreFileDirectory.GetFiles(dockerIgnoreFile, SearchOption.TopDirectoryOnly).Any()
-          ? File.ReadLines(Path.Combine(dockerIgnoreFileDirectory.FullName, dockerIgnoreFile)).Concat(new[] { dockerIgnoreFile }).ToArray()
-          : new[] { dockerIgnoreFile },
-        logger)
+    /// <param name="fileSystem">The file system abstraction.</param>
+    public DockerIgnoreFile(string dockerIgnoreFileDirectory, string dockerIgnoreFile, ILogger logger, IFileSystem fileSystem)
+      : base(GetDockerIgnoreFileContents(dockerIgnoreFileDirectory, dockerIgnoreFile, fileSystem), logger)
     {
+    }
+
+    /// <summary>
+    /// This will read the contents of the .dockerignore file. It will append negated patterns for the Dockerfile and
+    /// .dockerignore files so they are always included in the tarball. The docker daemon will make sure not to
+    /// include these in the image when they are excluded in the .dockerignore file. If the dockerignore file cannot
+    /// be found an empty enumerable will be returned.
+    /// </summary>
+    /// <param name="dockerIgnoreFileDirectory">Directory that contains all docker configuration files.</param>
+    /// <param name="dockerIgnoreFile">.dockerignore file name.</param>
+    /// <param name="fileSystem">The file system abstraction.</param>
+    /// <returns>The contents of the .dockerignore file as an array of strings or an empty enumerable when the dockerignore file does not exist.</returns>
+    private static IEnumerable<string> GetDockerIgnoreFileContents(string dockerIgnoreFileDirectory, string dockerIgnoreFile, IFileSystem fileSystem)
+    {
+      if (!fileSystem.FileExists(dockerIgnoreFileDirectory, dockerIgnoreFile))
+      {
+        return Enumerable.Empty<string>();
+      }
+
+      var fullPath = Path.Combine(fileSystem.GetDirectoryFullName(dockerIgnoreFileDirectory), dockerIgnoreFile);
+      return fileSystem.ReadLines(fullPath)
+        .Concat(new[] { $"!{dockerIgnoreFile}", NegatedDockerFileGlob })
+        .ToArray();
     }
   }
 }

--- a/src/Testcontainers/Images/FileSystem.cs
+++ b/src/Testcontainers/Images/FileSystem.cs
@@ -1,0 +1,25 @@
+﻿namespace DotNet.Testcontainers.Images
+{
+  using System.Collections.Generic;
+  using System.IO;
+  using System.Linq;
+
+  public class FileSystem : IFileSystem
+  {
+    public IEnumerable<string> ReadLines(string path)
+    {
+      return File.ReadLines(path);
+    }
+
+    public bool FileExists(string directory, string file)
+    {
+      var directoryInfo = new DirectoryInfo(directory);
+      return directoryInfo.GetFiles(file, SearchOption.TopDirectoryOnly).Any();
+    }
+
+    public string GetDirectoryFullName(string directory)
+    {
+      return new DirectoryInfo(directory).FullName;
+    }
+  }
+}

--- a/src/Testcontainers/Images/FileSystem.cs
+++ b/src/Testcontainers/Images/FileSystem.cs
@@ -4,7 +4,7 @@
   using System.IO;
   using System.Linq;
 
-  public class FileSystem : IFileSystem
+  internal class FileSystem : IFileSystem
   {
     public IEnumerable<string> ReadLines(string path)
     {

--- a/src/Testcontainers/Images/IFileSystem.cs
+++ b/src/Testcontainers/Images/IFileSystem.cs
@@ -1,0 +1,13 @@
+﻿namespace DotNet.Testcontainers.Images
+{
+  using System.Collections.Generic;
+
+  public interface IFileSystem
+  {
+    IEnumerable<string> ReadLines(string path);
+
+    bool FileExists(string directory, string file);
+
+    string GetDirectoryFullName(string directory);
+  }
+}

--- a/tests/Testcontainers.Tests/Fixtures/Images/DockerIgnoreFileFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/DockerIgnoreFileFixture.cs
@@ -37,6 +37,18 @@
         DirectoryFullName = "/mypath",
       });
 
+      var ignoreDirectoryWildcardDockerIgnoreAndWildcardDockerFile = new DockerIgnoreFile("/mypath/", ".dockerignore", logger, new FileSystemFixture()
+      {
+        Lines =
+        {
+          "**/bin/",
+          "**/.dockerignore",
+          "**/Dockerfile",
+        },
+        Exists = true,
+        DirectoryFullName = "/mypath",
+      });
+
       var dockerIgnoreFile = ".dockerignore";
       var dockerfile = "Dockerfile";
       var nestedDockerfile = "/lipsum/lorem/Dockerfile";
@@ -55,7 +67,12 @@
       this.Add(ignoreDirectoryDockerIgnoreAndDockerFile, dockerIgnoreFile, true);
       this.Add(ignoreDirectoryDockerIgnoreAndDockerFile, dockerfile, true);
       this.Add(ignoreDirectoryDockerIgnoreAndDockerFile, nestedDockerfile, true);
-      this.Add(ignoreDirectory, binDirectory, false);
+      this.Add(ignoreDirectoryDockerIgnoreAndDockerFile, binDirectory, false);
+
+      this.Add(ignoreDirectoryWildcardDockerIgnoreAndWildcardDockerFile, dockerIgnoreFile, true);
+      this.Add(ignoreDirectoryWildcardDockerIgnoreAndWildcardDockerFile, dockerfile, true);
+      this.Add(ignoreDirectoryWildcardDockerIgnoreAndWildcardDockerFile, nestedDockerfile, true);
+      this.Add(ignoreDirectoryWildcardDockerIgnoreAndWildcardDockerFile, binDirectory, false);
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Images/DockerIgnoreFileFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/DockerIgnoreFileFixture.cs
@@ -1,0 +1,61 @@
+﻿namespace DotNet.Testcontainers.Tests.Fixtures
+{
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Images;
+  using Xunit;
+
+  public class DockerIgnoreFileFixture : TheoryData<IgnoreFile, string, bool>
+  {
+    public DockerIgnoreFileFixture()
+    {
+      var logger = TestcontainersSettings.Logger;
+
+      var ignoreFileDoesNotExist = new DockerIgnoreFile("/mypath/", ".dockerignore", logger, new FileSystemFixture()
+      {
+        Exists = false,
+      });
+
+      var ignoreDirectory = new DockerIgnoreFile("/mypath/", ".dockerignore", logger, new FileSystemFixture()
+      {
+        Exists = true,
+        DirectoryFullName = "/mypath",
+        Lines =
+        {
+          "bin/",
+        },
+      });
+
+      var ignoreDirectoryDockerIgnoreAndDockerFile = new DockerIgnoreFile("/mypath/", ".dockerignore", logger, new FileSystemFixture()
+      {
+        Lines =
+        {
+          "bin/",
+          ".dockerignore",
+          "Dockerfile",
+        },
+        Exists = true,
+        DirectoryFullName = "/mypath",
+      });
+
+      var dockerIgnoreFile = ".dockerignore";
+      var dockerfile = "Dockerfile";
+      var nestedDockerfile = "/lipsum/lorem/Dockerfile";
+      var binDirectory = "bin";
+
+      this.Add(ignoreFileDoesNotExist, dockerIgnoreFile, true);
+      this.Add(ignoreFileDoesNotExist, dockerfile, true);
+      this.Add(ignoreFileDoesNotExist, nestedDockerfile, true);
+      this.Add(ignoreFileDoesNotExist, binDirectory, true);
+
+      this.Add(ignoreDirectory, dockerIgnoreFile, true);
+      this.Add(ignoreDirectory, dockerfile, true);
+      this.Add(ignoreDirectory, nestedDockerfile, true);
+      this.Add(ignoreDirectory, binDirectory, false);
+
+      this.Add(ignoreDirectoryDockerIgnoreAndDockerFile, dockerIgnoreFile, true);
+      this.Add(ignoreDirectoryDockerIgnoreAndDockerFile, dockerfile, true);
+      this.Add(ignoreDirectoryDockerIgnoreAndDockerFile, nestedDockerfile, true);
+      this.Add(ignoreDirectory, binDirectory, false);
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Fixtures/Images/FileSystemFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/FileSystemFixture.cs
@@ -1,0 +1,31 @@
+﻿namespace DotNet.Testcontainers.Tests.Fixtures
+{
+  using System.Collections.Generic;
+  using DotNet.Testcontainers.Images;
+  using JetBrains.Annotations;
+
+  public class FileSystemFixture : IFileSystem
+  {
+    public List<string> Lines { get; } = new List<string>();
+
+    public bool Exists { get; set; }
+
+    [CanBeNull]
+    public string DirectoryFullName { get; set; }
+
+    public IEnumerable<string> ReadLines(string path)
+    {
+      return this.Lines;
+    }
+
+    public bool FileExists(string directory, string file)
+    {
+      return this.Exists;
+    }
+
+    public string GetDirectoryFullName(string directory)
+    {
+      return this.DirectoryFullName ?? directory;
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Unit/Images/DockerIgnoreFileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/DockerIgnoreFileTest.cs
@@ -1,0 +1,17 @@
+﻿namespace DotNet.Testcontainers.Tests.Unit
+{
+  using DotNet.Testcontainers.Images;
+  using DotNet.Testcontainers.Tests.Fixtures;
+  using Xunit;
+
+  [Collection(nameof(Testcontainers))]
+  public sealed class DockerIgnoreFileTest
+  {
+    [Theory]
+    [ClassData(typeof(DockerIgnoreFileFixture))]
+    public void AlwaysAcceptsDockerfileAndDockerignoreFiles(IgnoreFile ignoreFile, string path, bool expected)
+    {
+      Assert.Equal(expected, ignoreFile.Accepts(path));
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -20,7 +20,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       // Given
       var image = new DockerImage("testcontainers", "test", "1.0.0");
 
-      var expected = new SortedSet<string> { "Dockerfile", "setup/setup.sh" };
+      var expected = new SortedSet<string> { ".dockerignore", "Dockerfile", "setup/setup.sh" };
 
       var actual = new SortedSet<string>();
 


### PR DESCRIPTION
Fixes #648 

I took the liberty to refactor the filesystem access out of the DockerIgnoreFile class into a FileSystem class. This way the DockerIgnoreFile class is testable without having to bother with creating temp files. This way I was able to test the dockerignore specific logic without having to change the IgnoreFile class or its tests. Let me know what you think!