### PR TITLE
chore: Increase HttpWaitStrategy test coverage

### DIFF
--- a/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
@@ -201,12 +201,7 @@
     /// <returns>A configured instance of <see cref="HttpWaitStrategy" />.</returns>
     public HttpWaitStrategy WithHeaders(IReadOnlyDictionary<string, string> headers)
     {
-      foreach (var header in headers)
-      {
-        _ = this.WithHeader(header.Key, header.Value);
-      }
-
-      return this;
+      return headers.Aggregate(this, (httpWaitStrategy, header) => httpWaitStrategy.WithHeader(header.Key, header.Value));
     }
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace DotNet.Testcontainers.Tests.Unit.Configurations
 {
   using System.Collections.Generic;
+  using System.Linq;
   using System.Net;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Builders;
@@ -10,38 +11,65 @@
   using Microsoft.Extensions.Logging.Abstractions;
   using Xunit;
 
-  public sealed class WaitUntilHttpRequestIsSucceededTest
+  public sealed class WaitUntilHttpRequestIsSucceededTest : IAsyncLifetime
   {
+    private const ushort HttpPort = 80;
+
+    private readonly ITestcontainersContainer container = new TestcontainersBuilder<TestcontainersContainer>()
+      .WithImage(CommonImages.Alpine)
+      .WithEntrypoint("/bin/sh", "-c")
+      .WithCommand($"echo \"HTTP/1.1 200 OK\r\n\" | nc -l -p {HttpPort}")
+      .WithPortBinding(HttpPort, true)
+      .Build();
+
     public static IEnumerable<object[]> GetHttpWaitStrategies()
     {
       yield return new object[] { new HttpWaitStrategy() };
+      yield return new object[] { new HttpWaitStrategy().ForPort(HttpPort) };
       yield return new object[] { new HttpWaitStrategy().ForStatusCode(HttpStatusCode.OK) };
       yield return new object[] { new HttpWaitStrategy().ForStatusCodeMatching(statusCode => HttpStatusCode.OK.Equals(statusCode)) };
-      yield return new object[] { new HttpWaitStrategy().ForStatusCode(HttpStatusCode.Moved).ForStatusCodeMatching(statusCode => HttpStatusCode.OK.Equals(statusCode)) };
+      yield return new object[] { new HttpWaitStrategy().ForStatusCode(HttpStatusCode.MovedPermanently).ForStatusCodeMatching(statusCode => HttpStatusCode.OK.Equals(statusCode)) };
+    }
+
+    public Task InitializeAsync()
+    {
+      return this.container.StartAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+      return this.container.DisposeAsync().AsTask();
     }
 
     [Theory]
     [MemberData(nameof(GetHttpWaitStrategies))]
-    public async Task HttpWaitStrategyShouldSucceeded(HttpWaitStrategy httpWaitStrategy)
+    public async Task HttpWaitStrategyReceivesStatusCode(HttpWaitStrategy httpWaitStrategy)
     {
-      // Given
-      const ushort httpPort = 80;
-
-      var container = new TestcontainersBuilder<TestcontainersContainer>()
-        .WithImage(CommonImages.Nginx)
-        .WithPortBinding(httpPort, true)
-        .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(httpPort))
-        .Build();
-
-      // When
-      await container.StartAsync()
+      var succeeded = await httpWaitStrategy.Until(this.container, NullLogger.Instance)
         .ConfigureAwait(false);
 
-      var succeeded = await httpWaitStrategy.Until(container, NullLogger.Instance)
+      Assert.True(succeeded);
+    }
+
+    [Fact]
+    public async Task HttpWaitStrategySendsHeaders()
+    {
+      // Given
+      var httpHeaders = new Dictionary<string, string> { { "Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==" } };
+
+      var httpWaitStrategy = new HttpWaitStrategy().WithHeaders(httpHeaders);
+
+      // When
+      var succeeded = await httpWaitStrategy.Until(this.container, NullLogger.Instance)
+        .ConfigureAwait(false);
+
+      var (stdout, _) = await this.container.GetLogs()
         .ConfigureAwait(false);
 
       // Then
       Assert.True(succeeded);
+      Assert.Contains(httpHeaders.First().Key, stdout);
+      Assert.Contains(httpHeaders.First().Value, stdout);
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Adds another test to cover the HTTP wait strategy header configuration.

## Why is it important?

Fulfil SonarCloud coverage gateway.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
