### PR TITLE
feat(#493): Add low level modifications API for all resources

### DIFF
--- a/src/Testcontainers/Builders/AbstractBuilder`2.cs
+++ b/src/Testcontainers/Builders/AbstractBuilder`2.cs
@@ -12,14 +12,15 @@
   /// </summary>
   /// <typeparam name="TBuilderEntity">The builder entity.</typeparam>
   /// <typeparam name="TResourceEntity">The resource entity.</typeparam>
+  /// <typeparam name="TCreateResourceEntity">The underlying Docker.DotNet resource entity.</typeparam>
   /// <typeparam name="TConfigurationEntity">The configuration entity.</typeparam>
   [PublicAPI]
-  public abstract class AbstractBuilder<TBuilderEntity, TResourceEntity, TConfigurationEntity> : IAbstractBuilder<TBuilderEntity, TResourceEntity>
-    where TBuilderEntity : IAbstractBuilder<TBuilderEntity, TResourceEntity>
-    where TConfigurationEntity : IResourceConfiguration
+  public abstract class AbstractBuilder<TBuilderEntity, TResourceEntity, TCreateResourceEntity, TConfigurationEntity> : IAbstractBuilder<TBuilderEntity, TResourceEntity, TCreateResourceEntity>
+    where TBuilderEntity : IAbstractBuilder<TBuilderEntity, TResourceEntity, TCreateResourceEntity>
+    where TConfigurationEntity : IResourceConfiguration<TCreateResourceEntity>
   {
     /// <summary>
-    /// Initializes a new instance of the <see cref="AbstractBuilder{TBuilderEntity, TResourceEntity, TConfigurationEntity}" /> class.
+    /// Initializes a new instance of the <see cref="AbstractBuilder{TBuilderEntity, TResourceEntity, TCreateResourceEntity, TConfigurationEntity}" /> class.
     /// </summary>
     /// <param name="dockerResourceConfiguration">The Docker resource configuration.</param>
     protected AbstractBuilder(TConfigurationEntity dockerResourceConfiguration)
@@ -33,43 +34,50 @@
     /// </summary>
     protected virtual TConfigurationEntity DockerResourceConfiguration { get; }
 
-    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity}" />
+    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity, TCreateResourceEntity}" />
     public TBuilderEntity WithDockerEndpoint(string endpoint)
     {
       return this.WithDockerEndpoint(new Uri(endpoint));
     }
 
-    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity}" />
+    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity, TCreateResourceEntity}" />
     public TBuilderEntity WithDockerEndpoint(Uri endpoint)
     {
       return this.WithDockerEndpoint(new DockerEndpointAuthenticationConfiguration(endpoint));
     }
 
-    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity}" />
+    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity, TCreateResourceEntity}" />
     public TBuilderEntity WithDockerEndpoint(IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig)
     {
-      return this.Clone(new ResourceConfiguration(dockerEndpointAuthenticationConfiguration: dockerEndpointAuthConfig));
+      return this.Clone(new ResourceConfiguration<TCreateResourceEntity>(dockerEndpointAuthenticationConfiguration: dockerEndpointAuthConfig));
     }
 
-    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity}" />
+    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity, TCreateResourceEntity}" />
     public TBuilderEntity WithCleanUp(bool cleanUp)
     {
       return this.WithResourceReaperSessionId(TestcontainersSettings.ResourceReaperEnabled && cleanUp ? ResourceReaper.DefaultSessionId : Guid.Empty);
     }
 
-    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity}" />
+    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity, TCreateResourceEntity}" />
     public TBuilderEntity WithLabel(string name, string value)
     {
       return this.WithLabel(new Dictionary<string, string> { { name, value } });
     }
 
-    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity}" />
+    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity, TCreateResourceEntity}" />
     public TBuilderEntity WithLabel(IReadOnlyDictionary<string, string> labels)
     {
-      return this.Clone(new ResourceConfiguration(labels: labels));
+      return this.Clone(new ResourceConfiguration<TCreateResourceEntity>(labels: labels));
     }
 
-    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity}" />
+    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity, TCreateResourceEntity}" />
+    public TBuilderEntity WithCreateParameterModifier(Action<TCreateResourceEntity> parameterModifier)
+    {
+      var parameterModifiers = new[] { parameterModifier };
+      return this.Clone(new ResourceConfiguration<TCreateResourceEntity>(parameterModifiers: parameterModifiers));
+    }
+
+    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TContainerEntity, TCreateResourceEntity}" />
     public abstract TResourceEntity Build();
 
     /// <summary>
@@ -119,7 +127,7 @@
     /// <exception cref="ArgumentException">Thrown when a mandatory Docker resource configuration is not set.</exception>
     protected virtual void Validate()
     {
-      _ = Guard.Argument(this.DockerResourceConfiguration.DockerEndpointAuthConfig, nameof(IResourceConfiguration.DockerEndpointAuthConfig))
+      _ = Guard.Argument(this.DockerResourceConfiguration.DockerEndpointAuthConfig, nameof(IResourceConfiguration<TCreateResourceEntity>.DockerEndpointAuthConfig))
         .DockerEndpointAuthConfigIsSet();
     }
 
@@ -128,7 +136,7 @@
     /// </summary>
     /// <param name="resourceConfiguration">The Docker resource configuration.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
-    protected abstract TBuilderEntity Clone(IResourceConfiguration resourceConfiguration);
+    protected abstract TBuilderEntity Clone(IResourceConfiguration<TCreateResourceEntity> resourceConfiguration);
 
     /// <summary>
     /// Merges the Docker resource builder configuration.

--- a/src/Testcontainers/Builders/ContainerBuilder.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder.cs
@@ -1,5 +1,6 @@
 ﻿namespace DotNet.Testcontainers.Builders
 {
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
   using JetBrains.Annotations;
@@ -57,7 +58,7 @@
     }
 
     /// <inheritdoc />
-    protected override ContainerBuilder Clone(IResourceConfiguration resourceConfiguration)
+    protected override ContainerBuilder Clone(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
     {
       return this.Merge(this.DockerResourceConfiguration, new ContainerConfiguration(resourceConfiguration));
     }

--- a/src/Testcontainers/Builders/ContainerBuilder.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder.cs
@@ -58,15 +58,15 @@
     }
 
     /// <inheritdoc />
-    protected override ContainerBuilder Clone(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
-    {
-      return this.Merge(this.DockerResourceConfiguration, new ContainerConfiguration(resourceConfiguration));
-    }
-
-    /// <inheritdoc />
     protected sealed override ContainerBuilder Init()
     {
       return base.Init();
+    }
+
+    /// <inheritdoc />
+    protected override ContainerBuilder Clone(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
+    {
+      return this.Merge(this.DockerResourceConfiguration, new ContainerConfiguration(resourceConfiguration));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/ContainerBuilder`1.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`1.cs
@@ -2,6 +2,7 @@
 {
   using System;
   using System.Reflection;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
   using JetBrains.Annotations;
@@ -71,7 +72,7 @@
     }
 
     /// <inheritdoc />
-    protected override ContainerBuilder<TContainerEntity> Clone(IResourceConfiguration resourceConfiguration)
+    protected override ContainerBuilder<TContainerEntity> Clone(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
     {
       return this.Merge(this.DockerResourceConfiguration, new ContainerConfiguration(resourceConfiguration));
     }

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -459,13 +459,13 @@
         public string Name { get; }
 
         /// <inheritdoc cref="IVolume" />
-        public Task CreateAsync(CancellationToken ct)
+        public Task CreateAsync(CancellationToken ct = default)
         {
           return Task.CompletedTask;
         }
 
         /// <inheritdoc cref="IVolume" />
-        public Task DeleteAsync(CancellationToken ct)
+        public Task DeleteAsync(CancellationToken ct = default)
         {
           return Task.CompletedTask;
         }

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -21,7 +21,7 @@
   /// <typeparam name="TContainerEntity">The resource entity.</typeparam>
   /// <typeparam name="TConfigurationEntity">The configuration entity.</typeparam>
   [PublicAPI]
-  public abstract class ContainerBuilder<TBuilderEntity, TContainerEntity, TConfigurationEntity> : AbstractBuilder<TBuilderEntity, TContainerEntity, TConfigurationEntity>, IContainerBuilder<TBuilderEntity, TContainerEntity>
+  public abstract class ContainerBuilder<TBuilderEntity, TContainerEntity, TConfigurationEntity> : AbstractBuilder<TBuilderEntity, TContainerEntity, CreateContainerParameters, TConfigurationEntity>, IContainerBuilder<TBuilderEntity, TContainerEntity>
     where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity>
     where TContainerEntity : IContainer
     where TConfigurationEntity : IContainerConfiguration
@@ -303,8 +303,7 @@
     /// <inheritdoc cref="IContainerBuilder{TBuilderEntity, TContainerEntity}" />
     public TBuilderEntity WithCreateContainerParametersModifier(Action<CreateContainerParameters> parameterModifier)
     {
-      var parameterModifiers = new[] { parameterModifier };
-      return this.Clone(new ContainerConfiguration(parameterModifiers: parameterModifiers));
+      return this.WithCreateParameterModifier(parameterModifier);
     }
 
     public TBuilderEntity WithImage(IDockerImage image)
@@ -327,13 +326,13 @@
       return this.WithVolumeMount(new DockerVolume(volume), destination, accessMode);
     }
 
-    /// <inheritdoc cref="AbstractBuilder{TBuilderEntity, TContainerEntity, TConfigurationEntity}" />
+    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TResourceEntity, TCreateResourceEntity}" />
     protected override TBuilderEntity Init()
     {
       return base.Init().WithImagePullPolicy(PullPolicy.Missing).WithOutputConsumer(Consume.DoNotConsumeStdoutAndStderr()).WithWaitStrategy(Wait.ForUnixContainer()).WithStartupCallback((_, ct) => Task.CompletedTask);
     }
 
-    /// <inheritdoc cref="AbstractBuilder{TBuilderEntity, TContainerEntity, TConfigurationEntity}" />
+    /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TResourceEntity, TCreateResourceEntity}" />
     protected override void Validate()
     {
       base.Validate();

--- a/src/Testcontainers/Builders/IAbstractBuilder`2.cs
+++ b/src/Testcontainers/Builders/IAbstractBuilder`2.cs
@@ -11,8 +11,9 @@
   /// </summary>
   /// <typeparam name="TBuilderEntity">The builder entity.</typeparam>
   /// <typeparam name="TResourceEntity">The resource entity.</typeparam>
+  /// <typeparam name="TCreateResourceEntity">The underlying Docker.DotNet resource entity.</typeparam>
   [PublicAPI]
-  public interface IAbstractBuilder<out TBuilderEntity, out TResourceEntity>
+  public interface IAbstractBuilder<out TBuilderEntity, out TResourceEntity, out TCreateResourceEntity>
   {
     /// <summary>
     /// Sets the Docker API endpoint.
@@ -74,6 +75,14 @@
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithLabel(IReadOnlyDictionary<string, string> labels);
+
+    /// <summary>
+    /// Allows low level modifications of the Docker.DotNet entity after the builder configuration has been applied. Multiple low level modifications will be executed in order of insertion.
+    /// </summary>
+    /// <param name="parameterModifier">The action that invokes modifying the Docker.DotNet entity instance.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
+    TBuilderEntity WithCreateParameterModifier(Action<TCreateResourceEntity> parameterModifier);
 
     /// <summary>
     /// Builds an instance of <typeparamref name="TResourceEntity" /> with the given resource configuration.

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -18,7 +18,7 @@
   /// <typeparam name="TBuilderEntity">The builder entity.</typeparam>
   /// <typeparam name="TContainerEntity">The resource entity.</typeparam>
   [PublicAPI]
-  public interface IContainerBuilder<out TBuilderEntity, out TContainerEntity> : IAbstractBuilder<TBuilderEntity, TContainerEntity>
+  public interface IContainerBuilder<out TBuilderEntity, out TContainerEntity> : IAbstractBuilder<TBuilderEntity, TContainerEntity, CreateContainerParameters>
   {
     /// <summary>
     /// Sets the module configuration of the container to override custom properties.
@@ -377,9 +377,7 @@
     /// </remarks>
     /// <param name="parameterModifier">The action that invokes modifying the <see cref="CreateContainerParameters" /> instance.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
-    [PublicAPI]
-
-    // TODO: Move this approach to the abstract builder, all resources benefit from a method like this.
+    [Obsolete("Use WithCreateParameterModifier(Action<CreateContainerParameters>) instead.")]
     TBuilderEntity WithCreateContainerParametersModifier(Action<CreateContainerParameters> parameterModifier);
 
     [Obsolete("Use WithImage(IImage) instead.")]

--- a/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
@@ -2,7 +2,6 @@
 {
   using System;
   using System.Collections.Generic;
-  using System.Globalization;
   using System.IO;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;

--- a/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
@@ -4,6 +4,7 @@
   using System.Collections.Generic;
   using System.Globalization;
   using System.IO;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Images;
   using JetBrains.Annotations;
@@ -25,7 +26,7 @@
   ///   </code>
   /// </example>
   [PublicAPI]
-  public class ImageFromDockerfileBuilder : AbstractBuilder<ImageFromDockerfileBuilder, IFutureDockerImage, IImageFromDockerfileConfiguration>, IImageFromDockerfileBuilder<ImageFromDockerfileBuilder>
+  public class ImageFromDockerfileBuilder : AbstractBuilder<ImageFromDockerfileBuilder, IFutureDockerImage, ImagesCreateParameters, IImageFromDockerfileConfiguration>, IImageFromDockerfileBuilder<ImageFromDockerfileBuilder>
   {
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageFromDockerfileBuilder" /> class.
@@ -112,7 +113,7 @@
     }
 
     /// <inheritdoc />
-    protected override ImageFromDockerfileBuilder Clone(IResourceConfiguration resourceConfiguration)
+    protected override ImageFromDockerfileBuilder Clone(IResourceConfiguration<ImagesCreateParameters> resourceConfiguration)
     {
       return this.Merge(this.DockerResourceConfiguration, new ImageFromDockerfileConfiguration(resourceConfiguration));
     }

--- a/src/Testcontainers/Builders/NetworkBuilder.cs
+++ b/src/Testcontainers/Builders/NetworkBuilder.cs
@@ -2,6 +2,7 @@
 {
   using System;
   using System.Collections.Generic;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Networks;
   using JetBrains.Annotations;
@@ -21,7 +22,7 @@
   ///   </code>
   /// </example>
   [PublicAPI]
-  public class NetworkBuilder : AbstractBuilder<NetworkBuilder, INetwork, INetworkConfiguration>, INetworkBuilder<NetworkBuilder>
+  public class NetworkBuilder : AbstractBuilder<NetworkBuilder, INetwork, NetworksCreateParameters, INetworkConfiguration>, INetworkBuilder<NetworkBuilder>
   {
     /// <summary>
     /// Initializes a new instance of the <see cref="NetworkBuilder" /> class.
@@ -88,7 +89,7 @@
     }
 
     /// <inheritdoc />
-    protected override NetworkBuilder Clone(IResourceConfiguration resourceConfiguration)
+    protected override NetworkBuilder Clone(IResourceConfiguration<NetworksCreateParameters> resourceConfiguration)
     {
       return this.Merge(this.DockerResourceConfiguration, new NetworkConfiguration(resourceConfiguration));
     }

--- a/src/Testcontainers/Builders/VolumeBuilder.cs
+++ b/src/Testcontainers/Builders/VolumeBuilder.cs
@@ -1,6 +1,7 @@
 ﻿namespace DotNet.Testcontainers.Builders
 {
   using System;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Volumes;
   using JetBrains.Annotations;
@@ -19,7 +20,7 @@
   ///   </code>
   /// </example>
   [PublicAPI]
-  public class VolumeBuilder : AbstractBuilder<VolumeBuilder, IVolume, IVolumeConfiguration>, IVolumeBuilder<VolumeBuilder>
+  public class VolumeBuilder : AbstractBuilder<VolumeBuilder, IVolume, VolumesCreateParameters, IVolumeConfiguration>, IVolumeBuilder<VolumeBuilder>
   {
     /// <summary>
     /// Initializes a new instance of the <see cref="VolumeBuilder" /> class.
@@ -73,7 +74,7 @@
     }
 
     /// <inheritdoc />
-    protected override VolumeBuilder Clone(IResourceConfiguration resourceConfiguration)
+    protected override VolumeBuilder Clone(IResourceConfiguration<VolumesCreateParameters> resourceConfiguration)
     {
       return this.Merge(this.DockerResourceConfiguration, new VolumeConfiguration(resourceConfiguration));
     }

--- a/src/Testcontainers/Configurations/Commons/IResourceConfiguration.cs
+++ b/src/Testcontainers/Configurations/Commons/IResourceConfiguration.cs
@@ -7,8 +7,9 @@
   /// <summary>
   /// A resource configuration.
   /// </summary>
+  /// <typeparam name="TCreateResourceEntity">The underlying Docker.DotNet resource entity.</typeparam>
   [PublicAPI]
-  public interface IResourceConfiguration
+  public interface IResourceConfiguration<in TCreateResourceEntity>
   {
     /// <summary>
     /// Gets the test session id.
@@ -24,5 +25,10 @@
     /// Gets a list of labels.
     /// </summary>
     IReadOnlyDictionary<string, string> Labels { get; }
+
+    /// <summary>
+    /// Gets a list of low level modifications of the Docker.DotNet entity.
+    /// </summary>
+    IReadOnlyList<Action<TCreateResourceEntity>> ParameterModifiers { get; }
   }
 }

--- a/src/Testcontainers/Configurations/Commons/ResourceConfiguration.cs
+++ b/src/Testcontainers/Configurations/Commons/ResourceConfiguration.cs
@@ -6,41 +6,45 @@
   using DotNet.Testcontainers.Containers;
   using JetBrains.Annotations;
 
-  /// <inheritdoc cref="IResourceConfiguration" />
+  /// <inheritdoc cref="IResourceConfiguration{TCreateResourceEntity}" />
   [PublicAPI]
-  public class ResourceConfiguration : IResourceConfiguration
+  public class ResourceConfiguration<TCreateResourceEntity> : IResourceConfiguration<TCreateResourceEntity>
   {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ResourceConfiguration" /> class.
+    /// Initializes a new instance of the <see cref="ResourceConfiguration{TCreateResourceEntity}" /> class.
     /// </summary>
     /// <param name="dockerEndpointAuthenticationConfiguration">The Docker endpoint authentication configuration.</param>
     /// <param name="labels">The test session id.</param>
+    /// <param name="parameterModifiers">A list of low level modifications of the Docker.DotNet entity.</param>
     public ResourceConfiguration(
       IDockerEndpointAuthenticationConfiguration dockerEndpointAuthenticationConfiguration = null,
-      IReadOnlyDictionary<string, string> labels = null)
+      IReadOnlyDictionary<string, string> labels = null,
+      IReadOnlyList<Action<TCreateResourceEntity>> parameterModifiers = null)
     {
+      this.SessionId = labels != null && labels.TryGetValue(ResourceReaper.ResourceReaperSessionLabel, out var resourceReaperSessionId) && Guid.TryParseExact(resourceReaperSessionId, "D", out var sessionId) ? sessionId : Guid.Empty;
       this.DockerEndpointAuthConfig = dockerEndpointAuthenticationConfiguration;
       this.Labels = labels;
-      this.SessionId = labels != null && labels.TryGetValue(ResourceReaper.ResourceReaperSessionLabel, out var resourceReaperSessionId) && Guid.TryParseExact(resourceReaperSessionId, "D", out var sessionId) ? sessionId : Guid.Empty;
+      this.ParameterModifiers = parameterModifiers;
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ResourceConfiguration" /> class.
+    /// Initializes a new instance of the <see cref="ResourceConfiguration{TCreateResourceEntity}" /> class.
     /// </summary>
     /// <param name="resourceConfiguration">The Docker resource configuration.</param>
-    protected ResourceConfiguration(IResourceConfiguration resourceConfiguration)
-      : this(new ResourceConfiguration(), resourceConfiguration)
+    protected ResourceConfiguration(IResourceConfiguration<TCreateResourceEntity> resourceConfiguration)
+      : this(new ResourceConfiguration<TCreateResourceEntity>(), resourceConfiguration)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ResourceConfiguration" /> class.
+    /// Initializes a new instance of the <see cref="ResourceConfiguration{TCreateResourceEntity}" /> class.
     /// </summary>
     /// <param name="oldValue">The old Docker resource configuration.</param>
     /// <param name="newValue">The new Docker resource configuration.</param>
-    protected ResourceConfiguration(IResourceConfiguration oldValue, IResourceConfiguration newValue)
+    protected ResourceConfiguration(IResourceConfiguration<TCreateResourceEntity> oldValue, IResourceConfiguration<TCreateResourceEntity> newValue)
       : this(
         dockerEndpointAuthenticationConfiguration: BuildConfiguration.Combine(oldValue.DockerEndpointAuthConfig, newValue.DockerEndpointAuthConfig),
+        parameterModifiers: BuildConfiguration.Combine(oldValue.ParameterModifiers, newValue.ParameterModifiers),
         labels: BuildConfiguration.Combine(oldValue.Labels, newValue.Labels))
     {
     }
@@ -53,5 +57,8 @@
 
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string> Labels { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<Action<TCreateResourceEntity>> ParameterModifiers { get; }
   }
 }

--- a/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
@@ -13,7 +13,7 @@
 
   /// <inheritdoc cref="IContainerConfiguration" />
   [PublicAPI]
-  public class ContainerConfiguration : ResourceConfiguration, IContainerConfiguration
+  public class ContainerConfiguration : ResourceConfiguration<CreateContainerParameters>, IContainerConfiguration
   {
     /// <summary>
     /// Initializes a new instance of the <see cref="ContainerConfiguration" /> class.
@@ -36,7 +36,6 @@
     /// <param name="outputConsumer">The output consumer.</param>
     /// <param name="waitStrategies">The wait strategies.</param>
     /// <param name="startupCallback">The startup callback.</param>
-    /// <param name="parameterModifiers">A list of low level modifications of <see cref="CreateContainerParameters" />.</param>
     /// <param name="autoRemove">A value indicating whether Docker removes the container after it exits or not.</param>
     /// <param name="privileged">A value indicating whether the privileged flag is set or not.</param>
     public ContainerConfiguration(
@@ -58,7 +57,6 @@
       IOutputConsumer outputConsumer = null,
       IEnumerable<IWaitUntil> waitStrategies = null,
       Func<IContainer, CancellationToken, Task> startupCallback = null,
-      IReadOnlyList<Action<CreateContainerParameters>> parameterModifiers = null,
       bool? autoRemove = null,
       bool? privileged = null)
     {
@@ -82,14 +80,13 @@
       this.OutputConsumer = outputConsumer;
       this.WaitStrategies = waitStrategies;
       this.StartupCallback = startupCallback;
-      this.ParameterModifiers = parameterModifiers;
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ContainerConfiguration" /> class.
     /// </summary>
     /// <param name="resourceConfiguration">The Docker resource configuration.</param>
-    public ContainerConfiguration(IResourceConfiguration resourceConfiguration)
+    public ContainerConfiguration(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
       : base(resourceConfiguration)
     {
     }
@@ -129,7 +126,6 @@
       this.OutputConsumer = BuildConfiguration.Combine(oldValue.OutputConsumer, newValue.OutputConsumer);
       this.WaitStrategies = BuildConfiguration.Combine<IEnumerable<IWaitUntil>>(oldValue.WaitStrategies, newValue.WaitStrategies);
       this.StartupCallback = BuildConfiguration.Combine(oldValue.StartupCallback, newValue.StartupCallback);
-      this.ParameterModifiers = BuildConfiguration.Combine(oldValue.ParameterModifiers, newValue.ParameterModifiers);
       this.AutoRemove = (oldValue.AutoRemove.HasValue && oldValue.AutoRemove.Value) || (newValue.AutoRemove.HasValue && newValue.AutoRemove.Value);
       this.Privileged = (oldValue.Privileged.HasValue && oldValue.Privileged.Value) || (newValue.Privileged.HasValue && newValue.Privileged.Value);
     }
@@ -193,8 +189,5 @@
 
     /// <inheritdoc />
     public Func<IContainer, CancellationToken, Task> StartupCallback { get; }
-
-    /// <inheritdoc />
-    public IReadOnlyList<Action<CreateContainerParameters>> ParameterModifiers { get; }
   }
 }

--- a/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
@@ -14,7 +14,7 @@
   /// A container configuration.
   /// </summary>
   [PublicAPI]
-  public interface IContainerConfiguration : IResourceConfiguration
+  public interface IContainerConfiguration : IResourceConfiguration<CreateContainerParameters>
   {
     /// <summary>
     /// Gets a value indicating whether Docker removes the container after it exits or not.
@@ -115,10 +115,5 @@
     /// Gets the startup callback.
     /// </summary>
     Func<IContainer, CancellationToken, Task> StartupCallback { get; }
-
-    /// <summary>
-    /// Gets a list of low level modifications of <see cref="CreateContainerParameters" />.
-    /// </summary>
-    IReadOnlyList<Action<CreateContainerParameters>> ParameterModifiers { get; }
   }
 }

--- a/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿namespace DotNet.Testcontainers.Configurations
 {
   using System.Collections.Generic;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Images;
   using JetBrains.Annotations;
 
@@ -8,7 +9,7 @@
   /// An image configuration.
   /// </summary>
   [PublicAPI]
-  public interface IImageFromDockerfileConfiguration : IResourceConfiguration
+  public interface IImageFromDockerfileConfiguration : IResourceConfiguration<ImagesCreateParameters>
   {
     /// <summary>
     /// Gets a value indicating whether Testcontainers removes an existing image or not.

--- a/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
@@ -1,13 +1,14 @@
 ﻿namespace DotNet.Testcontainers.Configurations
 {
   using System.Collections.Generic;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Builders;
   using DotNet.Testcontainers.Images;
   using JetBrains.Annotations;
 
   /// <inheritdoc cref="IImageFromDockerfileConfiguration" />
   [PublicAPI]
-  internal sealed class ImageFromDockerfileConfiguration : ResourceConfiguration, IImageFromDockerfileConfiguration
+  internal sealed class ImageFromDockerfileConfiguration : ResourceConfiguration<ImagesCreateParameters>, IImageFromDockerfileConfiguration
   {
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageFromDockerfileConfiguration" /> class.
@@ -35,7 +36,7 @@
     /// Initializes a new instance of the <see cref="ImageFromDockerfileConfiguration" /> class.
     /// </summary>
     /// <param name="resourceConfiguration">The Docker resource configuration.</param>
-    public ImageFromDockerfileConfiguration(IResourceConfiguration resourceConfiguration)
+    public ImageFromDockerfileConfiguration(IResourceConfiguration<ImagesCreateParameters> resourceConfiguration)
       : base(resourceConfiguration)
     {
     }

--- a/src/Testcontainers/Configurations/Networks/INetworkConfiguration.cs
+++ b/src/Testcontainers/Configurations/Networks/INetworkConfiguration.cs
@@ -1,13 +1,14 @@
 ﻿namespace DotNet.Testcontainers.Configurations
 {
   using System.Collections.Generic;
+  using Docker.DotNet.Models;
   using JetBrains.Annotations;
 
   /// <summary>
   /// A network configuration.
   /// </summary>
   [PublicAPI]
-  public interface INetworkConfiguration : IResourceConfiguration
+  public interface INetworkConfiguration : IResourceConfiguration<NetworksCreateParameters>
   {
     /// <summary>
     /// Gets the name.

--- a/src/Testcontainers/Configurations/Networks/NetworkConfiguration.cs
+++ b/src/Testcontainers/Configurations/Networks/NetworkConfiguration.cs
@@ -1,12 +1,13 @@
 ﻿namespace DotNet.Testcontainers.Configurations
 {
   using System.Collections.Generic;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Builders;
   using JetBrains.Annotations;
 
   /// <inheritdoc cref="INetworkConfiguration" />
   [PublicAPI]
-  internal sealed class NetworkConfiguration : ResourceConfiguration, INetworkConfiguration
+  internal sealed class NetworkConfiguration : ResourceConfiguration<NetworksCreateParameters>, INetworkConfiguration
   {
     /// <summary>
     /// Initializes a new instance of the <see cref="NetworkConfiguration" /> class.
@@ -28,7 +29,7 @@
     /// Initializes a new instance of the <see cref="NetworkConfiguration" /> class.
     /// </summary>
     /// <param name="resourceConfiguration">The Docker resource configuration.</param>
-    public NetworkConfiguration(IResourceConfiguration resourceConfiguration)
+    public NetworkConfiguration(IResourceConfiguration<NetworksCreateParameters> resourceConfiguration)
       : base(resourceConfiguration)
     {
     }

--- a/src/Testcontainers/Configurations/Volumes/IVolumeConfiguration.cs
+++ b/src/Testcontainers/Configurations/Volumes/IVolumeConfiguration.cs
@@ -1,12 +1,13 @@
 ﻿namespace DotNet.Testcontainers.Configurations
 {
+  using Docker.DotNet.Models;
   using JetBrains.Annotations;
 
   /// <summary>
   /// A volume configuration.
   /// </summary>
   [PublicAPI]
-  public interface IVolumeConfiguration : IResourceConfiguration
+  public interface IVolumeConfiguration : IResourceConfiguration<VolumesCreateParameters>
   {
     /// <summary>
     /// Gets the name.

--- a/src/Testcontainers/Configurations/Volumes/VolumeConfiguration.cs
+++ b/src/Testcontainers/Configurations/Volumes/VolumeConfiguration.cs
@@ -1,11 +1,12 @@
 ﻿namespace DotNet.Testcontainers.Configurations
 {
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Builders;
   using JetBrains.Annotations;
 
   /// <inheritdoc cref="IVolumeConfiguration" />
   [PublicAPI]
-  internal sealed class VolumeConfiguration : ResourceConfiguration, IVolumeConfiguration
+  internal sealed class VolumeConfiguration : ResourceConfiguration<VolumesCreateParameters>, IVolumeConfiguration
   {
     /// <summary>
     /// Initializes a new instance of the <see cref="VolumeConfiguration" /> class.
@@ -21,7 +22,7 @@
     /// Initializes a new instance of the <see cref="VolumeConfiguration" /> class.
     /// </summary>
     /// <param name="resourceConfiguration">The Docker resource configuration.</param>
-    public VolumeConfiguration(IResourceConfiguration resourceConfiguration)
+    public VolumeConfiguration(IResourceConfiguration<VolumesCreateParameters> resourceConfiguration)
       : base(resourceConfiguration)
     {
     }

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -83,7 +83,7 @@ namespace DotNet.Testcontainers.Containers
     /// </summary>
     /// <remarks>
     /// The default <see cref="ResourceReaper" /> will start either on <see cref="GetAndStartDefaultAsync(IDockerEndpointAuthenticationConfiguration, CancellationToken)" />
-    /// or if a <see cref="IContainer" /> is configured with <see cref="IAbstractBuilder{TBuilderEntity, TContainerEntity}.WithCleanUp" />.
+    /// or if a <see cref="IContainer" /> is configured with <see cref="IAbstractBuilder{TBuilderEntity, TContainerEntity, TCreateResourceEntity}.WithCleanUp" />.
     /// </remarks>
     [PublicAPI]
     public static Guid DefaultSessionId { get; }

--- a/src/Testcontainers/Resource.cs
+++ b/src/Testcontainers/Resource.cs
@@ -13,10 +13,7 @@
     /// Checks whether the resources exists or not.
     /// </summary>
     /// <returns>True if the resource exists; otherwise, false.</returns>
-    protected virtual bool Exists()
-    {
-      return true;
-    }
+    protected abstract bool Exists();
 
     /// <summary>
     /// Throws an <see cref="InvalidOperationException" /> when the resources was not found.

--- a/src/Testcontainers/_OBSOLETE_/TestcontainersBuilderAzuriteExtension.cs
+++ b/src/Testcontainers/_OBSOLETE_/TestcontainersBuilderAzuriteExtension.cs
@@ -1,5 +1,6 @@
 namespace DotNet.Testcontainers.Builders
 {
+  using System;
   using System.Collections.Generic;
   using System.Globalization;
   using System.IO;
@@ -129,7 +130,7 @@ namespace DotNet.Testcontainers.Builders
     private static string[] GetDebugModeEnabled(AzuriteTestcontainerConfiguration configuration)
     {
       var debugLogFilePath = Path.Combine(AzuriteTestcontainerConfiguration.DefaultWorkspaceDirectoryPath, "debug.log");
-      return configuration.DebugModeEnabled ? new[] { "--debug", debugLogFilePath } : null;
+      return configuration.DebugModeEnabled ? new[] { "--debug", debugLogFilePath } : Array.Empty<string>();
     }
 
     private static string GetSilentModeEnabled(AzuriteTestcontainerConfiguration configuration)


### PR DESCRIPTION
## What does this PR do?

Exposes the Docker.DotNet types to create (change) Docker resources for all builder implementations as a low level modification API. _Note_: We cannot control breaking changes for this types or API.

Besides adding the low level modification API it fixes some Sonar findings.

## Why is it important?

It does not make sense to expose every underlying Docker API through the builder implementation. However, some use cases might require access to certain not exposed configurations. This low level modification API allows developers to set very specific configurations:

```csharp
.WithCreateParameterModifier(modifier => modifier.HostConfig.Init = true)
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #493

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
