### PR TITLE
feat(#725): Do not return JSON auth config for partial Docker registry matches

### DIFF
--- a/src/Testcontainers/Builders/CredsHelperProvider.cs
+++ b/src/Testcontainers/Builders/CredsHelperProvider.cs
@@ -1,6 +1,5 @@
 ﻿namespace DotNet.Testcontainers.Builders
 {
-  using System;
   using System.Linq;
   using System.Text.Json;
   using DotNet.Testcontainers.Configurations;
@@ -40,11 +39,7 @@
     /// <inheritdoc />
     public bool IsApplicable(string hostname)
     {
-#if NETSTANDARD2_1_OR_GREATER
-      return !default(JsonElement).Equals(this.rootElement) && !JsonValueKind.Null.Equals(this.rootElement.ValueKind) && this.rootElement.EnumerateObject().Any(property => property.Name.Contains(hostname, StringComparison.OrdinalIgnoreCase));
-#else
-      return !default(JsonElement).Equals(this.rootElement) && !JsonValueKind.Null.Equals(this.rootElement.ValueKind) && this.rootElement.EnumerateObject().Any(property => property.Name.IndexOf(hostname, StringComparison.OrdinalIgnoreCase) >= 0);
-#endif
+      return !default(JsonElement).Equals(this.rootElement) && !JsonValueKind.Null.Equals(this.rootElement.ValueKind) && this.rootElement.EnumerateObject().Any(property => Base64Provider.HasDockerRegistryKey(property, hostname));
     }
 
     /// <inheritdoc />
@@ -57,11 +52,7 @@
         return null;
       }
 
-#if NETSTANDARD2_1_OR_GREATER
-      var registryEndpointProperty = this.rootElement.EnumerateObject().LastOrDefault(property => property.Name.Contains(hostname, StringComparison.OrdinalIgnoreCase));
-#else
-      var registryEndpointProperty = this.rootElement.EnumerateObject().LastOrDefault(property => property.Name.IndexOf(hostname, StringComparison.OrdinalIgnoreCase) >= 0);
-#endif
+      var registryEndpointProperty = this.rootElement.EnumerateObject().LastOrDefault(property => Base64Provider.HasDockerRegistryKey(property, hostname));
 
       if (!JsonValueKind.String.Equals(registryEndpointProperty.Value.ValueKind))
       {

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
@@ -63,6 +63,22 @@
     public sealed class Base64ProviderTest
     {
       [Theory]
+      [InlineData("{\"auths\":{\"ghcr.io\":{}}}")]
+      [InlineData("{\"auths\":{\"://ghcr.io\":{}}}")]
+      public void ResolvePartialDockerRegistry(string jsonDocument)
+      {
+        // Given
+        var jsonElement = JsonDocument.Parse(jsonDocument).RootElement;
+
+        // When
+        var authenticationProvider = new Base64Provider(jsonElement, NullLogger.Instance);
+
+        // Then
+        Assert.False(authenticationProvider.IsApplicable("ghcr"));
+        Assert.True(authenticationProvider.IsApplicable("ghcr.io"));
+      }
+
+      [Theory]
       [InlineData("{}", false)]
       [InlineData("{\"auths\":null}", false)]
       [InlineData("{\"auths\":{}}", false)]


### PR DESCRIPTION
## What does this PR do?

Changes the Docker registry resolution to use the entire TLD of the image name (not partial) anymore.

## Why is it important?

With the current implementation, looking up the JSON file based auth config for an image `registry.example.co/org/repo` would return the auth config for `https://registry.example.com` (note the missing `m` from the TLD of the image name). 

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #725

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
