### PR TITLE
docs: Add how to configure a container start and apps or services

### DIFF
--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -6,7 +6,7 @@ Testcontainers' generic container support offers the greatest flexibility and ma
 
 Both `ENTRYPOINT` and `CMD` allows you to configure an executable and parameters, that a container runs at the start. By default, a container will run whatever `ENTRYPOINT` or `CMD` is specified in the Docker container image. At least one of both configurations is necessary. The container builder implementation supports `WithEntrypoint(params string[])` and `WithCommand(params string[])` to set or override the executable. Ideally, the `ENTRYPOINT` should set the container's executable, whereas the `CMD` sets the default arguments for the `ENTRYPOINT`.
 
-Instead of running NGINX, the following container configuration overrides the default start and just test the NGINX configuration file.
+Instead of running the NGINX application, the following container configuration overrides the default start procedure of the image and just tests the NGINX configuration file.
 
 ```csharp
 _ = new TestcontainersBuilder<TestcontainersContainer>()

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -32,7 +32,7 @@ _ = new TestcontainersBuilder<TestcontainersContainer>()
   .WithResourceMapping("certificate.crt", "/app/certificate.crt")
 ```
 
-`WithBindMount(string, string)` is another option to provide access to directories or files. It mounts a host directory or file inside the container. Note, this does not follow our best practices. Host paths differ from environments and may not be available on every system, e.g. CI.
+`WithBindMount(string, string)` is another option to provide access to directories or files. It mounts a host directory or file into the container. Note, this does not follow our best practices. Host paths differ between environments and may not be available on every system or Docker setup, e.g. CI.
 
 ## Examples
 

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -2,6 +2,36 @@
 
 Testcontainers' generic container support offers the greatest flexibility and makes it easy to use virtually any container image in the context of a temporary test environment. To interact or exchange data with a container, Testcontainers provides  `TestcontainersBuilder<TDockerContainer>` to configure and create the resource.
 
+## Configure container start
+
+Both `ENTRYPOINT` and `CMD` allows you to configure an executable, that a container runs at the start. By default a container will run whatever `ENTRYPOINT` or `CMD` is specified in the Docker container image. At least one of both configurations is necessary. The container builder implementation supports `WithEntrypoint(params string[])` and `WithCommand(params string[])` to set or override the executable. The `ENTRYPOINT` should set the containers executable, where the `CMD` set the default arguments for an `ENTRYPOINT`.
+
+Instead of running NGINX, the following container configuration overrides the default start and just test the NGINX configuration file.
+
+```csharp
+_ = new TestcontainersBuilder<TestcontainersContainer>()
+  .WithEntrypoint("nginx")
+  .WithCommand("-t")
+```
+
+## Configure container app or service
+
+Apps or services running inside a container are usually configured either with environment variables or configuration files. `WithEnvironment(string, string)` sets an environment variable, while `WithResourceMapping(string, string)` copies a file into a container before it starts. This covers common use cases among many .NET applications.
+
+!!!tip
+
+    The majority of builder methods are overloaded and have different parameters to set configurations.
+
+To configure an ASP.NET Core application, either one or both can be used.
+
+```csharp
+_ = new TestcontainersBuilder<TestcontainersContainer>()
+  .WithEnvironment("ASPNETCORE_URLS", "https://+")
+  .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Path", "/app/certificate.crt")
+  .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Password", "password")
+  .WithResourceMapping("certificate.crt", "/app/certificate.crt")
+```
+
 ## Examples
 
 An NGINX container that binds the HTTP port to a random host port and hosts static content. The example connects to the web server and checks the HTTP status code.

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -22,7 +22,7 @@ Apps or services running inside a container are usually configured either with e
 
     The majority of builder methods are overloaded and have different parameters to set configurations.
 
-To configure an ASP.NET Core application, either one or both can be used.
+To configure an ASP.NET Core application, either one or both mechanisms can be used.
 
 ```csharp
 _ = new TestcontainersBuilder<TestcontainersContainer>()

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -4,7 +4,7 @@ Testcontainers' generic container support offers the greatest flexibility and ma
 
 ## Configure container start
 
-Both `ENTRYPOINT` and `CMD` allows you to configure an executable, that a container runs at the start. By default a container will run whatever `ENTRYPOINT` or `CMD` is specified in the Docker container image. At least one of both configurations is necessary. The container builder implementation supports `WithEntrypoint(params string[])` and `WithCommand(params string[])` to set or override the executable. The `ENTRYPOINT` should set the containers executable, where the `CMD` set the default arguments for an `ENTRYPOINT`.
+Both `ENTRYPOINT` and `CMD` allows you to configure an executable and parameters, that a container runs at the start. By default, a container will run whatever `ENTRYPOINT` or `CMD` is specified in the Docker container image. At least one of both configurations is necessary. The container builder implementation supports `WithEntrypoint(params string[])` and `WithCommand(params string[])` to set or override the executable. Ideally, the `ENTRYPOINT` should set the container's executable, whereas the `CMD` sets the default arguments for the `ENTRYPOINT`.
 
 Instead of running NGINX, the following container configuration overrides the default start and just test the NGINX configuration file.
 

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -32,6 +32,8 @@ _ = new TestcontainersBuilder<TestcontainersContainer>()
   .WithResourceMapping("certificate.crt", "/app/certificate.crt")
 ```
 
+`WithBindMount(string, string)` is another option to provide access to directories or files. It mounts a host directory or file inside the container. Note, this does not follow our best practices. Host paths differ from environments and may not be available on every system, e.g. CI.
+
 ## Examples
 
 An NGINX container that binds the HTTP port to a random host port and hosts static content. The example connects to the web server and checks the HTTP status code.


### PR DESCRIPTION
## What does this PR do?

Extends the .NET documentation and explains the basic features of how to configure a container start, apps, and services.

## Why is it important?

The documentation does not cover these topics explicitly. It helps developers to understand the features of Testcontainers and how to implement them in their use cases.

## Related issues

\-