### PR TITLE
fix: Wait until LocalStack writes ready message

### DIFF
--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -3,8 +3,6 @@ namespace DotNet.Testcontainers.Configurations
   using System;
   using System.Globalization;
   using System.Linq;
-  using System.Net;
-  using System.Net.Sockets;
   using System.Runtime.InteropServices;
   using System.Text;
   using System.Threading;


### PR DESCRIPTION
## What does this PR do?

Changes the LocalStack readiness check to wait until the container writes the ready message.

## Why is it important?

Previous readiness check did not always complete.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
