### PR TITLE
refactor: Richer error when docker is not found (#664)

### DIFF
--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -20,14 +20,13 @@ namespace DotNet.Testcontainers.Configurations
   {
     private static readonly IDockerImage RyukContainerImage = new DockerImage("testcontainers/ryuk:0.3.4");
 
-    private static readonly IDockerEndpointAuthenticationConfiguration DockerEndpointAuthConfig =
-      new IDockerEndpointAuthenticationProvider[]
+    private static readonly IDockerEndpointAuthenticationConfiguration DockerEndpointAuthConfig;
+
+    static TestcontainersSettings()
+    {
+      var authProviderConfig = new IDockerEndpointAuthenticationProvider[]
         {
-          new MTlsEndpointAuthenticationProvider(),
-          new TlsEndpointAuthenticationProvider(),
-          new EnvironmentEndpointAuthenticationProvider(),
-          new NpipeEndpointAuthenticationProvider(),
-          new UnixEndpointAuthenticationProvider(),
+          new MTlsEndpointAuthenticationProvider(), new TlsEndpointAuthenticationProvider(), new EnvironmentEndpointAuthenticationProvider(), new NpipeEndpointAuthenticationProvider(), new UnixEndpointAuthenticationProvider(),
         }
         .AsParallel()
         .Where(authProvider => authProvider.IsApplicable())
@@ -35,8 +34,12 @@ namespace DotNet.Testcontainers.Configurations
         .Select(authProvider => authProvider.GetAuthConfig())
         .FirstOrDefault();
 
-    static TestcontainersSettings()
-    {
+      if (authProviderConfig == null)
+      {
+        throw new InvalidOperationException("Unable to find docker daemon. Is it running?");
+      }
+
+      DockerEndpointAuthConfig = authProviderConfig;
     }
 
     /// <summary>


### PR DESCRIPTION
As brought up in #664. When you run testcontainers and docker isn't running you get an error that is not helpful.

The exact message is based on my own limited understanding of what the code is doing 🤷‍♂️ . Anything is better than "Sequence contains no elements."