### PR TITLE
chore: Replace host port 0 with an empty string

### DIFF
--- a/src/Testcontainers/Builders/TestcontainersBuilder.cs
+++ b/src/Testcontainers/Builders/TestcontainersBuilder.cs
@@ -186,6 +186,9 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc cref="ITestcontainersBuilder{TDockerContainer}" />
     public ITestcontainersBuilder<TDockerContainer> WithPortBinding(string hostPort, string containerPort)
     {
+      // Prepare Java alignment. Use an empty string instead of 0: https://github.com/docker/for-mac/issues/5588#issuecomment-934600089.
+      hostPort = "0".Equals(hostPort, StringComparison.OrdinalIgnoreCase) ? string.Empty : hostPort;
+
       var portBindings = new Dictionary<string, string> { { containerPort, hostPort } };
       return this.MergeNewConfiguration(new TestcontainersConfiguration(portBindings: portBindings))
         .WithExposedPort(containerPort);

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -143,7 +143,7 @@ namespace DotNet.Testcontainers.Configurations
     /// </remarks>
     [NotNull]
     public static Func<IDockerEndpointAuthenticationConfiguration, ushort> ResourceReaperPublicHostPort { get; set; }
-      = GetResourceReaperPublicHostPort;
+      = _ => 0;
 
     /// <summary>
     /// Gets or sets a prefix that applies to every image that is pulled from Docker Hub.
@@ -175,22 +175,5 @@ namespace DotNet.Testcontainers.Configurations
     [NotNull]
     public static WaitHandle SettingsInitialized
       => ManualResetEvent.WaitHandle;
-
-    private static ushort GetResourceReaperPublicHostPort(IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig)
-    {
-      // Let Docker choose the random public host port. This includes Docker Engines exposed via TCP (Docker Desktop for Windows).
-      if (!NpipeEndpointAuthenticationProvider.DockerEngine.Equals(dockerEndpointAuthConfig.Endpoint))
-      {
-        return 0;
-      }
-
-      // Get the next available public host port. This might run in rare cases into a race-condition.
-      // It's still much more stable than letting Docker Desktop for Windows choose the port.
-      using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-      {
-        socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-        return (ushort)((IPEndPoint)socket.LocalEndPoint).Port;
-      }
-    }
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
@@ -1,5 +1,6 @@
 ﻿namespace DotNet.Testcontainers.Tests.Unit.Configurations
 {
+  using System;
   using System.Collections.Generic;
   using System.Linq;
   using System.Net;
@@ -61,6 +62,9 @@
 
       // When
       var succeeded = await httpWaitStrategy.Until(this.container, NullLogger.Instance)
+        .ConfigureAwait(false);
+
+      await Task.Delay(TimeSpan.FromSeconds(1))
         .ConfigureAwait(false);
 
       var (stdout, _) = await this.container.GetLogs()


### PR DESCRIPTION
## What does this PR do?

Changes the default host port from `0` to an empty string. Considering https://github.com/docker/for-mac/issues/5588#issuecomment-934600089 the implementation of Docker Desktop behaves different. We see this in the chosen ports too. The port ranges are different. This is just the preparation. If there are no issues we can remove `ResourceReaperPublicHostPort` and the host port `0` configurations from the modules.

## Why is it important?

To align with the Java implementation. All TC developers should experience the same behavior.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/testcontainers/testcontainers-java/pull/6383#pullrequestreview-1235448254

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
