### PR TITLE
chore: Replace SharpZipLib TarArchive helper class with TarOutputStream

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -13,7 +13,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ on:
     branches: [ develop, master ]
 
 concurrency:
-  group: ${{ github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -115,9 +115,9 @@ namespace DotNet.Testcontainers.Clients
 
       try
       {
-        using (var dockerfileStream = new FileStream(dockerfileArchiveFilePath, FileMode.Open, FileAccess.Read))
+        using (var dockerfileArchiveStream = new FileStream(dockerfileArchiveFilePath, FileMode.Open, FileAccess.Read))
         {
-          await this.Docker.Images.BuildImageFromDockerfileAsync(buildParameters, dockerfileStream, Array.Empty<AuthConfig>(), new Dictionary<string, string>(), this.traceProgress, ct)
+          await this.Docker.Images.BuildImageFromDockerfileAsync(buildParameters, dockerfileArchiveStream, Array.Empty<AuthConfig>(), new Dictionary<string, string>(), this.traceProgress, ct)
             .ConfigureAwait(false);
 
           var imageHasBeenCreated = await this.ExistsWithNameAsync(image.FullName, ct)

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -111,7 +111,8 @@ namespace DotNet.Testcontainers.Clients
         Labels = configuration.Labels.ToDictionary(item => item.Key, item => item.Value),
       };
 
-      var dockerfileArchiveFilePath = dockerfileArchive.Tar();
+      var dockerfileArchiveFilePath = await dockerfileArchive.Tar(ct)
+        .ConfigureAwait(false);
 
       try
       {

--- a/src/Testcontainers/Images/DockerIgnoreFile.cs
+++ b/src/Testcontainers/Images/DockerIgnoreFile.cs
@@ -1,5 +1,6 @@
 ﻿namespace DotNet.Testcontainers.Images
 {
+  using System;
   using System.Collections.Generic;
   using System.IO;
   using System.Linq;
@@ -13,35 +14,43 @@
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerIgnoreFile" /> class.
     /// </summary>
-    /// <param name="dockerIgnoreFileDirectory">Directory that contains all docker configuration files.</param>
-    /// <param name="dockerIgnoreFile">.dockerignore file name.</param>
+    /// <param name="dockerignoreFileDirectory">Directory that contains all docker configuration files.</param>
+    /// <param name="dockerignoreFile">.dockerignore file name.</param>
     /// <param name="dockerfileFile">Dockerfile file name.</param>
     /// <param name="logger">The logger.</param>
-    public DockerIgnoreFile(string dockerIgnoreFileDirectory, string dockerIgnoreFile, string dockerfileFile, ILogger logger)
-      : this(new DirectoryInfo(dockerIgnoreFileDirectory), dockerIgnoreFile, dockerfileFile, logger)
+    public DockerIgnoreFile(string dockerignoreFileDirectory, string dockerignoreFile, string dockerfileFile, ILogger logger)
+      : this(new DirectoryInfo(dockerignoreFileDirectory), dockerignoreFile, dockerfileFile, logger)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerIgnoreFile" /> class.
     /// </summary>
-    /// <param name="dockerIgnoreFileDirectory">Directory that contains all docker configuration files.</param>
-    /// <param name="dockerIgnoreFile">.dockerignore file name.</param>
+    /// <param name="dockerignoreFileDirectory">Directory that contains all docker configuration files.</param>
+    /// <param name="dockerignoreFile">.dockerignore file name.</param>
     /// <param name="dockerfileFile">Dockerfile file name.</param>
     /// <param name="logger">The logger.</param>
-    public DockerIgnoreFile(DirectoryInfo dockerIgnoreFileDirectory, string dockerIgnoreFile, string dockerfileFile, ILogger logger)
-      : base(GetPatterns(dockerIgnoreFileDirectory, dockerIgnoreFile, dockerfileFile), logger)
+    public DockerIgnoreFile(DirectoryInfo dockerignoreFileDirectory, string dockerignoreFile, string dockerfileFile, ILogger logger)
+      : base(GetPatterns(dockerignoreFileDirectory, dockerignoreFile, dockerfileFile), logger)
     {
     }
 
-    private static IEnumerable<string> GetPatterns(DirectoryInfo dockerIgnoreFileDirectory, string dockerIgnoreFile, string dockerfileFile)
+    private static IEnumerable<string> GetPatterns(DirectoryInfo dockerignoreFileDirectory, string dockerignoreFile, string dockerfileFile)
     {
+      var dockerignoreFilePath = Path.Combine(dockerignoreFileDirectory.FullName, dockerignoreFile);
+
       // These files are necessary and sent to the Docker daemon. The ADD and COPY instructions do not copy them to the image:
       // https://docs.docker.com/engine/reference/builder/#dockerignore-file.
-      var negateNecessaryFiles = new[] { dockerIgnoreFile, dockerfileFile }.Select(file => "!" + file);
-      return dockerIgnoreFileDirectory.GetFiles(dockerIgnoreFile, SearchOption.TopDirectoryOnly).Any()
-        ? File.ReadLines(Path.Combine(dockerIgnoreFileDirectory.FullName, dockerIgnoreFile)).Concat(negateNecessaryFiles)
-        : negateNecessaryFiles;
+      var negateNecessaryFiles = new[] { dockerignoreFile, dockerfileFile }
+        .Select(file => "!" + file);
+
+      var dockerignorePatterns = File.Exists(dockerignoreFilePath)
+        ? File.ReadLines(dockerignoreFilePath)
+        : Array.Empty<string>();
+
+      return new[] { "**/.idea", "**/.vs" }
+        .Concat(dockerignorePatterns)
+        .Concat(negateNecessaryFiles);
     }
   }
 }

--- a/src/Testcontainers/Images/ITarArchive.cs
+++ b/src/Testcontainers/Images/ITarArchive.cs
@@ -1,5 +1,8 @@
 namespace DotNet.Testcontainers.Images
 {
+  using System.Threading;
+  using System.Threading.Tasks;
+
   /// <summary>
   /// Collects files into one tar archive file.
   /// </summary>
@@ -8,7 +11,8 @@ namespace DotNet.Testcontainers.Images
     /// <summary>
     /// Creates a tar archive file.
     /// </summary>
-    /// <returns>Path to the created archive file.</returns>
-    string Tar();
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the tar archive file has been created.</returns>
+    Task<string> Tar(CancellationToken ct = default);
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -14,7 +14,7 @@ namespace DotNet.Testcontainers.Tests.Unit
   public sealed class ImageFromDockerfileTest
   {
     [Fact]
-    public void DockerfileArchiveTar()
+    public async Task DockerfileArchiveTar()
     {
       // Given
       var image = new DockerImage("testcontainers", "test", "0.1.0");
@@ -23,12 +23,15 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       var actual = new SortedSet<string>();
 
-      var dockerFileArchive = new DockerfileArchive("Assets", "Dockerfile", image, NullLogger.Instance);
+      var dockerfileArchive = new DockerfileArchive("Assets", "Dockerfile", image, NullLogger.Instance);
+
+      var dockerfileArchiveFilePath = await dockerfileArchive.Tar()
+        .ConfigureAwait(false);
 
       // When
-      using (var tarOut = new FileInfo(dockerFileArchive.Tar()).OpenRead())
+      using (var tarOut = new FileStream(dockerfileArchiveFilePath, FileMode.Open, FileAccess.Read))
       {
-        using (var tarIn = TarArchive.CreateInputTarArchive(tarOut, Encoding.UTF8))
+        using (var tarIn = TarArchive.CreateInputTarArchive(tarOut, Encoding.Default))
         {
           tarIn.ProgressMessageEvent += (_, entry, _) => actual.Add(entry.Name);
           tarIn.ListContents();


### PR DESCRIPTION
## What does this PR do?

Replaces the TarArchive helper class with the TarOutputStream.

## Why is it important?

This PR allows us to read the input file before creating the tar entry. In some cases (e.g. the input file is used by another process), we cannot read the file contents. The SharpZipLib's `TarArchive.WriteEntry(TarEntry, bool)` helper method creates and adds the tar entry before reading the file. In the case mentioned above, this will throw a `TarException` that hides the underlying exception (issue).

For a better development experience, we replace the helper class / method. In case of an error, developers will get the underlying error.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
