### PR TITLE
DockerImageNotFoundException when logged in into Docker Desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - 610 Trim traling slashes in Dockerfile directory path (otherwise, it cuts the first character of the relative path), Normalize paths to forward slashes
 - 650 Update SharpZipLib to version 1.4.1 to prevent a deadlock in the Docker container image build
+- 666 DockerImageNotFoundException when logged in with Docker Desktop instead of the CLI
 
 ## [2.2.0]
 

--- a/src/Testcontainers/Builders/DockerRegistryAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/DockerRegistryAuthenticationProvider.cs
@@ -12,7 +12,7 @@
   /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
   internal sealed class DockerRegistryAuthenticationProvider : IDockerRegistryAuthenticationProvider
   {
-    private const string DockerHub = "index.docker.io";
+    private const string DockerHub = "https://index.docker.io/v1/";
 
     private static readonly ConcurrentDictionary<string, Lazy<IDockerRegistryAuthenticationConfiguration>> Credentials = new ConcurrentDictionary<string, Lazy<IDockerRegistryAuthenticationConfiguration>>();
 

--- a/src/Testcontainers/Clients/DockerSystemOperations.cs
+++ b/src/Testcontainers/Clients/DockerSystemOperations.cs
@@ -17,11 +17,17 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<bool> GetIsWindowsEngineEnabled(CancellationToken ct = default)
     {
-      return (await this.Docker.System.GetSystemInfoAsync(ct)
-        .ConfigureAwait(false)).OperatingSystem.Contains("Windows");
+      var info = await this.GetInfoAsync(ct)
+        .ConfigureAwait(false);
+      return info.OperatingSystem.IndexOf("Windows", StringComparison.OrdinalIgnoreCase) >= -1;
     }
 
-    public Task<VersionResponse> GetVersion(CancellationToken ct = default)
+    public Task<SystemInfoResponse> GetInfoAsync(CancellationToken ct = default)
+    {
+      return this.Docker.System.GetSystemInfoAsync(ct);
+    }
+
+    public Task<VersionResponse> GetVersionAsync(CancellationToken ct = default)
     {
       return this.Docker.System.GetVersionAsync(ct);
     }

--- a/src/Testcontainers/Clients/DockerSystemOperations.cs
+++ b/src/Testcontainers/Clients/DockerSystemOperations.cs
@@ -17,9 +17,9 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<bool> GetIsWindowsEngineEnabled(CancellationToken ct = default)
     {
-      var info = await this.GetInfoAsync(ct)
+      var version = await this.GetVersionAsync(ct)
         .ConfigureAwait(false);
-      return info.OperatingSystem.IndexOf("Windows", StringComparison.OrdinalIgnoreCase) >= -1;
+      return version.Os.IndexOf("Windows", StringComparison.OrdinalIgnoreCase) > -1;
     }
 
     public Task<SystemInfoResponse> GetInfoAsync(CancellationToken ct = default)

--- a/src/Testcontainers/Clients/IDockerSystemOperations.cs
+++ b/src/Testcontainers/Clients/IDockerSystemOperations.cs
@@ -8,6 +8,8 @@ namespace DotNet.Testcontainers.Clients
   {
     Task<bool> GetIsWindowsEngineEnabled(CancellationToken ct = default);
 
-    Task<VersionResponse> GetVersion(CancellationToken ct = default);
+    Task<SystemInfoResponse> GetInfoAsync(CancellationToken ct = default);
+
+    Task<VersionResponse> GetVersionAsync(CancellationToken ct = default);
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/ProtectDockerDaemonSocketTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/ProtectDockerDaemonSocketTest.cs
@@ -34,7 +34,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         IDockerSystemOperations dockerSystemOperations = new DockerSystemOperations(Guid.Empty, this.authConfig, NullLogger.Instance);
 
         // When
-        var version = await dockerSystemOperations.GetVersion()
+        var version = await dockerSystemOperations.GetVersionAsync()
           .ConfigureAwait(false);
 
         // Then
@@ -58,7 +58,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         IDockerSystemOperations dockerSystemOperations = new DockerSystemOperations(Guid.Empty, this.authConfig, NullLogger.Instance);
 
         // When
-        var version = await dockerSystemOperations.GetVersion()
+        var version = await dockerSystemOperations.GetVersionAsync()
           .ConfigureAwait(false);
 
         // Then


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where Testcontainers for .NET cannot authenticate against Docker Hub and pull images (even public available images). `docker-credential-desktop` returns the JWT instead of the secret for the input value `index.docker.io`. The correct input to receive the secret is `https://index.docker.io/v1/`. To stay compatible with future Docker Desktop updates, we read the input value from the Docker info response.

## Why is it important?

To pull Docker images even if developers are logged in into Docker Desktop.

## Related issues

- Closes #666

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Workaround

- Logout of Docker Desktop and login via CLI (auth token).