### PR TITLE
Minor fixes to cake scripts

### DIFF
--- a/.cake-scripts/parameters.cake
+++ b/.cake-scripts/parameters.cake
@@ -23,7 +23,7 @@ internal sealed class BuildParameters
   public bool IsReleaseBuild { get; private set; }
   public bool IsPullRequest { get; private set; }
   public bool ShouldPublish { get; private set; }
-  public DotNetCoreVerbosity Verbosity { get; private set; }
+  public DotNetVerbosity Verbosity { get; private set; }
   public BuildCredentials CodeSigningCertificateCredentials { get; private set; }
   public SonarQubeCredentials SonarQubeCredentials { get; private set; }
   public NuGetCredentials NuGetCredentials { get; private set; }
@@ -53,7 +53,7 @@ internal sealed class BuildParameters
       IsReleaseBuild = !buildInformation.IsLocalBuild && buildInformation.IsReleaseBuild,
       IsPullRequest = buildInformation.IsPullRequest,
       ShouldPublish = !buildInformation.IsLocalBuild && buildInformation.ShouldPublish,
-      Verbosity = DotNetCoreVerbosity.Quiet,
+      Verbosity = DotNetVerbosity.Quiet,
       CodeSigningCertificateCredentials = BuildCredentials.GetCodeSigningCertificateCredentials(context),
       SonarQubeCredentials = SonarQubeCredentials.GetSonarQubeCredentials(context),
       NuGetCredentials = NuGetCredentials.GetNuGetCredentials(context),

--- a/.cake-scripts/version.cake
+++ b/.cake-scripts/version.cake
@@ -1,3 +1,5 @@
+#addin nuget:file:../.cake-tools/Addins/?package=Cake.Git
+
 internal sealed class BuildInformation
 {
   private BuildInformation()

--- a/.cake-scripts/version.cake
+++ b/.cake-scripts/version.cake
@@ -1,4 +1,4 @@
-#addin nuget:file:../.cake-tools/Addins/?package=Cake.Git
+#addin nuget:?package=Cake.Git&version=2.0.0
 
 internal sealed class BuildInformation
 {


### PR DESCRIPTION
I was running into a few intellisense errors when developing locally for the following cake scripts: `version.cake`, `parameters.cake`

- Add package reference to local `Cake.Git` in dependent script to pick up intellisense for `ICakeContext:GitBranchCurrent`
- Update to use `DotNetVerbosity`