### PR TITLE
chore: Use TargetFrameworks (plural) to write the output to its corresponding target framework subdirectory

### DIFF
--- a/examples/WeatherForecast/Directory.Build.props
+++ b/examples/WeatherForecast/Directory.Build.props
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
+    <!-- https://github.com/dotnet/sdk/issues/17645 -->
+    <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <SolutionDir Condition=" '$(SolutionDir)' == '' ">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), WeatherForecast.sln))/</SolutionDir>
     <BuildDir>$(SolutionDir)build/</BuildDir>
     <BaseIntermediateOutputPath>$(BuildDir)obj/$(MSBuildProjectName)</BaseIntermediateOutputPath>

--- a/examples/WeatherForecast/src/WeatherForecast/WeatherForecast.csproj
+++ b/examples/WeatherForecast/src/WeatherForecast/WeatherForecast.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3"/>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
@@ -15,7 +15,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- https://learn.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-6.0#basic-tests-with-the-default-webapplicationfactory-1 -->
-    <InternalsVisibleTo Include="WeatherForecast.InProcess.Test" />
+    <InternalsVisibleTo Include="WeatherForecast.InProcess.Test"/>
   </ItemGroup>
   <ItemGroup>
     <None Update="certificate.crt" Visible="false">

--- a/examples/WeatherForecast/tests/WeatherForecast.InProcess.Test/WeatherForecast.InProcess.Test.csproj
+++ b/examples/WeatherForecast/tests/WeatherForecast.InProcess.Test/WeatherForecast.InProcess.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3"/>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations"/>

--- a/examples/WeatherForecast/tests/WeatherForecast.Test/WeatherForecast.Test.csproj
+++ b/examples/WeatherForecast/tests/WeatherForecast.Test/WeatherForecast.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3"/>
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations"/>

--- a/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
+++ b/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
+++ b/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
     <Configurations>Debug;Release</Configurations>


### PR DESCRIPTION
## What does this PR do?

Updates the C# project files (build configuration) and enables the common output directory property.

## Why is it important?

If the target framework property is singular, the build won't write the output to the corresponding target framework subdirectory. To write all files consistent to the target framework subdirectory, we use the plural: `TargetFrameworks`.

**Rebuilding** the example project may fail, due to a flaw in the .NET SDK. Projects that write their output to the same directory are not able to copy certain files like `*.deps.json` to the directory anymore (https://github.com/dotnet/sdk/issues/17645). 

## Related issues

\- 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
