### PR TITLE
fix: Rename coverage.json to coverage.net6.0.json to merge with the correct file

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -15,9 +15,8 @@
     <!-- Unit and integration test dependencies: -->
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Update="Microsoft.Extensions.Hosting" Version="3.1.23" />
-    <PackageReference Update="coverlet.msbuild" Version="3.1.2" />
+    <PackageReference Update="coverlet.msbuild" Version="3.2.0" />
     <PackageReference Update="FluentAssertions" Version="5.10.3" />
-    <PackageReference Update="Moq" Version="4.18.2" />
     <PackageReference Update="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Update="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Update="Serilog.Sinks.Console" Version="4.0.1" />

--- a/build.cake
+++ b/build.cake
@@ -89,7 +89,7 @@ Task("Tests")
         .Append("/p:Platform=AnyCPU")
         .Append("/p:CollectCoverage=true")
         .Append("/p:CoverletOutputFormat=\"json%2copencover\"") // https://github.com/coverlet-coverage/coverlet/pull/220#issuecomment-431507570.
-        .Append($"/p:MergeWith=\"{MakeAbsolute(param.Paths.Directories.TestCoverageDirectoryPath)}/coverage.json\"")
+        .Append($"/p:MergeWith=\"{MakeAbsolute(param.Paths.Directories.TestCoverageDirectoryPath)}/coverage.net6.0.json\"")
         .Append($"/p:CoverletOutput=\"{MakeAbsolute(param.Paths.Directories.TestCoverageDirectoryPath)}/\"")
     });
   }

--- a/src/Testcontainers/Guard.Null.cs
+++ b/src/Testcontainers/Guard.Null.cs
@@ -67,7 +67,7 @@ namespace DotNet.Testcontainers
         return ref argument;
       }
 
-      const string message = "Cannot detect the Docker endpoint. Use either the environment variables or the ~/.testcontainers.properties file to customize your configuration:\nhttps://www.testcontainers.org/features/configuration/#customizing-docker-host-detection";
+      const string message = "Cannot detect the Docker endpoint. Use either the environment variables or the ~/.testcontainers.properties file to customize your configuration:\nhttps://dotnet.testcontainers.org/custom_configuration/";
       throw new ArgumentNullException(argument.Name, message);
     }
   }

--- a/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
+++ b/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="coverlet.msbuild" />
-    <PackageReference Include="Moq" />
     <PackageReference Include="Serilog.Extensions.Logging" />
     <PackageReference Include="Serilog.Settings.Configuration" />
     <PackageReference Include="Serilog.Sinks.Console" />

--- a/tests/Testcontainers.Tests/Unit/Clients/TestcontainersConfigurationConverterTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Clients/TestcontainersConfigurationConverterTest.cs
@@ -4,12 +4,11 @@ namespace DotNet.Testcontainers.Tests.Unit
   using System.Linq;
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Configurations;
-  using Moq;
   using Xunit;
 
   public static class TestcontainersConfigurationConverterTest
   {
-    private const string Port = "7878";
+    private const string Port = "2375";
 
     public sealed class ExposedPorts
     {
@@ -17,15 +16,10 @@ namespace DotNet.Testcontainers.Tests.Unit
       public void ShouldAddTcpPortSuffix()
       {
         // Given
-        var containerConfiguration = new Mock<ITestcontainersConfiguration>();
-        containerConfiguration.Setup(config => config.ExposedPorts)
-          .Returns(new Dictionary<string, string> { { Port, null } });
+        var containerConfiguration = new TestcontainersConfiguration(exposedPorts: new Dictionary<string, string> { { Port, null } });
 
         // When
-        var exposedPort = new TestcontainersConfigurationConverter(containerConfiguration.Object)
-          .ExposedPorts
-          .Single()
-          .Key;
+        var exposedPort = new TestcontainersConfigurationConverter(containerConfiguration).ExposedPorts.Single().Key;
 
         // Then
         Assert.Equal($"{Port}/tcp", exposedPort);
@@ -40,15 +34,10 @@ namespace DotNet.Testcontainers.Tests.Unit
         // Given
         var qualifiedPort = $"{Port}/{portSuffix}";
 
-        var containerConfiguration = new Mock<ITestcontainersConfiguration>();
-        containerConfiguration.Setup(config => config.ExposedPorts)
-          .Returns(new Dictionary<string, string> { { qualifiedPort, null } });
+        var containerConfiguration = new TestcontainersConfiguration(exposedPorts: new Dictionary<string, string> { { qualifiedPort, null } });
 
         // When
-        var exposedPort = new TestcontainersConfigurationConverter(containerConfiguration.Object)
-          .ExposedPorts
-          .Single()
-          .Key;
+        var exposedPort = new TestcontainersConfigurationConverter(containerConfiguration).ExposedPorts.Single().Key;
 
         // Then
         Assert.Equal($"{Port}/{portSuffix}".ToLowerInvariant(), exposedPort);
@@ -61,15 +50,10 @@ namespace DotNet.Testcontainers.Tests.Unit
       public void ShouldAddTcpPortSuffix()
       {
         // Given
-        var containerConfiguration = new Mock<ITestcontainersConfiguration>();
-        containerConfiguration.Setup(config => config.PortBindings)
-          .Returns(new Dictionary<string, string> { { Port, Port } });
+        var containerConfiguration = new TestcontainersConfiguration(portBindings: new Dictionary<string, string> { { Port, Port } });
 
         // When
-        var portBinding = new TestcontainersConfigurationConverter(containerConfiguration.Object)
-          .PortBindings
-          .Single()
-          .Key;
+        var portBinding = new TestcontainersConfigurationConverter(containerConfiguration).PortBindings.Single().Key;
 
         // Then
         Assert.Equal($"{Port}/tcp", portBinding);
@@ -84,15 +68,10 @@ namespace DotNet.Testcontainers.Tests.Unit
         // Given
         var qualifiedPort = $"{Port}/{portSuffix}";
 
-        var containerConfiguration = new Mock<ITestcontainersConfiguration>();
-        containerConfiguration.Setup(config => config.PortBindings)
-          .Returns(new Dictionary<string, string> { { qualifiedPort, Port } });
+        var containerConfiguration = new TestcontainersConfiguration(portBindings: new Dictionary<string, string> { { qualifiedPort, Port } });
 
         // When
-        var portBinding = new TestcontainersConfigurationConverter(containerConfiguration.Object)
-          .PortBindings
-          .Single()
-          .Key;
+        var portBinding = new TestcontainersConfigurationConverter(containerConfiguration).PortBindings.Single().Key;
 
         // Then
         Assert.Equal($"{Port}/{portSuffix}".ToLowerInvariant(), portBinding);


### PR DESCRIPTION
## What does this PR do?

Fixes a regression of #667. Since we changed the target framework property, the name of the coverage files has changed.

In addition to that, I removed a mock framework. We don't need it, we can test it with real dependencies.

## Why is it important?

The coverage files are no longer merged and Sonar shows an incorrect test coverage.

## Related issues

- Relates #667

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
