### PR TITLE
Feature/683 resolve hostname from first network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - 642 Expose container port bindings automatically
 - 603 Add default logger that forwards messages to the console (does not support every test environment)
+- 683 Return the gateway address (`IDockerContainer.Hostname`) of a network if one is assigned
 
 ### Fixed
 

--- a/src/Testcontainers/Containers/TestcontainersContainer.cs
+++ b/src/Testcontainers/Containers/TestcontainersContainer.cs
@@ -388,19 +388,8 @@ namespace DotNet.Testcontainers.Containers
         return localhost;
       }
 
-      var endpointSettings = this.container.NetworkSettings.Networks.TryGetValue("bridge", out var network) ? network : new EndpointSettings();
-      if (!string.IsNullOrWhiteSpace(endpointSettings.Gateway))
-      {
-        return endpointSettings.Gateway;
-      }
-
-      var networkSettings = this.container.NetworkSettings;
-      if (!string.IsNullOrWhiteSpace(networkSettings.Gateway))
-      {
-        return networkSettings.Gateway;
-      }
-
-      return localhost;
+      var endpointSettings = this.container.NetworkSettings.Networks.Values.FirstOrDefault();
+      return endpointSettings == null ? localhost : endpointSettings.Gateway;
     }
   }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Changes the container hostname resolution. The previous implementation only considers networks with the name `bridge`.

## Why is it important?

If developers run in a Docker Wormhole environment, and assign a custom network, the previous implementation returned a wrong hostname. It did not consider the custom network. Custom networks cannot use the name `bridge`, it is a reserved name.

The fallback to `NetworkSettings.Gateway` does not make sense:

> Deprecated: This field is only propagated when attached to the default "bridge" network. Use the information from the "bridge" network inside the Networks map instead, which contains the same information. This field was deprecated in Docker 1.9 and is scheduled to be removed in Docker 17.12.0

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #679
- Closes #683

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
