### PR TITLE
docs: Add network communication

### DIFF
--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -30,28 +30,30 @@ Assert.Equal(HttpStatusCode.OK, httpResponseMessage.StatusCode);
 This example creates and starts a container, that listens for incoming TCP connections and returns the magic number 42.
 
 ```csharp
+const string MagicNumber = "42";
+
 const ushort MagicNumberPort = 80;
 
-var magicNumberContainer = new TestcontainersBuilder<TestcontainersContainer>()
+var deepThoughtContainer = new TestcontainersBuilder<TestcontainersContainer>()
   .WithName(Guid.NewGuid().ToString("D"))
   .WithImage("alpine")
   .WithExposedPort(MagicNumberPort)
   .WithPortBinding(MagicNumberPort, true)
-  .WithEnvironment("MAGIC_NUMBER", "42")
+  .WithEnvironment("MAGIC_NUMBER", MagicNumber)
   .WithEntrypoint("/bin/sh", "-c")
-  .WithCommand("while true; do echo \"$MAGIC_NUMBER\" | nc -l -p 80; done")
+  .WithCommand($"while true; do echo \"$MAGIC_NUMBER\" | nc -l -p {MagicNumberPort}; done")
   .Build();
 
-await magicNumberContainer.StartAsync()
+await deepThoughtContainer.StartAsync()
   .ConfigureAwait(false);
 
-using var magicNumberClient = new TcpClient(magicNumberContainer.Hostname, magicNumberContainer.GetMappedPublicPort(MagicNumberPort));
+using var magicNumberClient = new TcpClient(deepThoughtContainer.Hostname, deepThoughtContainer.GetMappedPublicPort(MagicNumberPort));
 using var magicNumberReader = new StreamReader(magicNumberClient.GetStream());
 
 var magicNumber = await magicNumberReader.ReadLineAsync()
   .ConfigureAwait(false);
 
-Assert.Equal("42", magicNumber);
+Assert.Equal(MagicNumber, magicNumber);
 ```
 
 !!!tip

--- a/docs/api/create_docker_network.md
+++ b/docs/api/create_docker_network.md
@@ -1,28 +1,71 @@
-# Creating a network
+# Network communication
 
-Testcontainers for .NET uses the builder design pattern to configure, create and delete Docker resources. It prepares and initializes your test environment and disposes of everything after your tests are finished — whether the tests are successful or not. To create a docker network use `TestcontainersNetworkBuilder`.
+There are two common cases to set up a communication with containers or between containers. The first case is simple and does not require additional configurations. The host that runs the test (test process) resolves the container address from the running container with the `_container.Hostname` property.
 
-## Examples
+!!! warning
 
-Builds and create a new docker network.
+    Do not use `localhost`, `127.0.0.1` or any other fix address to access the container. The address varies according to the environment.
+
+To access apps or services running inside the container behind a certain port, expose and bind the container port to a random host port with `_builder.WithPortBinding(ushort, bool)` and resolve it with `_container.GetMappedPublicPort(ushort)`. It is recommended to use the `Hostname` property and `GetMappedPublicPort(ushort)` together when constructing addresses:
 
 ```csharp
-var network = new TestcontainersNetworkBuilder()
-	.WithName(Guid.NewGuid().ToString("D"))
-	.WithDriver(NetworkDriver.Bridge)
-	.Build();
+_ = new UriBuilder("tcp", _container.Hostname, _container.GetMappedPublicPort(2375));
+```
 
-await network.CreateAsync();
+This is considered a best practice and prevents port collisions.
+
+## Custom network
+
+A more advanced case, places one or more containers on custom networks. The communication between those containers won't require exposing ports through the host anymore. To configure and create Docker networks use `TestcontainersNetworkBuilder`. The following example creates a network and assigns it to two containers. The second container establishes a network connection to Deep Thought by using its network alias and receives the magic number `42`.
+
+```csharp
+const string MagicNumber = "42";
+
+const string MagicNumberHost = "deep-thought";
+
+const ushort MagicNumberPort = 80;
+
+var network = new TestcontainersNetworkBuilder()
+  .WithName(Guid.NewGuid().ToString("D"))
+  .Build();
+
+var deepThoughtContainer = new TestcontainersBuilder<TestcontainersContainer>()
+  .WithName(Guid.NewGuid().ToString("D"))
+  .WithImage("alpine")
+  .WithEnvironment("MAGIC_NUMBER", MagicNumber)
+  .WithEntrypoint("/bin/sh", "-c")
+  .WithCommand($"while true; do echo \"$MAGIC_NUMBER\" | nc -l -p {MagicNumberPort}; done")
+  .WithNetwork(network)
+  .WithNetworkAliases(MagicNumberHost)
+  .Build();
+
+var ultimateQuestionContainer = new TestcontainersBuilder<TestcontainersContainer>()
+  .WithName(Guid.NewGuid().ToString("D"))
+  .WithImage("alpine")
+  .WithEntrypoint("top")
+  .WithNetwork(network)
+  .Build();
+
+await network.CreateAsync()
+  .ConfigureAwait(false);
+
+await Task.WhenAll(deepThoughtContainer.StartAsync(), ultimateQuestionContainer.StartAsync())
+  .ConfigureAwait(false);
+
+var execResult = await ultimateQuestionContainer.ExecAsync(new[] { "nc", MagicNumberHost, MagicNumberPort.ToString(CultureInfo.InvariantCulture) })
+  .ConfigureAwait(false);
+
+Assert.Equal(MagicNumber, execResult.Stdout.Trim());
 ```
 
 ## Supported commands
 
-| Builder method                | Description                                                                                                          |
-|-------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| `WithCleanUp`                 | Will remove the network automatically after all tests have been run.                                                 |
-| `WithDockerEndpoint`          | Sets the Docker daemon socket to connect to.                                                                         |
-| `WithDriver`                  | Sets the driver of the Docker network e.g `-d`, `--driver=bridge`.                                                   |
-| `WithLabel`                   | Applies metadata to the network e.g. `--label "testcontainers=awesome"`.                                             |
-| `WithName`                    | Sets the network name e.g. `docker network create MyName`.                                                           |
-| `WithOption`                  | Sets additional options of the network e.g. `-o`, `--opt "com.docker.network.bridge.host_binding_ipv4"="172.19.0.1"` |
-| `WithResourceReaperSessionId` | Assigns a Resource Reaper session id to the network. The assigned Resource Reaper takes care of the cleanup.         |
+| Builder method                | Description                                                                                                |
+|-------------------------------|------------------------------------------------------------------------------------------------------------|
+| `WithDockerEndpoint`          | Sets the Docker daemon socket to connect to.                                                               |
+| `WithCleanUp`                 | Will remove the network automatically after all tests have been run.                                       |
+| `WithLabel`                   | Applies metadata to the network e.g. `-l`, `--label "testcontainers=awesome"`.                             |
+| `WithResourceReaperSessionId` | Assigns a Resource Reaper session id to the image. The assigned Resource Reaper takes care of the cleanup. |
+| `WithName`                    | Sets the network name e.g. `docker network create "testcontainers"`.                                       |
+| `WithDriver`                  | Sets the network driver e.g. `-d`, `--driver "bridge"`                                                     |
+| `WithOption`                  | Adds a driver specific option `-o`, `--opt "com.docker.network.driver.mtu=1350"`                           |

--- a/examples/WeatherForecast/README.md
+++ b/examples/WeatherForecast/README.md
@@ -3,6 +3,7 @@
 This example builds and ships a Blazor application in a Docker image build, runs a Docker container and executes tests against a running instance of the application. Testcontainers for .NET takes care of the Docker image build and the Docker container that hosts the application. Spin up as much as containers as you like and run your tests heavily in parallel. Checkout and run the tests on your machine:
 
 ```console
+git lfs version
 git clone git@github.com:testcontainers/testcontainers-dotnet.git
 cd ./testcontainers-dotnet/examples/WeatherForecast/
 dotnet build WeatherForecast.sln


### PR DESCRIPTION
## What does this PR do?

Extends the .NET documentation and explains the basic features of how to communicate with containers incl. of how to create networks, etc.

## Why is it important?

The documentation does not cover these topics explicitly. It helps developers to understand the features of Testcontainers and how to implement them in their use cases.

## Related issues

\-