### PR TITLE
feat: Prepare next release cycle (2.4.0)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,26 @@
+name-template: $RESOLVED_VERSION
+tag-template: $RESOLVED_VERSION
+commitish: refs/heads/master
+prerelease: true
+template: |
+  # What's Changed
+  $CHANGES
+
+categories:
+  - title: ⚠️ Breaking Changes
+    labels: breaking change
+
+  - title: 🚀 Features
+    labels: enhancement
+
+  - title: 🐛 Bug Fixes
+    labels: bug
+
+  - title: 📖 Documentation
+    labels: documentation
+
+  - title: 🧹 Housekeeping
+    labels: chore
+
+  - title: 📦 Dependency Updates
+    label: dependencies

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -136,3 +136,10 @@ jobs:
         run: dotnet cake --target=Publish
         env:
           PUBLISH_NUGET_PACKAGE: ${{ inputs.publish_nuget_package }}
+
+      - uses: release-drafter/release-drafter@6df64e4ba4842c203c604c1f45246c5863410adb
+        with:
+          publish: true
+          version: ${{ env.semVer }} # Cake sets the semVer environment variable
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -76,6 +76,10 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    permissions:
+      contents: write
+      pull-requests: read
+
     env:
       FEED_SOURCE: https://api.nuget.org/v3/index.json
       FEED_APIKEY: ${{ secrets.FEED_APIKEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Added
 
 - 531 Add Docker health status wait strategy (@kfrajtak)
-- 640 Add `ITestcontainersBuilder<TDockerContainer>.WithResourceMapping` to copy files or or any binary contents into the created container even before it is started
+- 640 Add `ITestcontainersBuilder<TDockerContainer>.WithResourceMapping` to copy files or any binary contents into the created container before it is started
 - 654 Add `ITestcontainersNetworkBuilder.WithOption` (@vlaskal)
 - 678 Add support of custom configuration `TESTCONTAINERS_HOST_OVERRIDE` and `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`
 - 694 Add Resource Reaper (Ryuk) privileged mode support (`TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED`)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>$(AssemblyName)</PackageId>
-    <Version>2.3.0</Version>
+    <Version>2.4.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Product>Testcontainers</Product>

--- a/docs/api/wait_strategies.md
+++ b/docs/api/wait_strategies.md
@@ -1,6 +1,6 @@
 # Wait Strategies
 
-Wait strategies are useful to detect if a container is ready for testing (i.e., if the application inside the container is in a usable state). They check different indicators of readiness of the container and complete as soon as they are fulfilled. Per default, Testcontainers will wait until the container is running. For simple images, that is not enough. You can chain different pre-configured wait strategies together or implement your own by implementing the `IWaitUntil` interface.
+Wait strategies are useful to detect if a container is ready for testing (i.e., if the application inside the container is in a usable state). They check different indicators of readiness of the container and complete as soon as they are fulfilled. Per default, Testcontainers will wait until the container is running. For the most images, that is not enough. You can chain different pre-configured wait strategies together or implement your own by implementing the `IWaitUntil` interface.
 
 ```csharp
 _ = Wait.ForUnixContainer()
@@ -25,7 +25,10 @@ You can leverage the container's health status as your wait strategy to report r
 ```csharp
 _ = new TestcontainersBuilder<TestcontainersContainer>()
   .WithWaitStrategy(Wait.ForUnixContainer().UntilContainerIsHealthy())
-  .Build();
 ```
+
+## Wait until custom strategy succeed
+
+In case of the pre-configured wait strategies do not support your use case, you can add your own wait strategy by implementing `IWaitUntil` and calling `AddCustomWaitStrategy(IWaitUntil)`:
 
 [docker-docs-healthcheck]: https://docs.docker.com/engine/reference/builder/#healthcheck

--- a/docs/api/wait_strategies.md
+++ b/docs/api/wait_strategies.md
@@ -27,8 +27,4 @@ _ = new TestcontainersBuilder<TestcontainersContainer>()
   .WithWaitStrategy(Wait.ForUnixContainer().UntilContainerIsHealthy())
 ```
 
-## Wait until custom strategy succeed
-
-In case of the pre-configured wait strategies do not support your use case, you can add your own wait strategy by implementing `IWaitUntil` and calling `AddCustomWaitStrategy(IWaitUntil)`:
-
 [docker-docs-healthcheck]: https://docs.docker.com/engine/reference/builder/#healthcheck

--- a/src/Testcontainers/Containers/Modules/Databases/CouchbaseTestcontainer.cs
+++ b/src/Testcontainers/Containers/Modules/Databases/CouchbaseTestcontainer.cs
@@ -33,10 +33,10 @@ namespace DotNet.Testcontainers.Containers
     /// <param name="bucket">The name of the bucket to create.</param>
     /// <param name="memory">The amount of memory to allocate to the cache for this bucket, in Megabytes.</param>
     /// <returns>A task that returns the couchbase-cli exit code when it is finished.</returns>
-    public async Task<ExecResult> CreateBucket(string bucket, int memory = 128)
+    public Task<ExecResult> CreateBucket(string bucket, int memory = 128)
     {
       var createBucketCommand = $"{CouchbaseCli} bucket-create -c 127.0.0.1:8091 --username {this.Username} --password {this.Password} --bucket {bucket} --bucket-type couchbase --bucket-ramsize {memory} --enable-flush 1 --bucket-replica 0 --wait";
-      return await this.ExecAsync(new[] { "/bin/sh", "-c", createBucketCommand });
+      return this.ExecAsync(new[] { "/bin/sh", "-c", createBucketCommand });
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Sets the version of the next Testcontainers for .NET release. Adds Release Drafter CI integration.

## Why is it important?

To reduce the amount of work maintaining the CHANGELOG.MD, we add Release Drafter to the repository. The delta between a released and upcoming version will be tracked as prerelease in GitHub,

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
