### PR TITLE
refactor: Run database container on web app start up if connection string is missing, replace mssql/server with azure-sql-edge

### DIFF
--- a/examples/WeatherForecast/Packages.props
+++ b/examples/WeatherForecast/Packages.props
@@ -5,6 +5,7 @@
     <PackageReference Update="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.10"/>
     <PackageReference Update="Microsoft.EntityFrameworkCore" Version="6.0.10"/>
     <PackageReference Update="Microsoft.Fast.Components.FluentUI" Version="1.5.3"/>
+    <PackageReference Update="Testcontainers" Version="2.3.0-beta.3547636764"/>
     <PackageReference Update="System.ComponentModel.Annotations" Version="5.0.0"/>
     <PackageReference Update="System.Text.Json" Version="6.0.6"/>
     <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.10"/>

--- a/examples/WeatherForecast/README.md
+++ b/examples/WeatherForecast/README.md
@@ -6,6 +6,7 @@ This example builds and ships a Blazor application in a Docker image build, runs
 git lfs version
 git clone --branch develop git@github.com:testcontainers/testcontainers-dotnet.git
 cd ./testcontainers-dotnet/examples/WeatherForecast/
-dotnet build WeatherForecast.sln
-dotnet test WeatherForecast.sln
+dotnet test WeatherForecast.sln --configuration=Release
 ```
+
+_* One unit test depends on Seleium and requires Chrome 106._

--- a/examples/WeatherForecast/README.md
+++ b/examples/WeatherForecast/README.md
@@ -9,4 +9,4 @@ cd ./testcontainers-dotnet/examples/WeatherForecast/
 dotnet test WeatherForecast.sln --configuration=Release
 ```
 
-_* One unit test depends on Seleium and requires Chrome 106._
+_*) One unit test depends on Seleium and requires Chrome in version 106._

--- a/examples/WeatherForecast/src/WeatherForecast/DatabaseContainer.cs
+++ b/examples/WeatherForecast/src/WeatherForecast/DatabaseContainer.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Microsoft.Extensions.Hosting;
+
+namespace WeatherForecast;
+
+public sealed class DatabaseContainer : IHostedService
+{
+  private readonly TestcontainerDatabase _container = new TestcontainersBuilder<MsSqlTestcontainer>()
+    .WithDatabase(new DatabaseContainerConfiguration())
+    .Build();
+
+  public Task StartAsync(CancellationToken cancellationToken)
+  {
+    return _container.StartAsync(cancellationToken);
+  }
+
+  public Task StopAsync(CancellationToken cancellationToken)
+  {
+    return _container.StopAsync(cancellationToken);
+  }
+
+  public string GetConnectionString()
+  {
+    return _container.ConnectionString;
+  }
+}

--- a/examples/WeatherForecast/src/WeatherForecast/DatabaseContainerConfiguration.cs
+++ b/examples/WeatherForecast/src/WeatherForecast/DatabaseContainerConfiguration.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using Microsoft.Extensions.Logging;
+
+namespace WeatherForecast;
+
+public sealed class DatabaseContainerConfiguration : MsSqlTestcontainerConfiguration
+{
+  public DatabaseContainerConfiguration() : base("mcr.microsoft.com/azure-sql-edge:1.0.6")
+  {
+    Password = Guid.NewGuid().ToString("D");
+    Database = Guid.NewGuid().ToString("D");
+  }
+
+  public override IWaitForContainerOS WaitStrategy { get; }
+    = Wait.ForUnixContainer().AddCustomWaitStrategy(new AcceptsClientConnections());
+
+  private sealed class AcceptsClientConnections : IWaitUntil
+  {
+    public async Task<bool> Until(ITestcontainersContainer testcontainers, ILogger logger)
+    {
+      var (stdout, _) = await testcontainers.GetLogs()
+        .ConfigureAwait(false);
+      return stdout.Contains("SQL Server is now ready for client connections.", StringComparison.OrdinalIgnoreCase);
+    }
+  }
+}

--- a/examples/WeatherForecast/src/WeatherForecast/WeatherForecast.csproj
+++ b/examples/WeatherForecast/src/WeatherForecast/WeatherForecast.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer"/>
     <PackageReference Include="Microsoft.Fast.Components.FluentUI"/>
+    <PackageReference Include="Testcontainers"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)src/WeatherForecast.Contexts/WeatherForecast.Contexts.csproj"/>

--- a/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecast.InProcess.Tests.csproj
+++ b/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecast.InProcess.Tests.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="xunit"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../../../src/Testcontainers/Testcontainers.csproj"/>
     <!-- https://github.com/dotnet/sdk/issues/17645 -->
     <ProjectReference Include="$(SolutionDir)src/WeatherForecast/WeatherForecast.csproj" Private="False"/>
   </ItemGroup>

--- a/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecastTest.cs
+++ b/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecastTest.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -24,9 +23,7 @@ public sealed class WeatherForecastTest : IAsyncLifetime
 
   public WeatherForecastTest()
   {
-    var mssqlConfiguration = new MsSqlTestcontainerConfiguration();
-    mssqlConfiguration.Password = Guid.NewGuid().ToString("D");
-    mssqlConfiguration.Database = Guid.NewGuid().ToString("D");
+    var mssqlConfiguration = new DatabaseContainerConfiguration();
 
     _mssqlContainer = new TestcontainersBuilder<MsSqlTestcontainer>()
       .WithDatabase(mssqlConfiguration)

--- a/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecast.Tests.csproj
+++ b/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecast.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="../../../../src/Testcontainers/Testcontainers.csproj"/>
-    <ProjectReference Include="$(SolutionDir)src/WeatherForecast.Entities/WeatherForecast.Entities.csproj"/>
+    <!-- https://github.com/dotnet/sdk/issues/17645 -->
+    <ProjectReference Include="$(SolutionDir)src/WeatherForecast/WeatherForecast.csproj" Private="False"/>
   </ItemGroup>
 </Project>

--- a/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecastContainer.cs
+++ b/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecastContainer.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
 using DotNet.Testcontainers.Networks;
 using JetBrains.Annotations;
@@ -33,9 +32,7 @@ public sealed class WeatherForecastContainer : HttpClient, IAsyncLifetime
   {
     const string weatherForecastStorage = "weatherForecastStorage";
 
-    var mssqlConfiguration = new MsSqlTestcontainerConfiguration();
-    mssqlConfiguration.Password = Guid.NewGuid().ToString("D");
-    mssqlConfiguration.Database = Guid.NewGuid().ToString("D");
+    var mssqlConfiguration = new DatabaseContainerConfiguration();
 
     var connectionString = $"server={weatherForecastStorage};user id=sa;password={mssqlConfiguration.Password};database={mssqlConfiguration.Database}";
 

--- a/src/Testcontainers/Containers/ResourceReaperState.cs
+++ b/src/Testcontainers/Containers/ResourceReaperState.cs
@@ -1,5 +1,8 @@
 namespace DotNet.Testcontainers.Containers
 {
+  using System;
+  using System.Threading;
+
   /// <summary>
   /// Resource Reaper states.
   /// </summary>
@@ -19,7 +22,7 @@ namespace DotNet.Testcontainers.Containers
     /// <see cref="ResourceReaper" /> maintains the TCP connection to Ryuk.
     /// </summary>
     /// <remarks>
-    /// <see cref="ResourceReaper.GetAndStartNewAsync(DotNet.Testcontainers.Configurations.IDockerEndpointAuthenticationConfiguration, string, System.TimeSpan, System.Threading.CancellationToken)" /> will complete now.
+    /// <see cref="ResourceReaper.GetAndStartNewAsync(DotNet.Testcontainers.Configurations.IDockerEndpointAuthenticationConfiguration, string, string, bool, TimeSpan, CancellationToken)" /> will complete now.
     /// </remarks>
     MaintainingConnection,
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

1. Starts a database container on the web application start up, if no database connection string is available.
2. Replaces the Docker `mssql/server` image with `azure-sql-edge`.

## Why is it important?

Starting, configuring and seeding a database container on the web application start up runs the application against a real dependency instead of a mock implementation. This allows a much better development experience.

The `mssql/server` image is incompatible with Apple's M1, `azure-sql-edge` runs on the other hand on all platforms.
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
