### PR TITLE
feat(#640): Add WithResourceMapping

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -35,10 +35,10 @@ jobs:
           lfs: true
 
       - name: Cache NuGet Packages
-         uses: actions/cache@v3
-         with:
-           path: ~/.nuget/packages
-           key: ${{ matrix.os }}-nuget-${{ hashFiles('Directory.Build.props') }}
+        uses: actions/cache@v3
+        with:
+          key: ${{ matrix.os }}-nuget-${{ hashFiles('Directory.Build.props') }}
+          path: ~/.nuget/packages
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
@@ -114,10 +114,10 @@ jobs:
         shell: pwsh
 
       - name: Cache NuGet Packages
-         uses: actions/cache@v3
-         with:
-           path: ~/.nuget/packages
-           key: ubuntu-22.04-nuget-${{ hashFiles('Directory.Build.props') }}
+        uses: actions/cache@v3
+        with:
+          key: ubuntu-22.04-nuget-${{ hashFiles('Directory.Build.props') }}
+          path: ~/.nuget/packages
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -34,6 +34,12 @@ jobs:
           clean: true
           lfs: true
 
+      - name: Cache NuGet Packages
+         uses: actions/cache@v3
+         with:
+           path: ~/.nuget/packages
+           key: ${{ matrix.os }}-nuget-${{ hashFiles('Directory.Build.props') }}
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
 
@@ -106,6 +112,12 @@ jobs:
           Get-ChildItem -Path 'test-coverage' -Filter *.xml | % { (Get-Content $_) -Replace '[A-Za-z0-9:\-\/\\]+src', '${{ github.workspace }}/src' | Set-Content $_ }
           Get-ChildItem -Path 'test-coverage' -Filter *.xml | % { (Get-Content $_) -Replace '[A-Za-z0-9:\-\/\\]+tests', '${{ github.workspace }}/tests' | Set-Content $_ }
         shell: pwsh
+
+      - name: Cache NuGet Packages
+         uses: actions/cache@v3
+         with:
+           path: ~/.nuget/packages
+           key: ubuntu-22.04-nuget-${{ hashFiles('Directory.Build.props') }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- 640 Add `ITestcontainersBuilder<TDockerContainer>.WithResourceMapping` to copy files or or any binary contents into the created container even before it is started.
+
 ### Changed
 
 - 642 Expose container port bindings automatically

--- a/build.cake
+++ b/build.cake
@@ -67,8 +67,6 @@ Task("Build")
     Verbosity = param.Verbosity,
     NoRestore = true,
     ArgumentCustomization = args => args
-      .Append("/p:ContinuousIntegrationBuild=true")
-      .Append("/p:EmbedUntrackedSources=true")
       .Append($"/p:TreatWarningsAsErrors={param.IsReleaseBuild.ToString()}")
   });
 });

--- a/build.cake
+++ b/build.cake
@@ -67,6 +67,8 @@ Task("Build")
     Verbosity = param.Verbosity,
     NoRestore = true,
     ArgumentCustomization = args => args
+      .Append("/p:ContinuousIntegrationBuild=true")
+      .Append("/p:EmbedUntrackedSources=true")
       .Append($"/p:TreatWarningsAsErrors={param.IsReleaseBuild.ToString()}")
   });
 });

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -79,6 +79,7 @@ Assert.Equal("42", magicNumber);
 | `WithEnvironment`                       | Sets an environment variable in the container e.g. `-e`, `--env "MAGIC_NUMBER=42"`.                                                    |
 | `WithExposedPort`                       | Exposes a port inside the container e.g. `--expose "80"`.                                                                              |
 | `WithPortBinding`                       | Publishes a container port to the host e.g. `-p`, `--publish "80:80"`.                                                                 |
+| `WithResourceMapping`                   | Copies a file or any binary content into the created container even before it is started.                                              |
 | `WithBindMount`                         | Binds a path of a file or directory into the container e.g. `-v`, `--volume ".:/tmp"`.                                                 |
 | `WithVolumeMount`                       | Mounts a managed volume into the container e.g. `--mount "type=volume,source=my-vol,destination=/tmp"`.                                |
 | `WithTmpfsMount`                        | Mounts a temporary volume into the container e.g. `--mount "type=tmpfs,destination=/tmp"`.                                             |

--- a/src/Testcontainers/Builders/BuildConfiguration.cs
+++ b/src/Testcontainers/Builders/BuildConfiguration.cs
@@ -59,10 +59,12 @@ namespace DotNet.Testcontainers.Builders
     /// </summary>
     /// <param name="next">Changed configuration.</param>
     /// <param name="previous">Previous configuration.</param>
-    /// <typeparam name="T">Type of <see cref="IReadOnlyDictionary{TKey,TValue}" />.</typeparam>
+    /// <typeparam name="TKey">The type of keys in the read-only dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of values in the read-only dictionary.</typeparam>
     /// <returns>An updated configuration.</returns>
-    public static IReadOnlyDictionary<T, T> Combine<T>(IReadOnlyDictionary<T, T> next, IReadOnlyDictionary<T, T> previous)
-      where T : class
+    public static IReadOnlyDictionary<TKey, TValue> Combine<TKey, TValue>(IReadOnlyDictionary<TKey, TValue> next, IReadOnlyDictionary<TKey, TValue> previous)
+      where TKey : class
+      where TValue : class
     {
       if (next == null || previous == null)
       {

--- a/src/Testcontainers/Builders/ITestcontainersBuilder.cs
+++ b/src/Testcontainers/Builders/ITestcontainersBuilder.cs
@@ -174,6 +174,31 @@ namespace DotNet.Testcontainers.Builders
     ITestcontainersBuilder<TDockerContainer> WithPortBinding(string hostPort, string containerPort);
 
     /// <summary>
+    /// Copies the specified host machine file into the created container even before it is started.
+    /// </summary>
+    /// <param name="source">An absolute path or a name value within the host machine.</param>
+    /// <param name="destination">An absolute path as destination in the container.</param>
+    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    [PublicAPI]
+    ITestcontainersBuilder<TDockerContainer> WithResourceMapping(string source, string destination);
+
+    /// <summary>
+    /// Copies the byte array content into the created container even before it is started.
+    /// </summary>
+    /// <param name="resourceContent">Byte array content of the resource mapping.</param>
+    /// <param name="destination">An absolute path as destination in the container.</param>
+    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    [PublicAPI]
+    ITestcontainersBuilder<TDockerContainer> WithResourceMapping(byte[] resourceContent, string destination);
+
+    /// <summary>
+    /// Copies the byte array content of the resource mapping into the created container even before it is started.
+    /// </summary>
+    /// <param name="resourceMapping">Resource mapping.</param>
+    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    ITestcontainersBuilder<TDockerContainer> WithResourceMapping(IResourceMapping resourceMapping);
+
+    /// <summary>
     /// Binds and mounts the specified host machine volume into the Testcontainer.
     /// </summary>
     /// <param name="source">An absolute path or a name value within the host machine.</param>

--- a/src/Testcontainers/Builders/TestcontainersBuilderDatabaseExtension.cs
+++ b/src/Testcontainers/Builders/TestcontainersBuilderDatabaseExtension.cs
@@ -17,6 +17,9 @@ namespace DotNet.Testcontainers.Builders
       builder = configuration.Environments.Aggregate(builder, (current, environment)
         => current.WithEnvironment(environment.Key, environment.Value));
 
+      builder = configuration.ResourceMappings.Values.Aggregate(builder, (current, resourceMapping)
+        => current.WithResourceMapping(resourceMapping));
+
       return builder
         .WithImage(configuration.Image)
         .WithExposedPort(configuration.DefaultPort)

--- a/src/Testcontainers/Clients/DefaultLabels.cs
+++ b/src/Testcontainers/Clients/DefaultLabels.cs
@@ -3,6 +3,7 @@ namespace DotNet.Testcontainers.Clients
   using System;
   using System.Collections.Generic;
   using System.Collections.ObjectModel;
+  using System.Reflection;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
 
@@ -15,7 +16,9 @@ namespace DotNet.Testcontainers.Clients
     private DefaultLabels(Guid resourceReaperSessionId)
       : base(new Dictionary<string, string>
       {
-        { TestcontainersClient.TestcontainersLabel, bool.TrueString },
+        { TestcontainersClient.TestcontainersLabel, bool.TrueString.ToLowerInvariant() },
+        { TestcontainersClient.TestcontainersLangLabel, "dotnet" },
+        { TestcontainersClient.TestcontainersVersionLabel, typeof(DefaultLabels).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion },
         { ResourceReaper.ResourceReaperSessionLabel, resourceReaperSessionId.ToString("D") },
       })
     {

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -20,6 +20,10 @@ namespace DotNet.Testcontainers.Clients
   {
     public const string TestcontainersLabel = "org.testcontainers";
 
+    public const string TestcontainersLangLabel = TestcontainersLabel + ".lang";
+
+    public const string TestcontainersVersionLabel = TestcontainersLabel + ".version";
+
     private readonly string osRootDirectory = Path.GetPathRoot(Directory.GetCurrentDirectory());
 
     private readonly IDockerContainerOperations containers;

--- a/src/Testcontainers/Configurations/Containers/ITestcontainersConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ITestcontainersConfiguration.cs
@@ -85,7 +85,12 @@ namespace DotNet.Testcontainers.Configurations
     IReadOnlyDictionary<string, string> PortBindings { get; }
 
     /// <summary>
-    /// Gets a list of volumes.
+    /// Gets a list of resource mappings.
+    /// </summary>
+    IReadOnlyDictionary<string, IResourceMapping> ResourceMappings { get; }
+
+    /// <summary>
+    /// Gets a list of mounts.
     /// </summary>
     IEnumerable<IMount> Mounts { get; }
 

--- a/src/Testcontainers/Configurations/Containers/TestcontainersConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/TestcontainersConfiguration.cs
@@ -40,7 +40,8 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="labels">The labels.</param>
     /// <param name="exposedPorts">The exposed ports.</param>
     /// <param name="portBindings">The port bindings.</param>
-    /// <param name="mounts">The volumes.</param>
+    /// <param name="resourceMappings">The resource mappings.</param>
+    /// <param name="mounts">The mounts.</param>
     /// <param name="networks">The networks.</param>
     /// <param name="networkAliases">The container network aliases.</param>
     /// <param name="outputConsumer">The output consumer.</param>
@@ -64,6 +65,7 @@ namespace DotNet.Testcontainers.Configurations
       IReadOnlyDictionary<string, string> labels = null,
       IReadOnlyDictionary<string, string> exposedPorts = null,
       IReadOnlyDictionary<string, string> portBindings = null,
+      IReadOnlyDictionary<string, IResourceMapping> resourceMappings = null,
       IEnumerable<IMount> mounts = null,
       IEnumerable<IDockerNetwork> networks = null,
       IEnumerable<string> networkAliases = null,
@@ -89,6 +91,7 @@ namespace DotNet.Testcontainers.Configurations
       this.Environments = environments;
       this.ExposedPorts = exposedPorts;
       this.PortBindings = portBindings;
+      this.ResourceMappings = resourceMappings;
       this.Mounts = mounts;
       this.Networks = networks;
       this.NetworkAliases = networkAliases;
@@ -141,6 +144,9 @@ namespace DotNet.Testcontainers.Configurations
 
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string> PortBindings { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<string, IResourceMapping> ResourceMappings { get; }
 
     /// <inheritdoc />
     public IEnumerable<IMount> Mounts { get; }

--- a/src/Testcontainers/Configurations/Modules/HostedServiceConfiguration.cs
+++ b/src/Testcontainers/Configurations/Modules/HostedServiceConfiguration.cs
@@ -21,6 +21,7 @@ namespace DotNet.Testcontainers.Configurations
       this.Image = image;
       this.DefaultPort = defaultPort;
       this.Port = port;
+      this.ResourceMappings = new Dictionary<string, IResourceMapping>();
       this.Environments = new Dictionary<string, string>();
       this.OutputConsumer = Consume.DoNotConsumeStdoutAndStderr();
       this.WaitStrategy = Wait.ForUnixContainer();
@@ -40,6 +41,12 @@ namespace DotNet.Testcontainers.Configurations
     /// </remarks>
     [PublicAPI]
     public int DefaultPort { get; }
+
+    /// <summary>
+    /// Gets the resource mapping configuration.
+    /// </summary>
+    [PublicAPI]
+    public IDictionary<string, IResourceMapping> ResourceMappings { get; }
 
     /// <summary>
     /// Gets the environment configuration.

--- a/src/Testcontainers/Configurations/Volumes/BinaryResourceMapping.cs
+++ b/src/Testcontainers/Configurations/Volumes/BinaryResourceMapping.cs
@@ -1,0 +1,28 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System.Threading;
+  using System.Threading.Tasks;
+
+  /// <inheritdoc cref="IResourceMapping" />
+  internal class BinaryResourceMapping : FileResourceMapping
+  {
+    private readonly byte[] resourceContent;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BinaryResourceMapping" /> class.
+    /// </summary>
+    /// <param name="resourceContent">The byte array content to map in the container.</param>
+    /// <param name="containerPath">The absolute path of a file to map in the container.</param>
+    public BinaryResourceMapping(byte[] resourceContent, string containerPath)
+      : base(string.Empty, containerPath)
+    {
+      this.resourceContent = resourceContent;
+    }
+
+    /// <inheritdoc />
+    public override Task<byte[]> GetAllBytesAsync(CancellationToken ct = default)
+    {
+      return Task.FromResult(this.resourceContent);
+    }
+  }
+}

--- a/src/Testcontainers/Configurations/Volumes/FileResourceMapping.cs
+++ b/src/Testcontainers/Configurations/Volumes/FileResourceMapping.cs
@@ -1,0 +1,41 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System.IO;
+  using System.Threading;
+  using System.Threading.Tasks;
+
+  /// <inheritdoc cref="IResourceMapping" />
+  internal class FileResourceMapping : IResourceMapping
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileResourceMapping" /> class.
+    /// </summary>
+    /// <param name="hostPath">The absolute path of a file to map on the host system.</param>
+    /// <param name="containerPath">The absolute path of a file to map in the container.</param>
+    public FileResourceMapping(string hostPath, string containerPath)
+    {
+      this.Type = MountType.Bind;
+      this.Source = hostPath;
+      this.Target = containerPath;
+      this.AccessMode = AccessMode.ReadOnly;
+    }
+
+    /// <inheritdoc />
+    public MountType Type { get; }
+
+    /// <inheritdoc />
+    public AccessMode AccessMode { get; }
+
+    /// <inheritdoc />
+    public string Source { get; }
+
+    /// <inheritdoc />
+    public string Target { get; }
+
+    /// <inheritdoc />
+    public virtual Task<byte[]> GetAllBytesAsync(CancellationToken ct = default)
+    {
+      return Task.FromResult(File.ReadAllBytes(this.Source));
+    }
+  }
+}

--- a/src/Testcontainers/Configurations/Volumes/IResourceMapping.cs
+++ b/src/Testcontainers/Configurations/Volumes/IResourceMapping.cs
@@ -1,0 +1,18 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System.Threading;
+  using System.Threading.Tasks;
+
+  /// <summary>
+  /// This class represents a read-only filesystem resource mapping.
+  /// </summary>
+  public interface IResourceMapping : IMount
+  {
+    /// <summary>
+    /// Gets the byte array content of the resource mapping.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the byte array content of the resource mapping has been read.</returns>
+    Task<byte[]> GetAllBytesAsync(CancellationToken ct = default);
+  }
+}

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/CopyResourceMappingContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/CopyResourceMappingContainerTest.cs
@@ -1,0 +1,67 @@
+namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
+{
+  using System;
+  using System.IO;
+  using System.Linq;
+  using System.Text;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Containers;
+  using DotNet.Testcontainers.Tests.Fixtures;
+  using Xunit;
+
+  public sealed class CopyResourceMappingContainerTest : IAsyncLifetime, IDisposable
+  {
+    private const string ResourceMappingContent = "👋";
+
+    private readonly FileStream fileStream = new(Path.Combine(Path.GetTempPath(), Path.GetTempFileName()), FileMode.Create, FileAccess.Write, FileShare.Read, ResourceMappingContent.Length, FileOptions.DeleteOnClose);
+
+    private readonly string fileResourceMappingFilePath = Path.Combine("/tmp", Path.GetTempFileName());
+
+    private readonly string binaryResourceMappingFilePath = Path.Combine("/tmp", Path.GetTempFileName());
+
+    private readonly IDockerContainer container;
+
+    public CopyResourceMappingContainerTest()
+    {
+      this.container = new TestcontainersBuilder<TestcontainersContainer>()
+        .WithImage("alpine")
+        .WithEntrypoint(KeepTestcontainersUpAndRunning.Command)
+        .WithResourceMapping(this.fileStream.Name, this.fileResourceMappingFilePath)
+        .WithResourceMapping(Encoding.Default.GetBytes(ResourceMappingContent), this.binaryResourceMappingFilePath)
+        .Build();
+    }
+
+    public Task InitializeAsync()
+    {
+      this.fileStream.Write(Encoding.Default.GetBytes(ResourceMappingContent));
+      this.fileStream.Flush();
+      return this.container.StartAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+      this.fileStream.Dispose();
+      return this.container.DisposeAsync().AsTask();
+    }
+
+    public void Dispose()
+    {
+    }
+
+    [Fact]
+    public async Task ReadExistingFile()
+    {
+      // Given
+      var resourceMappingBytes = await Task.WhenAll(new[] { this.fileResourceMappingFilePath, this.binaryResourceMappingFilePath }
+          .Select(filePath => this.container.ReadFileAsync(filePath)))
+        .ConfigureAwait(false);
+
+      // When
+      var resourceMappingContent = resourceMappingBytes.Select(Encoding.Default.GetString);
+
+      // Then
+      Assert.All(resourceMappingContent, item => Assert.Equal(ResourceMappingContent, item));
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/ReadFileFromContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/ReadFileFromContainerTest.cs
@@ -32,7 +32,7 @@
         .ConfigureAwait(false);
 
       // Then
-      Assert.Equal(dayOfWeek, Encoding.ASCII.GetString(fileContent).TrimEnd());
+      Assert.Equal(dayOfWeek, Encoding.Default.GetString(fileContent).TrimEnd());
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

Adds `WithResourceMapping` to the Docker container builder pattern. The builder method allows to copy files or any binary contents to a created Docker container instance (that is **not** running).

## Why is it important?

Some containers require certain files or configurations before they get started. `WithResourceMapping` allows to add these files or configurations up front. E.g. we copy the Elasticsearch JVM options to the container before it starts.

## Related issues

- Closes #640

## Follow-ups

Add a more efficient way to bulk copy multiple resource mappings.
