### PR TITLE
feat: Prepare Resource Reaper (Ryuk) Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - 531 Add Docker health status wait strategy (@kfrajtak)
-- 640 Add `ITestcontainersBuilder<TDockerContainer>.WithResourceMapping` to copy files or or any binary contents into the created container even before it is started.
+- 640 Add `ITestcontainersBuilder<TDockerContainer>.WithResourceMapping` to copy files or or any binary contents into the created container even before it is started
 - 654 Add `ITestcontainersNetworkBuilder.WithOption` (@vlaskal)
 - 678 Add support of custom configuration `TESTCONTAINERS_HOST_OVERRIDE` and `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`.
 
@@ -14,6 +14,7 @@
 - 642 Expose container port bindings automatically
 - 603 Add default logger that forwards messages to the console (does not support every test environment)
 - 683 Return the gateway address (`IDockerContainer.Hostname`) of a network if one is assigned
+- 703 `ResourceReaper.GetAndStartDefaultAsync` no longer support optional arguments, it is necessary to set the Resource Reaper configuration immediately
 
 ### Fixed
 

--- a/src/Testcontainers/Builders/ITestcontainersBuilder.cs
+++ b/src/Testcontainers/Builders/ITestcontainersBuilder.cs
@@ -220,6 +220,14 @@ namespace DotNet.Testcontainers.Builders
     ITestcontainersBuilder<TDockerContainer> WithMount(string source, string destination, AccessMode accessMode);
 
     /// <summary>
+    /// Assigns the mount configuration to manage data in the container.
+    /// </summary>
+    /// <param name="mount">Mount configuration.</param>
+    /// <returns>A configured instance of <see cref="ITestcontainersBuilder{TDockerContainer}" />.</returns>
+    [PublicAPI]
+    ITestcontainersBuilder<TDockerContainer> WithMount(IMount mount);
+
+    /// <summary>
     /// Binds and mounts the specified host machine volume into the Testcontainer.
     /// </summary>
     /// <param name="source">An absolute path or a name value within the host machine.</param>

--- a/src/Testcontainers/Builders/TestcontainersBuilder.cs
+++ b/src/Testcontainers/Builders/TestcontainersBuilder.cs
@@ -223,6 +223,13 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
+    public ITestcontainersBuilder<TDockerContainer> WithMount(IMount mount)
+    {
+      var mounts = new[] { mount };
+      return this.MergeNewConfiguration(new TestcontainersConfiguration(mounts: mounts));
+    }
+
+    /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
     public ITestcontainersBuilder<TDockerContainer> WithBindMount(string source, string destination)
     {
       return this.WithBindMount(source, destination, AccessMode.ReadWrite);
@@ -231,8 +238,7 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
     public ITestcontainersBuilder<TDockerContainer> WithBindMount(string source, string destination, AccessMode accessMode)
     {
-      var mounts = new IMount[] { new BindMount(source, destination, accessMode) };
-      return this.MergeNewConfiguration(new TestcontainersConfiguration(mounts: mounts));
+      return this.WithMount(new BindMount(source, destination, accessMode));
     }
 
     /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
@@ -256,8 +262,7 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
     public ITestcontainersBuilder<TDockerContainer> WithVolumeMount(IDockerVolume source, string destination, AccessMode accessMode)
     {
-      var mounts = new IMount[] { new VolumeMount(source, destination, accessMode) };
-      return this.MergeNewConfiguration(new TestcontainersConfiguration(mounts: mounts));
+      return this.WithMount(new VolumeMount(source, destination, accessMode));
     }
 
     /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
@@ -269,8 +274,7 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
     public ITestcontainersBuilder<TDockerContainer> WithTmpfsMount(string destination, AccessMode accessMode)
     {
-      var mounts = new IMount[] { new TmpfsMount(destination, accessMode) };
-      return this.MergeNewConfiguration(new TestcontainersConfiguration(mounts: mounts));
+      return this.WithMount(new TmpfsMount(destination, accessMode));
     }
 
     /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -270,11 +270,7 @@ namespace DotNet.Testcontainers.Clients
           .ConfigureAwait(false);
       }
 
-      // TODO: Workaround until we have a Windows Docker image of Ryuk
-      var isWindowsEngineEnabled = await this.GetIsWindowsEngineEnabled(ct)
-        .ConfigureAwait(false);
-
-      if (!isWindowsEngineEnabled && ResourceReaper.DefaultSessionId.Equals(configuration.SessionId))
+      if (ResourceReaper.DefaultSessionId.Equals(configuration.SessionId))
       {
         _ = await ResourceReaper.GetAndStartDefaultAsync(configuration.DockerEndpointAuthConfig, ct)
           .ConfigureAwait(false);

--- a/src/Testcontainers/Configurations/Modules/HostedServiceConfiguration.cs
+++ b/src/Testcontainers/Configurations/Modules/HostedServiceConfiguration.cs
@@ -103,7 +103,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Releases all resources used by the <see cref="HostedServiceConfiguration" />.
     /// </summary>
-    /// <param name="disposing">True if managed resources should be disposed, otherwise false..</param>
+    /// <param name="disposing">True if managed resources should be disposed, otherwise false.</param>
     [PublicAPI]
     protected virtual void Dispose(bool disposing)
     {

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -21,10 +21,6 @@ namespace DotNet.Testcontainers.Configurations
   [PublicAPI]
   public static class TestcontainersSettings
   {
-    private const string DockerSocketFilePath = "/var/run/docker.sock";
-
-    private static readonly IDockerImage RyukImage = new DockerImage("testcontainers/ryuk:0.3.4");
-
     private static readonly ManualResetEventSlim ManualResetEvent = new ManualResetEventSlim(false);
 
     private static readonly IDockerEndpointAuthenticationConfiguration DockerEndpointAuthConfig =
@@ -113,7 +109,7 @@ namespace DotNet.Testcontainers.Configurations
     /// Gets or sets the Docker socket override value.
     /// </summary>
     public static string DockerSocketOverride { get; set; }
-      = PropertiesFileConfiguration.Instance.GetDockerSocketOverride() ?? EnvironmentConfiguration.Instance.GetDockerSocketOverride() ?? DockerSocketFilePath;
+      = PropertiesFileConfiguration.Instance.GetDockerSocketOverride() ?? EnvironmentConfiguration.Instance.GetDockerSocketOverride();
 
     /// <summary>
     /// Gets or sets a value indicating whether the <see cref="ResourceReaper" /> is enabled or not.
@@ -127,7 +123,7 @@ namespace DotNet.Testcontainers.Configurations
     /// </summary>
     [PublicAPI]
     public static IDockerImage ResourceReaperImage { get; set; }
-      = PropertiesFileConfiguration.Instance.GetRyukContainerImage() ?? EnvironmentConfiguration.Instance.GetRyukContainerImage() ?? RyukImage;
+      = PropertiesFileConfiguration.Instance.GetRyukContainerImage() ?? EnvironmentConfiguration.Instance.GetRyukContainerImage();
 
     /// <summary>
     /// Gets or sets the <see cref="ResourceReaper" /> public host port.

--- a/src/Testcontainers/Configurations/Volumes/MountType.cs
+++ b/src/Testcontainers/Configurations/Volumes/MountType.cs
@@ -27,6 +27,12 @@ namespace DotNet.Testcontainers.Configurations
     public static readonly MountType Tmpfs = new MountType("tmpfs");
 
     /// <summary>
+    /// The 'npipe' mount type.
+    /// </summary>
+    [PublicAPI]
+    public static readonly MountType NamedPipe = new MountType("npipe");
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="MountType" /> struct.
     /// </summary>
     /// <param name="type">The mount type.</param>

--- a/src/Testcontainers/Containers/IDockerContainer.cs
+++ b/src/Testcontainers/Containers/IDockerContainer.cs
@@ -4,7 +4,6 @@ namespace DotNet.Testcontainers.Containers
   using System.Collections.Generic;
   using System.Threading;
   using System.Threading.Tasks;
-  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Images;
   using JetBrains.Annotations;
 

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -146,7 +146,7 @@ namespace DotNet.Testcontainers.Containers
     /// Starts and returns a new <see cref="ResourceReaper" /> instance.
     /// </summary>
     /// <param name="dockerEndpointAuthConfig">The Docker endpoint authentication configuration.</param>
-    /// <param name="resourceReaperImage">The Ryuk image.</param>
+    /// <param name="resourceReaperImage">The Resource Reaper image.</param>
     /// <param name="dockerSocket">The Docker socket.</param>
     /// <param name="requiresPrivilegedMode">True if the container requires privileged mode, otherwise false.</param>
     /// <param name="initTimeout">The timeout to initialize the Ryuk connection (Default: <inheritdoc cref="ConnectionTimeoutInSeconds" />).</param>
@@ -163,7 +163,7 @@ namespace DotNet.Testcontainers.Containers
     /// </summary>
     /// <param name="sessionId">The session id.</param>
     /// <param name="dockerEndpointAuthConfig">The Docker endpoint authentication configuration.</param>
-    /// <param name="resourceReaperImage">The Ryuk image.</param>
+    /// <param name="resourceReaperImage">The Resource Reaper image.</param>
     /// <param name="dockerSocket">The Docker socket.</param>
     /// <param name="requiresPrivilegedMode">True if the container requires privileged mode, otherwise false.</param>
     /// <param name="initTimeout">The timeout to initialize the Ryuk connection (Default: <inheritdoc cref="ConnectionTimeoutInSeconds" />).</param>

--- a/tests/Testcontainers.ResourceReaper.Tests/DefaultResourceReaperTest.cs
+++ b/tests/Testcontainers.ResourceReaper.Tests/DefaultResourceReaperTest.cs
@@ -3,6 +3,7 @@ namespace DotNet.Testcontainers.ResourceReaper.Tests
   using System;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Tests.Unit;
   using Xunit;
@@ -76,7 +77,7 @@ namespace DotNet.Testcontainers.ResourceReaper.Tests
     {
       if (Docker.Exists(DockerResource.Container, DefaultRyukContainerName))
       {
-        var resourceReaper = await ResourceReaper.GetAndStartDefaultAsync()
+        var resourceReaper = await ResourceReaper.GetAndStartDefaultAsync(TestcontainersSettings.OS.DockerEndpointAuthConfig)
           .ConfigureAwait(false);
         await resourceReaper.DisposeAsync()
           .ConfigureAwait(false);

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/VolumeFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/VolumeFixture.cs
@@ -3,7 +3,9 @@ namespace DotNet.Testcontainers.Tests.Fixtures
   using System;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
+  using DotNet.Testcontainers.Images;
   using DotNet.Testcontainers.Volumes;
   using JetBrains.Annotations;
   using Xunit;
@@ -29,7 +31,7 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
     public Task InitializeAsync()
     {
-      return Task.WhenAll(ResourceReaper.GetAndStartNewAsync(this.SessionId), this.volume.CreateAsync());
+      return Task.WhenAll(ResourceReaper.GetAndStartNewAsync(this.SessionId, TestcontainersSettings.OS.DockerEndpointAuthConfig, new DockerImage("testcontainers/ryuk:0.3.4"), ResourceReaper.UnixSocketMount.Instance), this.volume.CreateAsync());
     }
 
     public Task DisposeAsync()

--- a/tests/Testcontainers.Tests/SkipOnLinuxEngineAttribute.cs
+++ b/tests/Testcontainers.Tests/SkipOnLinuxEngineAttribute.cs
@@ -2,19 +2,15 @@ namespace DotNet.Testcontainers.Tests
 {
   using System;
   using System.Diagnostics;
-  using DotNet.Testcontainers.Configurations;
   using Xunit;
 
   public sealed class SkipOnLinuxEngineAttribute : FactAttribute
   {
-    static SkipOnLinuxEngineAttribute()
-    {
-      TestcontainersSettings.ResourceReaperEnabled = GetIsLinuxEngineEnabled();
-    }
+    private static readonly bool IsLinuxEngineEnabled = GetIsLinuxEngineEnabled();
 
     public SkipOnLinuxEngineAttribute()
     {
-      if (TestcontainersSettings.ResourceReaperEnabled)
+      if (IsLinuxEngineEnabled)
       {
         this.Skip = "Windows Docker engine is not available.";
       }

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/ResourceReaperTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/ResourceReaperTest.cs
@@ -3,7 +3,9 @@
   using System;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
+  using DotNet.Testcontainers.Images;
   using DotNet.Testcontainers.Tests.Fixtures;
   using Xunit;
 
@@ -96,7 +98,7 @@
 
     public async Task InitializeAsync()
     {
-      this.resourceReaper = await ResourceReaper.GetAndStartNewAsync()
+      this.resourceReaper = await ResourceReaper.GetAndStartNewAsync(TestcontainersSettings.OS.DockerEndpointAuthConfig, new DockerImage("testcontainers/ryuk:0.3.4"), ResourceReaper.UnixSocketMount.Instance)
         .ConfigureAwait(false);
     }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Prepares the Resource Reaper implementation to support Ryuk on WCOW. According to the Docker engine (Linux or Windows) the Resource Repeaer requires a slightly different configuration. In case of Windows, it is necessary to mount the named pipe Docker socket (instead of the Unix socket). This requires a different mount type too (`type=npipe`).

## Why is it important?

Ryuk support increases the experience for anyone that requires or depends on WCOW. Especially for the heavy Windows containers a resilient service like Ryuk helps a lot to clean up test environments reliably.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
