### PR TITLE
feat(#678): Add support of custom configuration TESTCONTAINERS_HOST_OVERRIDE and TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - 640 Add `ITestcontainersBuilder<TDockerContainer>.WithResourceMapping` to copy files or or any binary contents into the created container even before it is started.
 - 654 Add `ITestcontainersNetworkBuilder.WithOption` (@vlaskal)
+- 678 Add support of custom configuration `TESTCONTAINERS_HOST_OVERRIDE` and `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`.
 
 ### Changed
 

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -21,7 +21,9 @@ namespace DotNet.Testcontainers.Configurations
   [PublicAPI]
   public static class TestcontainersSettings
   {
-    private static readonly IDockerImage RyukContainerImage = new DockerImage("testcontainers/ryuk:0.3.4");
+    private const string DockerSocketFilePath = "/var/run/docker.sock";
+
+    private static readonly IDockerImage RyukImage = new DockerImage("testcontainers/ryuk:0.3.4");
 
     private static readonly ManualResetEventSlim ManualResetEvent = new ManualResetEventSlim(false);
 
@@ -102,6 +104,18 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <summary>
+    /// Gets or sets the Docker host override value.
+    /// </summary>
+    public static string DockerHostOverride { get; set; }
+      = PropertiesFileConfiguration.Instance.GetDockerHostOverride() ?? EnvironmentConfiguration.Instance.GetDockerHostOverride();
+
+    /// <summary>
+    /// Gets or sets the Docker socket override value.
+    /// </summary>
+    public static string DockerSocketOverride { get; set; }
+      = PropertiesFileConfiguration.Instance.GetDockerSocketOverride() ?? EnvironmentConfiguration.Instance.GetDockerSocketOverride() ?? DockerSocketFilePath;
+
+    /// <summary>
     /// Gets or sets a value indicating whether the <see cref="ResourceReaper" /> is enabled or not.
     /// </summary>
     [PublicAPI]
@@ -113,7 +127,7 @@ namespace DotNet.Testcontainers.Configurations
     /// </summary>
     [PublicAPI]
     public static IDockerImage ResourceReaperImage { get; set; }
-      = PropertiesFileConfiguration.Instance.GetRyukContainerImage() ?? EnvironmentConfiguration.Instance.GetRyukContainerImage() ?? RyukContainerImage;
+      = PropertiesFileConfiguration.Instance.GetRyukContainerImage() ?? EnvironmentConfiguration.Instance.GetRyukContainerImage() ?? RyukImage;
 
     /// <summary>
     /// Gets or sets the <see cref="ResourceReaper" /> public host port.

--- a/src/Testcontainers/Containers/TestcontainersContainer.cs
+++ b/src/Testcontainers/Containers/TestcontainersContainer.cs
@@ -87,6 +87,11 @@ namespace DotNet.Testcontainers.Containers
     {
       get
       {
+        if (!string.IsNullOrEmpty(TestcontainersSettings.DockerHostOverride))
+        {
+          return TestcontainersSettings.DockerHostOverride;
+        }
+
         var dockerHostUri = this.configuration.DockerEndpointAuthConfig.Endpoint;
 
         switch (dockerHostUri.Scheme)

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/ResourceReaperCancellableTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/ResourceReaperCancellableTest.cs
@@ -41,7 +41,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
     [Fact]
     public async Task ResourceReaperShouldTimeoutIfInitializationFails()
     {
-      var resourceReaperTask = ResourceReaper.GetAndStartNewAsync(this.sessionId, null, "nginx", TimeSpan.FromSeconds(10));
+      var resourceReaperTask = ResourceReaper.GetAndStartNewAsync(this.sessionId, null, "nginx", null, false, TimeSpan.FromSeconds(10));
       _ = await Assert.ThrowsAsync<ResourceReaperException>(() => resourceReaperTask);
       Assert.Equal(new[] { ResourceReaperState.Created, ResourceReaperState.InitializingConnection }, this.stateChanges);
     }
@@ -51,7 +51,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
     {
       ResourceReaper.StateChanged += this.CancelOnCreated;
 
-      var resourceReaperTask = ResourceReaper.GetAndStartNewAsync(this.sessionId, null, "nginx", TimeSpan.FromSeconds(10), this.cts.Token);
+      var resourceReaperTask = ResourceReaper.GetAndStartNewAsync(this.sessionId, null, "nginx", null, false, TimeSpan.FromSeconds(10), this.cts.Token);
       _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => resourceReaperTask);
       Assert.Equal(new[] { ResourceReaperState.Created }, this.stateChanges);
     }
@@ -61,7 +61,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
     {
       ResourceReaper.StateChanged += this.CancelOnInitializingConnection;
 
-      var resourceReaperTask = ResourceReaper.GetAndStartNewAsync(this.sessionId, null, "nginx", TimeSpan.FromSeconds(10), this.cts.Token);
+      var resourceReaperTask = ResourceReaper.GetAndStartNewAsync(this.sessionId, null, "nginx", null, false, TimeSpan.FromSeconds(10), this.cts.Token);
       _ = await Assert.ThrowsAsync<ResourceReaperException>(() => resourceReaperTask);
       Assert.Equal(new[] { ResourceReaperState.Created, ResourceReaperState.InitializingConnection }, this.stateChanges);
     }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Adds the support of the custom configurations `TESTCONTAINERS_HOST_OVERRIDE` and `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`. The host resolution will favor the host override configuration, where the Resource Reaper will favor to mount the socket override configuration as Docker daemon socket.

## Why is it important?

Some test (CI) environments require overriding the configurations mentioned above. This allows more developers to use Testcontainers for .NET.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #678 

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
