### PR TITLE
Bugfix/631 debug azurite configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - 642 Expose container port bindings automatically
 
+### Fixed
+
+- 610 Trim traling slashes in Dockerfile directory path (otherwise, it cuts the first character of the relative path)
+
 ## [2.2.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- 610 Trim traling slashes in Dockerfile directory path (otherwise, it cuts the first character of the relative path)
+- 610 Trim traling slashes in Dockerfile directory path (otherwise, it cuts the first character of the relative path), Normalize paths to forward slashes
 
 ## [2.2.0]
 

--- a/examples/WeatherForecast/README.md
+++ b/examples/WeatherForecast/README.md
@@ -1,3 +1,10 @@
 # Testcontainers for .NET WeatherForecast example
 
-This example builds and ships a Blazor application in a Docker image build, runs a Docker container and executes tests against a running instance of the application. Testcontainers for .NET takes care of the Docker image build and the Docker container that hosts the application. Spin up as much as containers as you like and run your tests heavily in parallel.
+This example builds and ships a Blazor application in a Docker image build, runs a Docker container and executes tests against a running instance of the application. Testcontainers for .NET takes care of the Docker image build and the Docker container that hosts the application. Spin up as much as containers as you like and run your tests heavily in parallel. Checkout and run the tests on your machine:
+
+```console
+git clone git@github.com:testcontainers/testcontainers-dotnet.git
+cd ./testcontainers-dotnet/examples/WeatherForecast/
+dotnet build WeatherForecast.sln
+dotnet test WeatherForecast.sln
+```

--- a/examples/WeatherForecast/tests/WeatherForecast.Test/WeatherForecastTest.cs
+++ b/examples/WeatherForecast/tests/WeatherForecast.Test/WeatherForecastTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
+using OpenQA.Selenium.Support.UI;
 using WeatherForecast.Entities;
 using Xunit;
 
@@ -69,7 +70,7 @@ public static class WeatherForecastTest
 
     [Fact]
     [Trait("Category", nameof(Web))]
-    public async Task Get_WeatherForecast_ReturnsSevenDays()
+    public void Get_WeatherForecast_ReturnsSevenDays()
     {
       // Given
       string ScreenshotFileName() => $"{nameof(Get_WeatherForecast_ReturnsSevenDays)}_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}.png";
@@ -83,8 +84,8 @@ public static class WeatherForecastTest
 
       chrome.FindElement(By.TagName("fluent-button")).Click();
 
-      await Task.Delay(TimeSpan.FromSeconds(1))
-        .ConfigureAwait(false);
+      var wait = new WebDriverWait(chrome, TimeSpan.FromSeconds(10));
+      wait.Until(webDriver => 1.Equals(webDriver.FindElements(By.TagName("span")).Count));
 
       chrome.GetScreenshot().SaveAsFile(Path.Combine(CommonDirectoryPath.GetSolutionDirectory().DirectoryPath, ScreenshotFileName()));
 

--- a/src/Testcontainers/Builders/DockerEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/DockerEndpointAuthenticationProvider.cs
@@ -1,12 +1,16 @@
 ﻿namespace DotNet.Testcontainers.Builders
 {
   using System;
+  using System.Threading;
+  using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
 
   /// <inheritdoc cref="IDockerEndpointAuthenticationProvider" />
   internal class DockerEndpointAuthenticationProvider : IDockerEndpointAuthenticationProvider
   {
+    private static readonly TaskFactory TaskFactory = new TaskFactory(CancellationToken.None, TaskCreationOptions.None, TaskContinuationOptions.None, TaskScheduler.Default);
+
     /// <inheritdoc />
     public virtual bool IsApplicable()
     {
@@ -29,7 +33,7 @@
         {
           try
           {
-            dockerClient.System.PingAsync().GetAwaiter().GetResult();
+            TaskFactory.StartNew(() => dockerClient.System.PingAsync()).Unwrap().GetAwaiter().GetResult();
             return true;
           }
           catch (Exception)

--- a/src/Testcontainers/Builders/TestcontainersBuilderAzuriteExtension.cs
+++ b/src/Testcontainers/Builders/TestcontainersBuilderAzuriteExtension.cs
@@ -58,7 +58,7 @@ namespace DotNet.Testcontainers.Builders
       }
 
       return builder
-        .WithCommand(GetExecutable(configuration))
+        .WithEntrypoint(GetExecutable(configuration))
         .WithCommand(GetEnabledServices(configuration))
         .WithCommand(GetWorkspaceDirectoryPath())
         .WithCommand(GetDebugModeEnabled(configuration))

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -17,7 +17,7 @@ namespace DotNet.Testcontainers.Clients
   /// <inheritdoc cref="ITestcontainersClient" />
   internal sealed class TestcontainersClient : ITestcontainersClient
   {
-    public const string TestcontainersLabel = "testcontainers";
+    public const string TestcontainersLabel = "org.testcontainers";
 
     private readonly string osRootDirectory = Path.GetPathRoot(Directory.GetCurrentDirectory());
 

--- a/src/Testcontainers/Configurations/IOperatingSystem.cs
+++ b/src/Testcontainers/Configurations/IOperatingSystem.cs
@@ -19,6 +19,6 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="path">Path to normalize.</param>
     /// <returns>Normalized path.</returns>
     [PublicAPI]
-    string NormalizePath(string path);
+    string NormalizePath([CanBeNull] string path);
   }
 }

--- a/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
@@ -6,6 +6,8 @@ namespace DotNet.Testcontainers.Configurations
   /// <inheritdoc cref="IImageFromDockerfileConfiguration" />
   internal sealed class ImageFromDockerfileConfiguration : DockerResourceConfiguration, IImageFromDockerfileConfiguration
   {
+    private static readonly IOperatingSystem OS = new Unix();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageFromDockerfileConfiguration" /> class.
     /// </summary>
@@ -36,8 +38,8 @@ namespace DotNet.Testcontainers.Configurations
       : base(dockerEndpointAuthenticationConfiguration, labels)
     {
       this.Image = image;
-      this.Dockerfile = dockerfile;
-      this.DockerfileDirectory = dockerfileDirectory;
+      this.Dockerfile = OS.NormalizePath(dockerfile);
+      this.DockerfileDirectory = OS.NormalizePath(dockerfileDirectory);
       this.DeleteIfExists = deleteIfExists;
       this.BuildArguments = buildArguments;
     }

--- a/src/Testcontainers/Configurations/Unix.cs
+++ b/src/Testcontainers/Configurations/Unix.cs
@@ -55,7 +55,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     public string NormalizePath(string path)
     {
-      return path.Replace('\\', '/');
+      return path?.Replace('\\', '/');
     }
   }
 }

--- a/src/Testcontainers/Configurations/Windows.cs
+++ b/src/Testcontainers/Configurations/Windows.cs
@@ -55,7 +55,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     public string NormalizePath(string path)
     {
-      return path.Replace('/', '\\');
+      return path?.Replace('/', '\\');
     }
   }
 }

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -77,7 +77,7 @@
           foreach (var file in GetFiles(this.dockerfileDirectory.FullName))
           {
             // SharpZipLib drops the root path: https://github.com/icsharpcode/SharpZipLib/pull/582.
-            var relativePath = file.Substring(this.dockerfileDirectory.FullName.Length + 1);
+            var relativePath = file.Substring(this.dockerfileDirectory.FullName.TrimEnd('/', '\\').Length + 1);
 
             if (dockerIgnoreFile.Denies(relativePath))
             {


### PR DESCRIPTION
## What does this PR do?

This PR contains several minor fixes and improvements to increase the Testcontainers for .NET development experience. Some configurations are very strict. This makes it unnecessarily difficult for developers to set up their test environment. These changes will support more variety of configurations.

## Why is it important?

- The `ImageFromDockerfileConfiguration` configuration did not work properly with file paths that contains backward slashes. Especially, on Windows machines backward slashes are common. Supporting backward slashes makes it more convenient for the developers to work with Testcontainesr for .NET.
- It adds the CLI commands to checkout and run the Weather Forecase example immediately. Developers do not need to enter the CLI commands manually anymore.
- It contains an improvement that may fix an issue with the Azurite configuration. Somehow, some Azurite containers response with the wrong service while the connection string is correct. This may relate to a wrong entrypoint.

## Related issues

- Relates #610
- Relates #631
