### PR TITLE
chore: Reduce CodeQL concurrent builds, do not add all PRs to the release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,21 +4,29 @@ template: |
   # What's Changed
   $CHANGES
 
+include-labels:
+  - breaking change
+  - enhancement
+  - bug
+  - documentation
+  - chore
+  - dependencies
+
 categories:
   - title: ⚠️ Breaking Changes
-    labels: breaking change
+    label: breaking change
 
   - title: 🚀 Features
-    labels: enhancement
+    label: enhancement
 
   - title: 🐛 Bug Fixes
-    labels: bug
+    label: bug
 
   - title: 📖 Documentation
-    labels: documentation
+    label: documentation
 
   - title: 🧹 Housekeeping
-    labels: chore
+    label: chore
 
   - title: 📦 Dependency Updates
     label: dependencies

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-2022]
+        os: [ ubuntu-22.04, windows-2022 ]
 
     runs-on: ${{ matrix.os }}
 
@@ -35,7 +35,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
-          clean: true
           lfs: true
 
       - name: Cache NuGet Packages
@@ -96,7 +95,6 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
-          clean: true
           lfs: true
           fetch-depth: 0
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ develop, master ]
 
+concurrency:
+  group: ${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     strategy:

--- a/src/Testcontainers/Configurations/Modules/MessageBrokers/LocalStackTestcontainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Modules/MessageBrokers/LocalStackTestcontainerConfiguration.cs
@@ -26,8 +26,8 @@ namespace DotNet.Testcontainers.Configurations
     public LocalStackTestcontainerConfiguration(string image)
       : base(image, LocalStackPort)
     {
-        this.Environments.Add("EXTERNAL_SERVICE_PORTS_START", "4510");
-        this.Environments.Add("EXTERNAL_SERVICE_PORTS_END", "4559");
+      this.Environments.Add("EXTERNAL_SERVICE_PORTS_START", "4510");
+      this.Environments.Add("EXTERNAL_SERVICE_PORTS_END", "4559");
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -93,7 +93,7 @@
             }
 
             // SharpZipLib's WriteEntry(TarEntry, bool) writes the entry, but without bytes if the file is used by another process.
-            // This results in a TarException on TarArchive.Dispose(): Entry closed at '0' before the 'x' bytes specified in the header were written.
+            // This results in a TarException on TarArchive.Dispose(): Entry closed at '0' before the 'x' bytes specified in the header were written: https://github.com/icsharpcode/SharpZipLib/issues/819.
             try
             {
               var fileStream = File.Open(absoluteFilePath, FileMode.Open, FileAccess.Read, FileShare.Read);

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
@@ -57,7 +57,7 @@
     public void ShouldGetDefaultDockerRegistryAuthenticationConfiguration()
     {
       var authenticationProvider = new DockerRegistryAuthenticationProvider("/tmp/docker.config", NullLogger.Instance);
-      Assert.Equal(default(DockerRegistryAuthenticationConfiguration), authenticationProvider.GetAuthConfig(DockerRegistry));
+      Assert.Equal(default(DockerRegistryAuthenticationConfiguration), authenticationProvider.GetAuthConfig("index.docker.io"));
     }
 
     public sealed class Base64ProviderTest


### PR DESCRIPTION
## What does this PR do?

Reduces the amount of CodeQL concurrent builds and does not publish every PR to the release notes (like this one or e.g. removing Sonar findings).

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
