### PR TITLE
[Bug]: #736 Cannot connect a Schema Registry running from another containe…

### DIFF
--- a/src/Testcontainers/Builders/TestcontainersBuilderKafkaExtension.cs
+++ b/src/Testcontainers/Builders/TestcontainersBuilderKafkaExtension.cs
@@ -19,6 +19,7 @@ namespace DotNet.Testcontainers.Builders
       return builder
         .WithImage(configuration.Image)
         .WithCommand(configuration.Command)
+        .WithNetworkAliases(configuration.KafkaBrokerAlias)
         .WithPortBinding(configuration.Port, configuration.DefaultPort)
         .WithWaitStrategy(configuration.WaitStrategy)
         .WithStartupCallback(configuration.StartupCallback)

--- a/src/Testcontainers/Configurations/Modules/MessageBrokers/KafkaTestcontainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Modules/MessageBrokers/KafkaTestcontainerConfiguration.cs
@@ -23,6 +23,8 @@ namespace DotNet.Testcontainers.Configurations
 
     private const int ZookeeperPort = 2181;
 
+    public string KafkaBrokerAlias { get; private set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="KafkaTestcontainerConfiguration" /> class.
     /// </summary>
@@ -38,6 +40,8 @@ namespace DotNet.Testcontainers.Configurations
     public KafkaTestcontainerConfiguration(string image)
       : base(image, KafkaPort)
     {
+      this.KafkaBrokerAlias = Guid.NewGuid().ToString();
+
       // Use two listeners with different names, it will force Kafka to communicate with itself via internal
       // listener when KAFKA_INTER_BROKER_LISTENER_NAME is set, otherwise Kafka will try to use the advertised listener.
       this.Environments.Add("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT");
@@ -75,7 +79,7 @@ namespace DotNet.Testcontainers.Configurations
         startupScript.Append(lf);
         startupScript.Append("zookeeper-server-start zookeeper.properties &");
         startupScript.Append(lf);
-        startupScript.Append($"export KAFKA_ADVERTISED_LISTENERS='PLAINTEXT://{container.Hostname}:{container.GetMappedPublicPort(this.DefaultPort)},BROKER://localhost:{BrokerPort}'");
+        startupScript.Append($"export KAFKA_ADVERTISED_LISTENERS='PLAINTEXT://{container.Hostname}:{container.GetMappedPublicPort(this.DefaultPort)},BROKER://{this.KafkaBrokerAlias}:{BrokerPort}'");
         startupScript.Append(lf);
         startupScript.Append(". /etc/confluent/docker/bash-config");
         startupScript.Append(lf);


### PR DESCRIPTION
## What does this PR do?
Fix the problem when connecting a schema registry to the Kafka broker running in test containers. Bug #736 

## Why is it important?
Without the fix, a Kafka broker launched from a Testcontainer cannot be accessible inside the docker network.
That being said, we cannot run a schema registry in a test container and connect to the kafka broker.

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

## Related issues
- Closes #737
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
