### PR TITLE
feat: add azure sql edge test container configuration

### DIFF
--- a/src/Testcontainers/_OBSOLETE_/Modules/Databases/AzureSqlEdgeTestcontainerConfiguration.cs
+++ b/src/Testcontainers/_OBSOLETE_/Modules/Databases/AzureSqlEdgeTestcontainerConfiguration.cs
@@ -1,0 +1,44 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System.IO;
+  using DotNet.Testcontainers.Builders;
+  using JetBrains.Annotations;
+
+  /// <inheritdoc cref="TestcontainerDatabaseConfiguration" />
+  [PublicAPI]
+  public class AzureSqlEdgeTestcontainerConfiguration : MsSqlTestcontainerConfiguration
+  {
+    public override IOutputConsumer OutputConsumer { get; } = Consume.RedirectStdoutAndStderrToStream(new MemoryStream(), new MemoryStream());
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureSqlEdgeTestcontainerConfiguration" /> class.
+    /// </summary>
+    public AzureSqlEdgeTestcontainerConfiguration()
+      : this("mcr.microsoft.com/azure-sql-edge:1.0.6")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureSqlEdgeTestcontainerConfiguration" /> class.
+    /// </summary>
+    /// <param name="image">
+    /// The Docker image.
+    /// You can retrieve a list of all available tags for azure-sql-edge at https://mcr.microsoft.com/v2/azure-sql-edge/tags/list
+    /// </param>
+    public AzureSqlEdgeTestcontainerConfiguration(string image)
+      : base(image)
+    {
+    }
+
+    /// <summary>
+    /// Scanning for messages in log since sqlcmd is not available on all platforms:
+    ///   https://hub.docker.com/_/microsoft-azure-sql-edge
+    ///   https://learn.microsoft.com/en-us/azure/azure-sql-edge/connect#tools-to-connect-to-azure-sql-edge
+    /// [!NOTE] sqlcmd tool is not available inside the ARM64 version of SQL Edge containers.
+    /// </summary>
+    public override IWaitForContainerOS WaitStrategy =>
+      Wait
+        .ForUnixContainer()
+        .UntilMessageIsLogged(this.OutputConsumer.Stdout, "Recovery is complete.*");
+  }
+}

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/AzureSqlEdgeFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/Modules/Databases/AzureSqlEdgeFixture.cs
@@ -1,0 +1,44 @@
+namespace DotNet.Testcontainers.Tests.Fixtures
+{
+  using System.Data.Common;
+  using System.Data.SqlClient;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Containers;
+  using JetBrains.Annotations;
+
+  [UsedImplicitly]
+  public sealed class AzureSqlEdgeFixture : DatabaseFixture<MsSqlTestcontainer, DbConnection>
+  {
+    private readonly TestcontainerDatabaseConfiguration configuration = new AzureSqlEdgeTestcontainerConfiguration { Password = "yourStrong(!)Password" }; // https://hub.docker.com/_/microsoft-azure-sql-edge
+
+    public AzureSqlEdgeFixture()
+    {
+      this.Container = new TestcontainersBuilder<MsSqlTestcontainer>()
+        .WithDatabase(this.configuration)
+        .Build();
+    }
+
+    public override async Task InitializeAsync()
+    {
+      await this.Container.StartAsync()
+        .ConfigureAwait(false);
+
+      this.Connection = new SqlConnection(this.Container.ConnectionString);
+    }
+
+    public override async Task DisposeAsync()
+    {
+      this.Connection.Dispose();
+
+      await this.Container.DisposeAsync()
+        .ConfigureAwait(false);
+    }
+
+    public override void Dispose()
+    {
+      this.configuration.Dispose();
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/MsSqlTestcontainerUsingAzureSqlEdgeConfigurationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/Modules/Databases/MsSqlTestcontainerUsingAzureSqlEdgeConfigurationTest.cs
@@ -1,0 +1,31 @@
+namespace DotNet.Testcontainers.Tests.Unit
+{
+  using System.Data;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Tests.Fixtures;
+  using Xunit;
+
+  public sealed class MsSqlTestcontainerUsingAzureSqlEdgeConfigurationTest : IClassFixture<AzureSqlEdgeFixture>
+  {
+    private readonly AzureSqlEdgeFixture azureSqlFixture;
+
+    public MsSqlTestcontainerUsingAzureSqlEdgeConfigurationTest(AzureSqlEdgeFixture azureSqlFixture)
+    {
+      this.azureSqlFixture = azureSqlFixture;
+    }
+
+    [Fact]
+    public async Task ConnectionEstablished()
+    {
+      // Given
+      var connection = this.azureSqlFixture.Connection;
+
+      // When
+      await connection.OpenAsync()
+        .ConfigureAwait(false);
+
+      // Then
+      Assert.Equal(ConnectionState.Open, connection.State);
+    }
+  }
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Add support for Azure SQL Edge test containers.

## Why is it important?

Only SQL variant that runs on MacBook M1 🤘🏻

## Related issues

No issues.

## How to test this PR

Running the new integration test will suffice.

## Follow-ups

Including a dedicated test container is optional.