### PR TITLE
refactor: Normalize container paths to forward slashes

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -104,7 +104,7 @@ Task("Sonar-Begin")
     Key = param.SonarQubeCredentials.Key,
     Login = param.SonarQubeCredentials.Token,
     Organization = param.SonarQubeCredentials.Organization,
-    Branch = param.IsPullRequest ? null : param.Branch, // A pull request analysis can not have the branch analysis parameter 'sonar.branch.name'.
+    Branch = param.IsPullRequest ? null : param.Branch, // A pull request analysis cannot have the branch analysis parameter 'sonar.branch.name'.
     UseCoreClr = true,
     Silent = true,
     Version = param.Version.Substring(0, 5),

--- a/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
@@ -6,8 +6,6 @@ namespace DotNet.Testcontainers.Configurations
   /// <inheritdoc cref="IImageFromDockerfileConfiguration" />
   internal sealed class ImageFromDockerfileConfiguration : DockerResourceConfiguration, IImageFromDockerfileConfiguration
   {
-    private static readonly IOperatingSystem OS = new Unix();
-
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageFromDockerfileConfiguration" /> class.
     /// </summary>
@@ -38,8 +36,8 @@ namespace DotNet.Testcontainers.Configurations
       : base(dockerEndpointAuthenticationConfiguration, labels)
     {
       this.Image = image;
-      this.Dockerfile = OS.NormalizePath(dockerfile);
-      this.DockerfileDirectory = OS.NormalizePath(dockerfileDirectory);
+      this.Dockerfile = dockerfile;
+      this.DockerfileDirectory = dockerfileDirectory;
       this.DeleteIfExists = deleteIfExists;
       this.BuildArguments = buildArguments;
     }

--- a/src/Testcontainers/Configurations/Modules/Databases/ElasticsearchTestcontainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Modules/Databases/ElasticsearchTestcontainerConfiguration.cs
@@ -12,7 +12,7 @@ namespace DotNet.Testcontainers.Configurations
   [PublicAPI]
   public class ElasticsearchTestcontainerConfiguration : TestcontainerDatabaseConfiguration
   {
-    private const string ElasticsearchVmOptionsDirectoryPath = "/usr/share/elasticsearch/config/jvm.options.d";
+    private const string ElasticsearchVmOptionsDirectoryPath = "/usr/share/elasticsearch/config/jvm.options.d/";
 
     private const string ElasticsearchDefaultMemoryVmOptionFileName = "elasticsearch-default-memory-vm.options";
 

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -58,7 +58,7 @@ namespace DotNet.Testcontainers.Configurations
     /// </summary>
     /// <remarks>
     /// The <see cref="ResourceReaper" /> might not be able to connect to Ryuk on Docker Desktop for Windows.
-    /// Assigning a random port might run into the excluded port range. The container starts, but we can not establish a TCP connection:
+    /// Assigning a random port might run into the excluded port range. The container starts, but we cannot establish a TCP connection:
     /// - https://github.com/docker/for-win/issues/3171.
     /// - https://github.com/docker/for-win/issues/11584.
     /// </remarks>

--- a/src/Testcontainers/Guard.Null.cs
+++ b/src/Testcontainers/Guard.Null.cs
@@ -44,7 +44,7 @@ namespace DotNet.Testcontainers
     {
       if (!argument.HasValue())
       {
-        throw new ArgumentNullException(argument.Name, $"{argument.Name} can not be null.");
+        throw new ArgumentNullException(argument.Name, $"{argument.Name} cannot be null.");
       }
 
       return ref argument;

--- a/src/Testcontainers/Guard.String.cs
+++ b/src/Testcontainers/Guard.String.cs
@@ -40,7 +40,7 @@ namespace DotNet.Testcontainers
     {
       if (argument.Value.Length == 0)
       {
-        throw new ArgumentException($"{argument.Name} can not be empty.", argument.Name);
+        throw new ArgumentException($"{argument.Name} cannot be empty.", argument.Name);
       }
 
       return ref argument;
@@ -58,7 +58,7 @@ namespace DotNet.Testcontainers
     {
       if (argument.Value.Any(char.IsUpper))
       {
-        throw new ArgumentException(argument.Name, $"{argument.Name} can not have uppercase characters.");
+        throw new ArgumentException(argument.Name, $"{argument.Name} cannot have uppercase characters.");
       }
 
       return ref argument;

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -66,10 +66,10 @@ namespace DotNet.Testcontainers
       = LoggerMessage.Define<string>(LogLevel.Information, default, "Delete Docker volume {Name}");
 
     private static readonly Action<ILogger, Guid, Exception> _CanNotGetResourceReaperEndpoint
-      = LoggerMessage.Define<Guid>(LogLevel.Debug, default, "Can not get resource reaper {Id} endpoint");
+      = LoggerMessage.Define<Guid>(LogLevel.Debug, default, "Cannot get resource reaper {Id} endpoint");
 
     private static readonly Action<ILogger, Guid, string, Exception> _CanNotConnectToResourceReaper
-      = LoggerMessage.Define<Guid, string>(LogLevel.Debug, default, "Can not connect to resource reaper {Id} at {Endpoint}");
+      = LoggerMessage.Define<Guid, string>(LogLevel.Debug, default, "Cannot connect to resource reaper {Id} at {Endpoint}");
 
     private static readonly Action<ILogger, Guid, string, Exception> _LostConnectionToResourceReaper
       = LoggerMessage.Define<Guid, string>(LogLevel.Debug, default, "Lost connection to resource reaper {Id} at {Endpoint}");


### PR DESCRIPTION
## What does this PR do?

It normalizes some paths to forward slashes.

## Why is it important?

Interacting with most containers or f.g. tarballs requires paths to use a forward slash as path separator. Running Testcontainers on Windows combines paths with backward slashes. This is not always compatible (like in the mentioned cases above). Replace backward with forward slashes if it is required.

This PR contains some changes that do not relate to the description above regarding consistent spelling and refactoring a test.

## Related issues

\-