### PR TITLE
feat: Add Docker host and socket override custom configuration

### DIFF
--- a/docs/custom_configuration/index.md
+++ b/docs/custom_configuration/index.md
@@ -2,17 +2,19 @@
 
 Testcontainers supports various configurations to set up your test environment. It automatically discovers the Docker environment and applies the configuration. You can set or override the default values either with the Testcontainers [properties file][properties-file-format] (`~/testcontainers.properties`) or with environment variables. If you prefer to configure your test environment at runtime, you can set or override the configuration through the `TestcontainersSettings` class. The following configurations are available:
 
-| Properties File         | Environment Variable                   | Description                                                                                                               | Default                     |
-|-------------------------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------------|-----------------------------|
-| `docker.config`         | `DOCKER_CONFIG`                        | The directory path that contains the Docker configuration (`config.json`) file.                                           | `~/.docker/`                |
-| `docker.host`           | `DOCKER_HOST`                          | The Docker daemon socket to connect to.                                                                                   | -                           |
-| `docker.auth.config`    | `DOCKER_AUTH_CONFIG`                   | The Docker configuration file content (GitLab: [Use statically-defined credentials][use-statically-defined-credentials]). | -                           |
-| `docker.cert.path`      | `DOCKER_CERT_PATH`                     | The directory path that contains the client certificate (`{ca,cert,key}.pem`) files.                                      | `~/.docker/`                |
-| `docker.tls`            | `DOCKER_TLS`                           | Enables TLS.                                                                                                              | false                       |
-| `docker.tls.verify`     | `DOCKER_TLS_VERIFY`                    | Enables TLS verify.                                                                                                       | false                       |
-| `ryuk.disabled`         | `TESTCONTAINERS_RYUK_DISABLED`         | Disables Ryuk (resource reaper).                                                                                          | false                       |
-| `ryuk.container.image`  | `TESTCONTAINERS_RYUK_CONTAINER_IMAGE`  | The Ryuk (resource reaper) Docker image.                                                                                  | `testcontainers/ryuk:0.3.4` |
-| `hub.image.name.prefix` | `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` | The name to use for substituting the Docker Hub registry part of the image name.                                          | -                           |
+| Properties File          | Environment Variable                    | Description                                                                                                               | Default                     |
+|--------------------------|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------------|-----------------------------|
+| `docker.config`          | `DOCKER_CONFIG`                         | The directory path that contains the Docker configuration (`config.json`) file.                                           | `~/.docker/`                |
+| `docker.host`            | `DOCKER_HOST`                           | The Docker daemon socket to connect to.                                                                                   | -                           |
+| `docker.auth.config`     | `DOCKER_AUTH_CONFIG`                    | The Docker configuration file content (GitLab: [Use statically-defined credentials][use-statically-defined-credentials]). | -                           |
+| `docker.cert.path`       | `DOCKER_CERT_PATH`                      | The directory path that contains the client certificate (`{ca,cert,key}.pem`) files.                                      | `~/.docker/`                |
+| `docker.tls`             | `DOCKER_TLS`                            | Enables TLS.                                                                                                              | `false`                     |
+| `docker.tls.verify`      | `DOCKER_TLS_VERIFY`                     | Enables TLS verify.                                                                                                       | `false`                     |
+| `host.override`          | `TESTCONTAINERS_HOST_OVERRIDE`          | The host that exposes Docker's ports.                                                                                     | -                           |
+| `docker.socket.override` | `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` | The file path to the Docker daemon socket that is used by Ryuk (resource reaper).                                         | `/var/run/docker.sock`      |
+| `ryuk.disabled`          | `TESTCONTAINERS_RYUK_DISABLED`          | Disables Ryuk (resource reaper).                                                                                          | `false`                     |
+| `ryuk.container.image`   | `TESTCONTAINERS_RYUK_CONTAINER_IMAGE`   | The Ryuk (resource reaper) Docker image.                                                                                  | `testcontainers/ryuk:0.3.4` |
+| `hub.image.name.prefix`  | `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX`  | The name to use for substituting the Docker Hub registry part of the image name.                                          | -                           |
 
 ## Enable logging
 

--- a/src/Testcontainers/Configurations/CustomConfiguration.cs
+++ b/src/Testcontainers/Configurations/CustomConfiguration.cs
@@ -24,6 +24,16 @@ namespace DotNet.Testcontainers.Configurations
       return this.properties.TryGetValue(propertyName, out var propertyValue) && Uri.TryCreate(propertyValue, UriKind.RelativeOrAbsolute, out var dockerHost) ? dockerHost : null;
     }
 
+    protected string GetDockerHostOverride(string propertyName)
+    {
+      return this.GetPropertyValue(propertyName);
+    }
+
+    protected string GetDockerSocketOverride(string propertyName)
+    {
+      return this.GetPropertyValue(propertyName);
+    }
+
     protected JsonDocument GetDockerAuthConfig(string propertyName)
     {
       _ = this.properties.TryGetValue(propertyName, out var propertyValue);

--- a/src/Testcontainers/Configurations/EnvironmentConfiguration.cs
+++ b/src/Testcontainers/Configurations/EnvironmentConfiguration.cs
@@ -22,6 +22,10 @@ namespace DotNet.Testcontainers.Configurations
 
     private const string DockerTlsVerify = "DOCKER_TLS_VERIFY";
 
+    private const string DockerHostOverride = "TESTCONTAINERS_HOST_OVERRIDE";
+
+    private const string DockerSocketOverride = "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE";
+
     private const string RyukDisabled = "TESTCONTAINERS_RYUK_DISABLED";
 
     private const string RyukContainerImage = "TESTCONTAINERS_RYUK_CONTAINER_IMAGE";
@@ -44,6 +48,8 @@ namespace DotNet.Testcontainers.Configurations
           DockerHost,
           DockerTls,
           DockerTlsVerify,
+          DockerHostOverride,
+          DockerSocketOverride,
           RyukDisabled,
           RyukContainerImage,
           HubImageNamePrefix,
@@ -68,6 +74,18 @@ namespace DotNet.Testcontainers.Configurations
     public Uri GetDockerHost()
     {
       return this.GetDockerHost(DockerHost);
+    }
+
+    /// <inheritdoc />
+    public string GetDockerHostOverride()
+    {
+      return this.GetDockerHostOverride(DockerHostOverride);
+    }
+
+    /// <inheritdoc />
+    public string GetDockerSocketOverride()
+    {
+      return this.GetDockerSocketOverride(DockerSocketOverride);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Configurations/ICustomConfiguration.cs
+++ b/src/Testcontainers/Configurations/ICustomConfiguration.cs
@@ -14,7 +14,7 @@ namespace DotNet.Testcontainers.Configurations
     /// Gets the Docker config custom configuration.
     /// </summary>
     /// <returns>The Docker config custom configuration.</returns>
-    /// <remarks>https://www.testcontainers.org/features/configuration/#customizing-docker-host-detection.</remarks>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
     [CanBeNull]
     string GetDockerConfig();
 
@@ -22,15 +22,31 @@ namespace DotNet.Testcontainers.Configurations
     /// Gets the Docker host custom configuration.
     /// </summary>
     /// <returns>The Docker host custom configuration.</returns>
-    /// <remarks>https://www.testcontainers.org/features/configuration/#customizing-docker-host-detection.</remarks>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
     [CanBeNull]
     Uri GetDockerHost();
+
+    /// <summary>
+    /// Gets the Docker host override custom configuration.
+    /// </summary>
+    /// <returns>The Docker host override custom configuration.</returns>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
+    [CanBeNull]
+    string GetDockerHostOverride();
+
+    /// <summary>
+    /// Gets the Docker socket override custom configuration.
+    /// </summary>
+    /// <returns>The Docker socket override custom configuration.</returns>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
+    [CanBeNull]
+    string GetDockerSocketOverride();
 
     /// <summary>
     /// Gets the Docker registry authentication custom configuration.
     /// </summary>
     /// <returns>The Docker authentication custom configuration.</returns>
-    /// <remarks>https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#access-an-image-from-a-private-container-registry.</remarks>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
     [CanBeNull]
     JsonDocument GetDockerAuthConfig();
 
@@ -38,7 +54,7 @@ namespace DotNet.Testcontainers.Configurations
     /// Gets the Docker certificates path custom configuration.
     /// </summary>
     /// <returns>The Docker certificates path custom configuration.</returns>
-    /// <remarks>https://www.testcontainers.org/features/configuration/#customizing-docker-host-detection.</remarks>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
     [CanBeNull]
     string GetDockerCertPath();
 
@@ -46,28 +62,28 @@ namespace DotNet.Testcontainers.Configurations
     /// Gets the Docker TLS custom configuration.
     /// </summary>
     /// <returns>The Docker TLS custom configuration.</returns>
-    /// <remarks>https://www.testcontainers.org/features/configuration/#customizing-docker-host-detection.</remarks>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
     bool GetDockerTls();
 
     /// <summary>
     /// Gets the Docker TLS verify custom configuration.
     /// </summary>
     /// <returns>The Docker TLS verify custom configuration.</returns>
-    /// <remarks>https://www.testcontainers.org/features/configuration/#customizing-docker-host-detection.</remarks>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
     bool GetDockerTlsVerify();
 
     /// <summary>
     /// Gets the Ryuk disabled custom configuration.
     /// </summary>
     /// <returns>The Ryuk disabled custom configuration.</returns>
-    /// <remarks>https://www.testcontainers.org/features/configuration/#customizing-ryuk-resource-reaper.</remarks>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
     bool GetRyukDisabled();
 
     /// <summary>
     /// Gets the Ryuk container image custom configuration.
     /// </summary>
     /// <returns>The Ryuk container image custom configuration.</returns>
-    /// <remarks>https://www.testcontainers.org/features/configuration/#customizing-ryuk-resource-reaper.</remarks>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
     [CanBeNull]
     IDockerImage GetRyukContainerImage();
 
@@ -75,7 +91,7 @@ namespace DotNet.Testcontainers.Configurations
     /// Gets the Docker Hub image name prefix custom configuration.
     /// </summary>
     /// <returns>The Docker Hub image name prefix custom configuration.</returns>
-    /// <remarks>https://www.testcontainers.org/features/image_name_substitution/.</remarks>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
     [CanBeNull]
     string GetHubImageNamePrefix();
   }

--- a/src/Testcontainers/Configurations/PropertiesFileConfiguration.cs
+++ b/src/Testcontainers/Configurations/PropertiesFileConfiguration.cs
@@ -71,6 +71,20 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
+    public string GetDockerHostOverride()
+    {
+      const string propertyName = "host.override";
+      return this.GetDockerHostOverride(propertyName);
+    }
+
+    /// <inheritdoc />
+    public string GetDockerSocketOverride()
+    {
+      const string propertyName = "docker.socket.override";
+      return this.GetDockerSocketOverride(propertyName);
+    }
+
+    /// <inheritdoc />
     public JsonDocument GetDockerAuthConfig()
     {
       const string propertyName = "docker.auth.config";

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -22,10 +22,13 @@ namespace DotNet.Testcontainers.Containers
     private const ushort RyukPort = 8080;
 
     /// <summary>
-    /// 60 seconds timeout.
+    /// 60 seconds connection timeout.
     /// </summary>
     private const int ConnectionTimeoutInSeconds = 60;
 
+    /// <summary>
+    /// 2 seconds retry timeout.
+    /// </summary>
     private const int RetryTimeoutInSeconds = 2;
 
     private static readonly SemaphoreSlim DefaultLock = new SemaphoreSlim(1, 1);

--- a/tests/Testcontainers.Tests/Unit/Configurations/CustomConfigurationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/CustomConfigurationTest.cs
@@ -21,6 +21,8 @@ namespace DotNet.Testcontainers.Tests.Unit
         EnvironmentVariables.Add("DOCKER_CERT_PATH");
         EnvironmentVariables.Add("DOCKER_TLS");
         EnvironmentVariables.Add("DOCKER_TLS_VERIFY");
+        EnvironmentVariables.Add("TESTCONTAINERS_HOST_OVERRIDE");
+        EnvironmentVariables.Add("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE");
         EnvironmentVariables.Add("TESTCONTAINERS_RYUK_DISABLED");
         EnvironmentVariables.Add("TESTCONTAINERS_RYUK_CONTAINER_IMAGE");
         EnvironmentVariables.Add("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX");
@@ -46,6 +48,28 @@ namespace DotNet.Testcontainers.Tests.Unit
         SetEnvironmentVariable(propertyName, propertyValue);
         ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
         Assert.Equal(expected, customConfiguration.GetDockerHost()?.ToString());
+      }
+
+      [Theory]
+      [InlineData("", "", null)]
+      [InlineData("TESTCONTAINERS_HOST_OVERRIDE", "", null)]
+      [InlineData("TESTCONTAINERS_HOST_OVERRIDE", "docker.svc.local", "docker.svc.local")]
+      public void GetDockerHostOverrideCustomConfiguration(string propertyName, string propertyValue, string expected)
+      {
+        SetEnvironmentVariable(propertyName, propertyValue);
+        ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
+        Assert.Equal(expected, customConfiguration.GetDockerHostOverride());
+      }
+
+      [Theory]
+      [InlineData("", "", null)]
+      [InlineData("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "", null)]
+      [InlineData("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE", "/var/run/docker.sock", "/var/run/docker.sock")]
+      public void GetDockerSocketOverrideCustomConfiguration(string propertyName, string propertyValue, string expected)
+      {
+        SetEnvironmentVariable(propertyName, propertyValue);
+        ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
+        Assert.Equal(expected, customConfiguration.GetDockerSocketOverride());
       }
 
       [Theory]
@@ -177,6 +201,26 @@ namespace DotNet.Testcontainers.Tests.Unit
       {
         ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
         Assert.Equal(expected, customConfiguration.GetDockerHost()?.ToString());
+      }
+
+      [Theory]
+      [InlineData("", null)]
+      [InlineData("host.override=", null)]
+      [InlineData("host.override=docker.svc.local", "docker.svc.local")]
+      public void GetDockerHostOverrideCustomConfiguration(string configuration, string expected)
+      {
+        ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
+        Assert.Equal(expected, customConfiguration.GetDockerHostOverride());
+      }
+
+      [Theory]
+      [InlineData("", null)]
+      [InlineData("docker.socket.override=", null)]
+      [InlineData("docker.socket.override=/var/run/docker.sock", "/var/run/docker.sock")]
+      public void GetDockerSocketOverrideCustomConfiguration(string configuration, string expected)
+      {
+        ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
+        Assert.Equal(expected, customConfiguration.GetDockerSocketOverride());
       }
 
       [Theory]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Extends the custom configurations to override the Docker host and socket.

## Why is it important?

To continue to align with other Testcontainers implements we add the custom configurations `TESTCONTAINERS_HOST_OVERRIDE` and `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`. In Java e.g. they are used to spin up the Resource Reaper container. It allows to run the Resource Reaper and Testcontainers configurations in general, in more environments.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #678

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Follow-ups

- Use the above mentioned custom configurations to spin up the Resource Reaper.
