### PR TITLE
feat(#694): Add Resource Reaper (Ryuk) privileged mode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - 531 Add Docker health status wait strategy (@kfrajtak)
 - 640 Add `ITestcontainersBuilder<TDockerContainer>.WithResourceMapping` to copy files or or any binary contents into the created container even before it is started
 - 654 Add `ITestcontainersNetworkBuilder.WithOption` (@vlaskal)
-- 678 Add support of custom configuration `TESTCONTAINERS_HOST_OVERRIDE` and `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`.
+- 678 Add support of custom configuration `TESTCONTAINERS_HOST_OVERRIDE` and `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`
+- 694 Add Resource Reaper (Ryuk) privileged mode support (`TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED`)
 
 ### Changed
 

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -119,6 +119,13 @@ namespace DotNet.Testcontainers.Configurations
       = !PropertiesFileConfiguration.Instance.GetRyukDisabled() && !EnvironmentConfiguration.Instance.GetRyukDisabled();
 
     /// <summary>
+    /// Gets or sets a value indicating whether the <see cref="ResourceReaper" /> privileged mode is enabled or not.
+    /// </summary>
+    [PublicAPI]
+    public static bool ResourceReaperPrivilegedModeEnabled { get; set; }
+      = PropertiesFileConfiguration.Instance.GetRyukContainerPrivileged() || EnvironmentConfiguration.Instance.GetRyukContainerPrivileged();
+
+    /// <summary>
     /// Gets or sets the <see cref="ResourceReaper" /> image.
     /// </summary>
     [PublicAPI]

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -58,6 +58,7 @@ namespace DotNet.Testcontainers.Containers
         .WithName($"testcontainers-ryuk-{sessionId:D}")
         .WithDockerEndpoint(dockerEndpointAuthConfig)
         .WithImage(resourceReaperImage)
+        .WithPrivileged(requiresPrivilegedMode)
         .WithAutoRemove(true)
         .WithCleanUp(false)
         .WithExposedPort(RyukPort)
@@ -131,7 +132,9 @@ namespace DotNet.Testcontainers.Containers
 
         var resourceReaperImage = TestcontainersSettings.ResourceReaperImage ?? RyukImage;
 
-        defaultInstance = await GetAndStartNewAsync(DefaultSessionId, dockerEndpointAuthConfig, resourceReaperImage, UnixSocketMount.Instance, ct: ct)
+        var requiresPrivilegedMode = TestcontainersSettings.ResourceReaperPrivilegedModeEnabled;
+
+        defaultInstance = await GetAndStartNewAsync(DefaultSessionId, dockerEndpointAuthConfig, resourceReaperImage, UnixSocketMount.Instance, requiresPrivilegedMode, ct: ct)
           .ConfigureAwait(false);
 
         return defaultInstance;


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Adds the `ResourceReaperPrivilegedModeEnabled` setting and forwards the value to the Resource Reaper (Ryuk) container start.

## Why is it important?

Some environments require to start the Resource Reaper in privileged mode. This change will add support for those environments. Furthermore, it aligns with other Testcontainers implementations.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #694

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
