### PR TITLE
Bugfix/648 do not ignore dockerfile or dockerignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - 610 Trim traling slashes in Dockerfile directory path (otherwise, it cuts the first character of the relative path), Normalize paths to forward slashes
+- 648 Always include `.dockerignore` and `Dockerfile` files in tarball (`docker build`)
 - 650 Update SharpZipLib to version 1.4.1 to prevent a deadlock in the Docker container image build
 - 666 DockerImageNotFoundException when logged in with Docker Desktop instead of the CLI
 

--- a/tests/Testcontainers.Tests/Assets/.dockerignore
+++ b/tests/Testcontainers.Tests/Assets/.dockerignore
@@ -1,3 +1,4 @@
+Dockerfile
 credHelpers
 credsStore
 healthWaitStrategy


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Appends always the `.dockerignore` and `Dockerfile` file to the `.dockerignore` list.

## Why is it important?

As mentioned in the Docker [docs](https://docs.docker.com/engine/reference/builder/#dockerignore-file), this is the default behaviour of `docker build`.

> You can even use the .dockerignore file to exclude the Dockerfile and .dockerignore files. These files are still sent to the daemon because it needs them to do its job. But the ADD and COPY instructions do not copy them to the image.

In addition to align with Docker, keeping the `Dockerfile` will prevent errors when developers add the file by mistake to the `.dockerignore` file.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #648 
- Relates #649

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
