### PR TITLE
docs: Fix Docker docs HEALTHCHECK link

### DIFF
--- a/docs/api/wait_strategies.md
+++ b/docs/api/wait_strategies.md
@@ -13,7 +13,7 @@ _ = Wait.ForUnixContainer()
 
 ## Wait until the container is healthy
 
-If the Docker image supports Dockers's [HEALTHCHECK](docker-docs-healthcheck) feature, like the following configuration:
+If the Docker image supports Dockers's [HEALTHCHECK][docker-docs-healthcheck] feature, like the following configuration:
 
 ```Dockerfile
 FROM alpine
@@ -29,4 +29,3 @@ _ = new TestcontainersBuilder<TestcontainersContainer>()
 ```
 
 [docker-docs-healthcheck]: https://docs.docker.com/engine/reference/builder/#healthcheck
-


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Fixes the Docker docs HEALTHCHECK link.

## Why is it important?

The current link is wrong (HTTP 404).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
