### PR TITLE
feat(#694): Add Ryuk container privileged custom configuration

### DIFF
--- a/docs/custom_configuration/index.md
+++ b/docs/custom_configuration/index.md
@@ -2,19 +2,20 @@
 
 Testcontainers supports various configurations to set up your test environment. It automatically discovers the Docker environment and applies the configuration. You can set or override the default values either with the Testcontainers [properties file][properties-file-format] (`~/testcontainers.properties`) or with environment variables. If you prefer to configure your test environment at runtime, you can set or override the configuration through the `TestcontainersSettings` class. The following configurations are available:
 
-| Properties File          | Environment Variable                    | Description                                                                                                               | Default                     |
-|--------------------------|-----------------------------------------|---------------------------------------------------------------------------------------------------------------------------|-----------------------------|
-| `docker.config`          | `DOCKER_CONFIG`                         | The directory path that contains the Docker configuration (`config.json`) file.                                           | `~/.docker/`                |
-| `docker.host`            | `DOCKER_HOST`                           | The Docker daemon socket to connect to.                                                                                   | -                           |
-| `docker.auth.config`     | `DOCKER_AUTH_CONFIG`                    | The Docker configuration file content (GitLab: [Use statically-defined credentials][use-statically-defined-credentials]). | -                           |
-| `docker.cert.path`       | `DOCKER_CERT_PATH`                      | The directory path that contains the client certificate (`{ca,cert,key}.pem`) files.                                      | `~/.docker/`                |
-| `docker.tls`             | `DOCKER_TLS`                            | Enables TLS.                                                                                                              | `false`                     |
-| `docker.tls.verify`      | `DOCKER_TLS_VERIFY`                     | Enables TLS verify.                                                                                                       | `false`                     |
-| `host.override`          | `TESTCONTAINERS_HOST_OVERRIDE`          | The host that exposes Docker's ports.                                                                                     | -                           |
-| `docker.socket.override` | `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE` | The file path to the Docker daemon socket that is used by Ryuk (resource reaper).                                         | `/var/run/docker.sock`      |
-| `ryuk.disabled`          | `TESTCONTAINERS_RYUK_DISABLED`          | Disables Ryuk (resource reaper).                                                                                          | `false`                     |
-| `ryuk.container.image`   | `TESTCONTAINERS_RYUK_CONTAINER_IMAGE`   | The Ryuk (resource reaper) Docker image.                                                                                  | `testcontainers/ryuk:0.3.4` |
-| `hub.image.name.prefix`  | `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX`  | The name to use for substituting the Docker Hub registry part of the image name.                                          | -                           |
+| Properties File             | Environment Variable                       | Description                                                                                                               | Default                     |
+|-----------------------------|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|-----------------------------|
+| `docker.config`             | `DOCKER_CONFIG`                            | The directory path that contains the Docker configuration (`config.json`) file.                                           | `~/.docker/`                |
+| `docker.host`               | `DOCKER_HOST`                              | The Docker daemon socket to connect to.                                                                                   | -                           |
+| `docker.auth.config`        | `DOCKER_AUTH_CONFIG`                       | The Docker configuration file content (GitLab: [Use statically-defined credentials][use-statically-defined-credentials]). | -                           |
+| `docker.cert.path`          | `DOCKER_CERT_PATH`                         | The directory path that contains the client certificate (`{ca,cert,key}.pem`) files.                                      | `~/.docker/`                |
+| `docker.tls`                | `DOCKER_TLS`                               | Enables TLS.                                                                                                              | `false`                     |
+| `docker.tls.verify`         | `DOCKER_TLS_VERIFY`                        | Enables TLS verify.                                                                                                       | `false`                     |
+| `host.override`             | `TESTCONTAINERS_HOST_OVERRIDE`             | The host that exposes Docker's ports.                                                                                     | -                           |
+| `docker.socket.override`    | `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`    | The file path to the Docker daemon socket that is used by Ryuk (resource reaper).                                         | `/var/run/docker.sock`      |
+| `ryuk.disabled`             | `TESTCONTAINERS_RYUK_DISABLED`             | Disables Ryuk (resource reaper).                                                                                          | `false`                     |
+| `ryuk.container.privileged` | `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED` | Runs Ryuk (resource reaper) in privileged mode.                                                                           | `false`                     |
+| `ryuk.container.image`      | `TESTCONTAINERS_RYUK_CONTAINER_IMAGE`      | The Ryuk (resource reaper) Docker image.                                                                                  | `testcontainers/ryuk:0.3.4` |
+| `hub.image.name.prefix`     | `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX`     | The name to use for substituting the Docker Hub registry part of the image name.                                          | -                           |
 
 ## Enable logging
 

--- a/src/Testcontainers/Configurations/CustomConfiguration.cs
+++ b/src/Testcontainers/Configurations/CustomConfiguration.cs
@@ -16,7 +16,7 @@ namespace DotNet.Testcontainers.Configurations
 
     protected string GetDockerConfig(string propertyName)
     {
-      return this.GetPropertyValue(propertyName);
+      return this.GetPropertyValue<string>(propertyName);
     }
 
     protected Uri GetDockerHost(string propertyName)
@@ -26,12 +26,12 @@ namespace DotNet.Testcontainers.Configurations
 
     protected string GetDockerHostOverride(string propertyName)
     {
-      return this.GetPropertyValue(propertyName);
+      return this.GetPropertyValue<string>(propertyName);
     }
 
     protected string GetDockerSocketOverride(string propertyName)
     {
-      return this.GetPropertyValue(propertyName);
+      return this.GetPropertyValue<string>(propertyName);
     }
 
     protected JsonDocument GetDockerAuthConfig(string propertyName)
@@ -55,24 +55,27 @@ namespace DotNet.Testcontainers.Configurations
 
     protected string GetDockerCertPath(string propertyName)
     {
-      return this.GetPropertyValue(propertyName);
+      return this.GetPropertyValue<string>(propertyName);
     }
 
     protected bool GetDockerTls(string propertyName)
     {
-      _ = this.properties.TryGetValue(propertyName, out var propertyValue);
-      return "1".Equals(propertyValue, StringComparison.Ordinal) || (bool.TryParse(propertyValue, out var tlsEnabled) && tlsEnabled);
+      return this.GetPropertyValue<bool>(propertyName);
     }
 
     protected bool GetDockerTlsVerify(string propertyName)
     {
-      _ = this.properties.TryGetValue(propertyName, out var propertyValue);
-      return "1".Equals(propertyValue, StringComparison.Ordinal) || (bool.TryParse(propertyValue, out var tlsVerifyEnabled) && tlsVerifyEnabled);
+      return this.GetPropertyValue<bool>(propertyName);
     }
 
     protected bool GetRyukDisabled(string propertyName)
     {
-      return this.properties.TryGetValue(propertyName, out var propertyValue) && bool.TryParse(propertyValue, out var ryukDisabled) && ryukDisabled;
+      return this.GetPropertyValue<bool>(propertyName);
+    }
+
+    protected bool GetRyukContainerPrivileged(string propertyName)
+    {
+      return this.GetPropertyValue<bool>(propertyName);
     }
 
     protected IDockerImage GetRyukContainerImage(string propertyName)
@@ -96,13 +99,25 @@ namespace DotNet.Testcontainers.Configurations
 
     protected string GetHubImageNamePrefix(string propertyName)
     {
-      return this.GetPropertyValue(propertyName);
+      return this.GetPropertyValue<string>(propertyName);
     }
 
-    private string GetPropertyValue(string propertyName)
+    private T GetPropertyValue<T>(string propertyName)
     {
-      _ = this.properties.TryGetValue(propertyName, out var propertyValue);
-      return propertyValue;
+      switch (Type.GetTypeCode(typeof(T)))
+      {
+        case TypeCode.Boolean:
+        {
+          return (T)(object)(this.properties.TryGetValue(propertyName, out var propertyValue) && ("1".Equals(propertyValue, StringComparison.Ordinal) || (bool.TryParse(propertyValue, out var result) && result)));
+        }
+        case TypeCode.String:
+        {
+          _ = this.properties.TryGetValue(propertyName, out var propertyValue);
+          return (T)(object)propertyValue;
+        }
+        default:
+          throw new InvalidOperationException();
+      }
     }
   }
 }

--- a/src/Testcontainers/Configurations/CustomConfiguration.cs
+++ b/src/Testcontainers/Configurations/CustomConfiguration.cs
@@ -110,13 +110,15 @@ namespace DotNet.Testcontainers.Configurations
         {
           return (T)(object)(this.properties.TryGetValue(propertyName, out var propertyValue) && ("1".Equals(propertyValue, StringComparison.Ordinal) || (bool.TryParse(propertyValue, out var result) && result)));
         }
+
         case TypeCode.String:
         {
           _ = this.properties.TryGetValue(propertyName, out var propertyValue);
           return (T)(object)propertyValue;
         }
+
         default:
-          throw new InvalidOperationException();
+          throw new ArgumentOutOfRangeException(typeof(T).Name);
       }
     }
   }

--- a/src/Testcontainers/Configurations/EnvironmentConfiguration.cs
+++ b/src/Testcontainers/Configurations/EnvironmentConfiguration.cs
@@ -28,6 +28,8 @@ namespace DotNet.Testcontainers.Configurations
 
     private const string RyukDisabled = "TESTCONTAINERS_RYUK_DISABLED";
 
+    private const string RyukContainerPrivileged = "TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED";
+
     private const string RyukContainerImage = "TESTCONTAINERS_RYUK_CONTAINER_IMAGE";
 
     private const string HubImageNamePrefix = "TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX";
@@ -51,6 +53,7 @@ namespace DotNet.Testcontainers.Configurations
           DockerHostOverride,
           DockerSocketOverride,
           RyukDisabled,
+          RyukContainerPrivileged,
           RyukContainerImage,
           HubImageNamePrefix,
         }
@@ -116,6 +119,12 @@ namespace DotNet.Testcontainers.Configurations
     public bool GetRyukDisabled()
     {
       return this.GetRyukDisabled(RyukDisabled);
+    }
+
+    /// <inheritdoc />
+    public bool GetRyukContainerPrivileged()
+    {
+      return this.GetRyukContainerPrivileged(RyukContainerPrivileged);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Configurations/ICustomConfiguration.cs
+++ b/src/Testcontainers/Configurations/ICustomConfiguration.cs
@@ -80,6 +80,13 @@ namespace DotNet.Testcontainers.Configurations
     bool GetRyukDisabled();
 
     /// <summary>
+    /// Gets the Ryuk container privileged custom configuration.
+    /// </summary>
+    /// <returns>The Ryuk container privileged custom configuration.</returns>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
+    bool GetRyukContainerPrivileged();
+
+    /// <summary>
     /// Gets the Ryuk container image custom configuration.
     /// </summary>
     /// <returns>The Ryuk container image custom configuration.</returns>

--- a/src/Testcontainers/Configurations/PropertiesFileConfiguration.cs
+++ b/src/Testcontainers/Configurations/PropertiesFileConfiguration.cs
@@ -120,6 +120,13 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
+    public bool GetRyukContainerPrivileged()
+    {
+      const string propertyName = "ryuk.container.privileged";
+      return this.GetRyukContainerPrivileged(propertyName);
+    }
+
+    /// <inheritdoc />
     public IDockerImage GetRyukContainerImage()
     {
       const string propertyName = "ryuk.container.image";

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -230,10 +230,6 @@ namespace DotNet.Testcontainers.Containers
         await this.maintainConnectionTask
           .ConfigureAwait(false);
       }
-      catch (Exception)
-      {
-        // Ignore
-      }
       finally
       {
         this.maintainConnectionCts.Dispose();

--- a/tests/Testcontainers.Tests/Unit/Configurations/CustomConfigurationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/CustomConfigurationTest.cs
@@ -24,6 +24,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         EnvironmentVariables.Add("TESTCONTAINERS_HOST_OVERRIDE");
         EnvironmentVariables.Add("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE");
         EnvironmentVariables.Add("TESTCONTAINERS_RYUK_DISABLED");
+        EnvironmentVariables.Add("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED");
         EnvironmentVariables.Add("TESTCONTAINERS_RYUK_CONTAINER_IMAGE");
         EnvironmentVariables.Add("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX");
       }
@@ -140,6 +141,18 @@ namespace DotNet.Testcontainers.Tests.Unit
         SetEnvironmentVariable(propertyName, propertyValue);
         ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
         Assert.Equal(expected, customConfiguration.GetRyukDisabled());
+      }
+
+      [Theory]
+      [InlineData("", "", false)]
+      [InlineData("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "", false)]
+      [InlineData("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "false", false)]
+      [InlineData("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED", "true", true)]
+      public void GetRyukContainerPrivilegedCustomConfiguration(string propertyName, string propertyValue, bool expected)
+      {
+        SetEnvironmentVariable(propertyName, propertyValue);
+        ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
+        Assert.Equal(expected, customConfiguration.GetRyukContainerPrivileged());
       }
 
       [Theory]
@@ -286,6 +299,17 @@ namespace DotNet.Testcontainers.Tests.Unit
       {
         ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
         Assert.Equal(expected, customConfiguration.GetRyukDisabled());
+      }
+
+      [Theory]
+      [InlineData("", false)]
+      [InlineData("ryuk.container.privileged=", false)]
+      [InlineData("ryuk.container.privileged=false", false)]
+      [InlineData("ryuk.container.privileged=true", true)]
+      public void GetRyukContainerPrivilegedCustomConfiguration(string configuration, bool expected)
+      {
+        ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
+        Assert.Equal(expected, customConfiguration.GetRyukContainerPrivileged());
       }
 
       [Theory]


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Adds `GetRyukContainerPrivileged(string)` to the `CustomConfiguration` incl. to the equivalent implementations of environment (`TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED`) and properties file (`ryuk.container.privileged`) custom configuration.

## Why is it important?

The custom configuration is required to start the Resource Reaper  in privileged mode. Some environments require this configuration or mode. In addition it aligns with the configurations Java offers.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #694

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Follow-ups

Use the custom configuration to create and start the Resource Reaper container.