### PR TITLE
docs: Add Docker Desktop Compose example

### DIFF
--- a/docs/examples/compose.md
+++ b/docs/examples/compose.md
@@ -3,7 +3,7 @@
 ## Docker Desktop
 
 To use Docker's Compose tool to build and run a Testcontainers environment in a Docker Desktop Wormhole configuration,
-it is necessary to override Testcontainers Docker host resolution and set the environment variable `TESTCONTAINERS_HOST_OVERRIDE` to `host.docker.internal`.
+it is necessary to override Testcontainers' Docker host resolution and set the environment variable `TESTCONTAINERS_HOST_OVERRIDE` to `host.docker.internal`.
 Otherwise, Testcontainers cannot access sibling containers like the Resource Reaper Ryuk or other services running on the Docker's host.
 A minimal `docker-compose.yml` file that builds a new container image and runs the test inside the container look something like:
 

--- a/docs/examples/compose.md
+++ b/docs/examples/compose.md
@@ -14,7 +14,8 @@ services:
     build:
       dockerfile: Dockerfile
       context: .
-    entrypoint: dotnet test
+    entrypoint: dotnet
+    command: test
     environment:
       - TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal
     volumes:

--- a/docs/examples/compose.md
+++ b/docs/examples/compose.md
@@ -1,0 +1,22 @@
+# Compose
+
+## Docker Desktop
+
+To use Docker's Compose tool to build and run a Testcontainers environment in a Docker Desktop Wormhole configuration,
+it is necessary to override Testcontainers Docker host resolution and set the environment variable `TESTCONTAINERS_HOST_OVERRIDE` to `host.docker.internal`.
+Otherwise, Testcontainers cannot access sibling containers like the Resource Reaper Ryuk or other services running on the Docker's host.
+A minimal `docker-compose.yml` file that builds a new container image and runs the test inside the container look something like:
+
+```Yaml
+version: "3"
+services:
+  docker_compose_test:
+    build:
+      dockerfile: Dockerfile
+      context: .
+    entrypoint: dotnet test
+    environment:
+      - TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```

--- a/docs/examples/compose.md
+++ b/docs/examples/compose.md
@@ -4,7 +4,7 @@
 
 To use Docker's Compose tool to build and run a Testcontainers environment in a Docker Desktop Wormhole configuration,
 it is necessary to override Testcontainers' Docker host resolution and set the environment variable `TESTCONTAINERS_HOST_OVERRIDE` to `host.docker.internal`.
-Otherwise, Testcontainers cannot access sibling containers like the Resource Reaper Ryuk or other services running on the Docker's host.
+Otherwise, Testcontainers cannot access sibling containers like the Resource Reaper Ryuk or other services running on the Docker host.
 A minimal `docker-compose.yml` file that builds a new container image and runs the test inside the container look something like:
 
 ```Yaml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
   - api/resource-reaper.md
   - api/wait_strategies.md
   - Examples:
+    - examples/compose.md
     - examples/aspnet.md
   - Modules:
     - modules/index.md


### PR DESCRIPTION
## What does this PR do?

Adds a Docker Desktop Compose example.

## Why is it important?

For the Docker Desktop Compose configuration, it is necessary to set the `TESTCONTAINERS_HOST_OVERRIDE` environment variable to `host.docker.internal`. This configuration is not obvious. The example helps developers to set up a Docker Desktop Compose configuration.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
