### PR TITLE
Added HTTP Wait Strategry

### DIFF
--- a/docs/api/wait_strategies.md
+++ b/docs/api/wait_strategies.md
@@ -28,5 +28,30 @@ _ = new TestcontainersBuilder<TestcontainersContainer>()
   .Build();
 ```
 
+## Wait until Http Request is successful
+
+You can wait for an HttpResponseCode or even compare the Response Body of an http request to an exposed port on your container
+
+```csharp
+_ = new TestcontainersBuilder<TestcontainersContainer>()
+  .WithWaitStrategy(
+    Wait.ForUnixContainer()
+      .UntilHttp() //Default to a GET to localhost:80 [ExposedfromContianer] Expecting 200 with no response body Validation 
+  .Build();
+```
+or with Options 
+```csharp
+_ = new TestcontainersBuilder<TestcontainersContainer>()
+  .WithWaitStrategy(
+    Wait.ForUnixContainer()
+      .UntilHttp( options => {
+        options.Port = [YourServiceExposedPort];
+        options.Path = [RequestPath];
+        options.Method = [HttpRequestMethod];
+        options.ExpectedResponseCodes = new(){ HttpStatusCode.OK, HttpStatusCode.Accepted };
+      })
+  .Build();
+```
+
 [docker-docs-healthcheck]: https://docs.docker.com/engine/reference/builder/#healthcheck
 

--- a/src/Testcontainers/Configurations/UntilHttpOptions.cs
+++ b/src/Testcontainers/Configurations/UntilHttpOptions.cs
@@ -7,6 +7,9 @@ namespace DotNet.Testcontainers.Configurations
   using System.Net.Http;
   using System.Security;
 
+  /// <summary>
+  /// Configured the Request and Response Behaviour of the UntilHttp Wait
+  /// </summary>
   public class UntilHttpOptions
   {
     public UntilHttpOptions()

--- a/src/Testcontainers/Configurations/UntilHttpOptions.cs
+++ b/src/Testcontainers/Configurations/UntilHttpOptions.cs
@@ -1,0 +1,39 @@
+﻿#nullable enable
+namespace DotNet.Testcontainers.Configurations
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Net;
+  using System.Net.Http;
+  using System.Security;
+
+  public class UntilHttpOptions
+  {
+    public UntilHttpOptions()
+    {
+      this.Method = HttpMethod.Get;
+      this.Path = "/";
+      this.Host = "localhost";
+      this.Port = 80;
+      this.ExpectedResponseCodes = new() { HttpStatusCode.OK };
+      this.TimeOut = TimeSpan.FromMinutes(1);
+      this.RequestDelay = 1;
+    }
+
+    public HttpMethod Method { get; set; }
+    public string Path { get; set; }
+    public string Host { get; set; }
+    public int Port { get; set; }
+    public HashSet<HttpStatusCode> ExpectedResponseCodes { get; set; }
+    public string? ExpectedOutput { get; set; }
+    public HttpContent? RequestContent { get; set; }
+    public bool UseSecure { get; set; }
+    public SecureString? AuthString { get; set; }
+    public bool UseAuth { get; set; }
+    public TimeSpan TimeOut { get; set; }
+    public bool ValidateContent { get; set; }
+    public double RequestDelay { get; set; }
+
+    public Uri Uri => new($"{(this.UseSecure ? "https" : "http")}://{this.Host}:{this.Port}{this.Path}");
+  }
+}

--- a/src/Testcontainers/Configurations/UntilHttpOptions.cs
+++ b/src/Testcontainers/Configurations/UntilHttpOptions.cs
@@ -21,6 +21,7 @@ namespace DotNet.Testcontainers.Configurations
       this.ExpectedResponseCodes = new() { HttpStatusCode.OK };
       this.TimeOut = TimeSpan.FromMinutes(1);
       this.RequestDelay = 1;
+      this.MaxRetries = 10;
     }
 
     public HttpMethod Method { get; set; }
@@ -36,6 +37,7 @@ namespace DotNet.Testcontainers.Configurations
     public TimeSpan TimeOut { get; set; }
     public bool ValidateContent { get; set; }
     public double RequestDelay { get; set; }
+    public int MaxRetries { get; set; }
 
     public Uri Uri => new($"{(this.UseSecure ? "https" : "http")}://{this.Host}:{this.Port}{this.Path}");
   }

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
@@ -87,6 +87,13 @@ namespace DotNet.Testcontainers.Configurations
     IWaitForContainerOS UntilContainerIsHealthy(long failingStreak = 20);
 
     /// <summary>
+    /// Waits until Http Requests returns Ok
+    /// </summary>
+    /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
+    [PublicAPI]
+    IWaitForContainerOS UntilHttpSuccess(Action<UntilHttpOptions>? action = null);
+
+    /// <summary>
     /// Returns a collection with all configured wait strategies.
     /// </summary>
     /// <returns>List with all configured wait strategies.</returns>

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilHttp.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilHttp.cs
@@ -1,0 +1,66 @@
+﻿namespace DotNet.Testcontainers.Configurations
+{
+  using System;
+  using System.Net.Http;
+  using System.Net.Http.Headers;
+  using System.Text.RegularExpressions;
+  using System.Threading;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Containers;
+  using Microsoft.Extensions.Logging;
+
+  public class UntilHttp : IWaitUntil
+  {
+    private readonly UntilHttpOptions Options;
+
+    public UntilHttp(string path)
+    {
+      this.Options = new() { Path = path, Method = HttpMethod.Get };
+    }
+
+    public UntilHttp(UntilHttpOptions options)
+    {
+      this.Options = options;
+    }
+
+    public async Task<bool> Until(ITestcontainersContainer testcontainers, ILogger logger)
+    {
+      var mappedPort = testcontainers.GetMappedPublicPort(this.Options.Port);
+      this.Options.Port = mappedPort;
+      var client = new HttpClient();
+      var message = new HttpRequestMessage(this.Options.Method, this.Options.Uri);
+      if (this.Options.RequestContent is not null && (this.Options.Method == HttpMethod.Post || this.Options.Method == HttpMethod.Put))
+      {
+        message.Content = this.Options.RequestContent;
+      }
+
+      if (this.Options.UseAuth && this.Options.AuthString is not null)
+      {
+        message.Headers.Authorization = AuthenticationHeaderValue.Parse(this.Options.AuthString.ToString());
+      }
+
+      var sendTask = Task.Run(async () =>
+      {
+        HttpResponseMessage response = null;
+        while (response is null || !this.Options.ExpectedResponseCodes.Contains(response.StatusCode))
+        {
+          response = await client.SendAsync(message);
+          if (!this.Options.ExpectedResponseCodes.Contains(response.StatusCode))
+          {
+            Thread.Sleep(TimeSpan.FromSeconds(this.Options.RequestDelay));
+          }
+        }
+
+        return response;
+      });
+      var completed = sendTask.Wait(this.Options.TimeOut);
+      if (!completed)
+      {
+        return false;
+      }
+
+      var responseContent = await sendTask.Result.Content.ReadAsStringAsync();
+      return !this.Options.ValidateContent || Regex.Match(this.Options.ExpectedOutput, responseContent).Success;
+    }
+  }
+}

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilHttp.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilHttp.cs
@@ -12,6 +12,7 @@
   public class UntilHttp : IWaitUntil
   {
     private readonly UntilHttpOptions Options;
+    private int RetryCount = 0;
 
     public UntilHttp(string path)
     {
@@ -25,42 +26,59 @@
 
     public async Task<bool> Until(ITestcontainersContainer testcontainers, ILogger logger)
     {
-      var mappedPort = testcontainers.GetMappedPublicPort(this.Options.Port);
-      this.Options.Port = mappedPort;
-      var client = new HttpClient();
-      var message = new HttpRequestMessage(this.Options.Method, this.Options.Uri);
-      if (this.Options.RequestContent is not null && (this.Options.Method == HttpMethod.Post || this.Options.Method == HttpMethod.Put))
-      {
-        message.Content = this.Options.RequestContent;
-      }
 
-      if (this.Options.UseAuth && this.Options.AuthString is not null)
+      try
       {
-        message.Headers.Authorization = AuthenticationHeaderValue.Parse(this.Options.AuthString.ToString());
-      }
-
-      var sendTask = Task.Run(async () =>
-      {
-        HttpResponseMessage response = null;
-        while (response is null || !this.Options.ExpectedResponseCodes.Contains(response.StatusCode))
+        var mappedPort = testcontainers.GetMappedPublicPort(this.Options.Port);
+        this.Options.Port = mappedPort;
+        var client = new HttpClient();
+        var message = new HttpRequestMessage(this.Options.Method, this.Options.Uri);
+        if (this.Options.RequestContent is not null && (this.Options.Method == HttpMethod.Post || this.Options.Method == HttpMethod.Put))
         {
-          response = await client.SendAsync(message);
-          if (!this.Options.ExpectedResponseCodes.Contains(response.StatusCode))
-          {
-            Thread.Sleep(TimeSpan.FromSeconds(this.Options.RequestDelay));
-          }
+          message.Content = this.Options.RequestContent;
         }
 
-        return response;
-      });
-      var completed = sendTask.Wait(this.Options.TimeOut);
-      if (!completed)
+        if (this.Options.UseAuth && this.Options.AuthString is not null)
+        {
+          message.Headers.Authorization = AuthenticationHeaderValue.Parse(this.Options.AuthString.ToString());
+        }
+
+        var sendTask = Task.Run(async () =>
+        {
+          HttpResponseMessage response = null;
+          while (response is null || !this.Options.ExpectedResponseCodes.Contains(response.StatusCode))
+          {
+            response = await client.SendAsync(message);
+            if (++this.RetryCount > this.Options.MaxRetries)
+            {
+              throw new TimeoutException($"Http Wait Failed {this.Options.MaxRetries} Times");
+            }
+
+            if (!this.Options.ExpectedResponseCodes.Contains(response.StatusCode))
+            {
+              Thread.Sleep(TimeSpan.FromSeconds(this.Options.RequestDelay));
+            }
+          }
+          return response;
+        });
+        var completed = sendTask.Wait(this.Options.TimeOut);
+        if (!completed)
+        {
+          throw new TimeoutException($"Http Wait Failed Timed Out after {this.Options.TimeOut}");
+        }
+
+        var responseContent = await sendTask.Result.Content.ReadAsStringAsync();
+        return !this.Options.ValidateContent || Regex.Match(this.Options.ExpectedOutput, responseContent).Success;
+      }
+      catch (Exception)
       {
+        if (++this.RetryCount > this.Options.MaxRetries)
+        {
+          throw new TimeoutException($"Http Wait Failed {this.Options.MaxRetries} Times");
+        }
+
         return false;
       }
-
-      var responseContent = await sendTask.Result.Content.ReadAsStringAsync();
-      return !this.Options.ValidateContent || Regex.Match(this.Options.ExpectedOutput, responseContent).Success;
     }
   }
 }

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
@@ -58,6 +58,15 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
+    public IWaitForContainerOS UntilHttpSuccess(Action<UntilHttpOptions> action = null)
+    {
+      var options = new UntilHttpOptions();
+      action?.Invoke(options);
+      var httpWait = new UntilHttp(options);
+      return this.AddCustomWaitStrategy(httpWait);
+    }
+
+    /// <inheritdoc />
     public IEnumerable<IWaitUntil> Build()
     {
       return this.waitStrategies;

--- a/src/Testcontainers/Testcontainers.csproj
+++ b/src/Testcontainers/Testcontainers.csproj
@@ -5,6 +5,7 @@
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
     <RootNamespace>DotNet.Testcontainers</RootNamespace>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" />


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Add an HttpWait Strategy to help wait and Validate HTTP Requests

## Why is it important?

Helping to Bring Feature Parity with testcontainers-java


## How to test this PR

to Test I'd recommend a simple nginx container setup with the wait strategy setup like so

```csharp
var nginx =new TestcontainersBuilder<TestcontainersContainer>()
                .WithImage("nginx:latest")
                .WithExposedPort(80)
                .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpSucceed())
                .Build();
await nginx.StartAsync();
await nginx.StopAsync();
```

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
