### PR TITLE
feat(#493): Add container lifecycle events

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs==1.4.1
+mkdocs==1.4.2
 mkdocs-codeinclude-plugin==0.2.0
 mkdocs-markdownextradata-plugin==0.2.5
-mkdocs-material==8.5.6
+mkdocs-material==8.5.11

--- a/src/Testcontainers/Builders/AbstractBuilder`2.cs
+++ b/src/Testcontainers/Builders/AbstractBuilder`2.cs
@@ -127,8 +127,9 @@
     /// <exception cref="ArgumentException">Thrown when a mandatory Docker resource configuration is not set.</exception>
     protected virtual void Validate()
     {
+      const string message = "Cannot detect the Docker endpoint. Use either the environment variables or the ~/.testcontainers.properties file to customize your configuration:\nhttps://dotnet.testcontainers.org/custom_configuration/";
       _ = Guard.Argument(this.DockerResourceConfiguration.DockerEndpointAuthConfig, nameof(IResourceConfiguration<TCreateResourceEntity>.DockerEndpointAuthConfig))
-        .DockerEndpointAuthConfigIsSet();
+        .ThrowIf(argument => argument.Value == null, argument => new ArgumentException(message, argument.Name));
     }
 
     /// <summary>

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -46,14 +46,6 @@ namespace DotNet.Testcontainers.Clients
     Task<(string Stdout, string Stderr)> GetContainerLogs(string id, DateTime since = default, DateTime until = default, CancellationToken ct = default);
 
     /// <summary>
-    /// Gets the Testcontainers.
-    /// </summary>
-    /// <param name="id">Docker container id.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that gets the Testcontainers.</returns>
-    Task<ContainerListResponse> GetContainer(string id, CancellationToken ct = default);
-
-    /// <summary>
     /// Gets the Testcontainers inspect information.
     /// </summary>
     /// <param name="id">Docker container id.</param>

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -88,12 +88,6 @@ namespace DotNet.Testcontainers.Clients
     }
 
     /// <inheritdoc />
-    public Task<ContainerListResponse> GetContainer(string id, CancellationToken ct = default)
-    {
-      return this.containers.ByIdAsync(id, ct);
-    }
-
-    /// <inheritdoc />
     public Task<ContainerInspectResponse> InspectContainer(string id, CancellationToken ct = default)
     {
       return this.containers.InspectAsync(id, ct);

--- a/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
@@ -8,7 +8,6 @@
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
   using JetBrains.Annotations;
-  using Microsoft.Extensions.Logging;
 
   /// <summary>
   /// Wait for an HTTP(S) endpoint to return a particular status code.
@@ -43,7 +42,7 @@
     }
 
     /// <inheritdoc />
-    public async Task<bool> Until(IContainer container, ILogger logger)
+    public async Task<bool> UntilAsync(IContainer container)
     {
       // Java falls back to the first exposed port. The .NET wait strategies do not have access to the exposed port information yet.
       var containerPort = this.portNumber.GetValueOrDefault(Uri.UriSchemeHttp.Equals(this.schemeName, StringComparison.OrdinalIgnoreCase) ? HttpPort : HttpsPort);

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitUntil.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitUntil.cs
@@ -3,11 +3,10 @@ namespace DotNet.Testcontainers.Configurations
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
   using JetBrains.Annotations;
-  using Microsoft.Extensions.Logging;
 
   [PublicAPI]
   public interface IWaitUntil
   {
-    Task<bool> Until(IContainer container, ILogger logger);
+    Task<bool> UntilAsync(IContainer container);
   }
 }

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitWhile.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitWhile.cs
@@ -3,11 +3,10 @@ namespace DotNet.Testcontainers.Configurations
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
   using JetBrains.Annotations;
-  using Microsoft.Extensions.Logging;
 
   [PublicAPI]
   public interface IWaitWhile
   {
-    Task<bool> While(IContainer container, ILogger logger);
+    Task<bool> WhileAsync(IContainer container);
   }
 }

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilContainerIsHealthy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilContainerIsHealthy.cs
@@ -3,7 +3,6 @@ namespace DotNet.Testcontainers.Configurations
   using System;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
-  using Microsoft.Extensions.Logging;
 
   internal class UntilContainerIsHealthy : IWaitUntil
   {
@@ -14,7 +13,7 @@ namespace DotNet.Testcontainers.Configurations
       this.failingStreak = failingStreak;
     }
 
-    public Task<bool> Until(IContainer container, ILogger logger)
+    public Task<bool> UntilAsync(IContainer container)
     {
       if (TestcontainersStates.Exited.Equals(container.State))
       {

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilContainerIsRunning.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilContainerIsRunning.cs
@@ -2,13 +2,12 @@ namespace DotNet.Testcontainers.Configurations
 {
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
-  using Microsoft.Extensions.Logging;
 
   internal class UntilContainerIsRunning : IWaitUntil
   {
     private const TestcontainersStates ContainerHasBeenRunningStates = TestcontainersStates.Running | TestcontainersStates.Exited;
 
-    public Task<bool> Until(IContainer container, ILogger logger)
+    public Task<bool> UntilAsync(IContainer container)
     {
       return Task.FromResult(ContainerHasBeenRunningStates.HasFlag(container.State));
     }

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilFilesExists.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilFilesExists.cs
@@ -3,7 +3,6 @@ namespace DotNet.Testcontainers.Configurations
   using System.IO;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
-  using Microsoft.Extensions.Logging;
 
   internal class UntilFilesExists : IWaitUntil
   {
@@ -14,7 +13,7 @@ namespace DotNet.Testcontainers.Configurations
       this.file = file;
     }
 
-    public Task<bool> Until(IContainer container, ILogger logger)
+    public Task<bool> UntilAsync(IContainer container)
     {
       return Task.FromResult(File.Exists(this.file));
     }

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
@@ -6,7 +6,6 @@ namespace DotNet.Testcontainers.Configurations
   using System.Text.RegularExpressions;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
-  using Microsoft.Extensions.Logging;
 
   internal class UntilMessageIsLogged : IWaitUntil
   {
@@ -20,7 +19,7 @@ namespace DotNet.Testcontainers.Configurations
       this.message = message;
     }
 
-    public async Task<bool> Until(IContainer container, ILogger logger)
+    public async Task<bool> UntilAsync(IContainer container)
     {
       this.stream.Seek(0, SeekOrigin.Begin);
 

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilOperationIsSucceeded.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilOperationIsSucceeded.cs
@@ -3,7 +3,6 @@ namespace DotNet.Testcontainers.Configurations
   using System;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
-  using Microsoft.Extensions.Logging;
 
   internal class UntilOperationIsSucceeded : IWaitUntil
   {
@@ -19,7 +18,7 @@ namespace DotNet.Testcontainers.Configurations
       this.maxCallCount = maxCallCount;
     }
 
-    public Task<bool> Until(IContainer container, ILogger logger)
+    public Task<bool> UntilAsync(IContainer container)
     {
       if (++this.tryCount > this.maxCallCount)
       {

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilUnixCommandIsCompleted.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilUnixCommandIsCompleted.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Configurations
 {
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
-  using Microsoft.Extensions.Logging;
 
   internal class UntilUnixCommandIsCompleted : IWaitUntil
   {
@@ -18,7 +17,7 @@ namespace DotNet.Testcontainers.Configurations
       this.command = command;
     }
 
-    public virtual async Task<bool> Until(IContainer container, ILogger logger)
+    public virtual async Task<bool> UntilAsync(IContainer container)
     {
       var execResult = await container.ExecAsync(this.command)
         .ConfigureAwait(false);

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
@@ -17,7 +17,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <exception cref="TimeoutException">Thrown as soon as the timeout expires.</exception>
     /// <returns>A task that represents the asynchronous block operation.</returns>
     [PublicAPI]
-    public static async Task WaitWhile(Func<Task<bool>> wait, int frequency = 25, int timeout = -1, CancellationToken ct = default)
+    public static async Task WaitWhileAsync(Func<Task<bool>> wait, int frequency = 25, int timeout = -1, CancellationToken ct = default)
     {
       var waitTask = Task.Run(
         async () =>
@@ -51,7 +51,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <exception cref="TimeoutException">Thrown as soon as the timeout expires.</exception>
     /// <returns>A task that represents the asynchronous block operation.</returns>
     [PublicAPI]
-    public static async Task WaitUntil(Func<Task<bool>> wait, int frequency = 25, int timeout = -1, CancellationToken ct = default)
+    public static async Task WaitUntilAsync(Func<Task<bool>> wait, int frequency = 25, int timeout = -1, CancellationToken ct = default)
     {
       var waitTask = Task.Run(
         async () =>

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -337,7 +337,7 @@ namespace DotNet.Testcontainers.Containers
     /// Creates the container.
     /// </summary>
     /// <remarks>
-    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync"/> are thread-safe for now.
+    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync" /> are thread-safe for now.
     /// </remarks>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that completes when the container has been created.</returns>
@@ -365,7 +365,7 @@ namespace DotNet.Testcontainers.Containers
     /// Deletes the container.
     /// </summary>
     /// <remarks>
-    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync"/> are thread-safe for now.
+    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync" /> are thread-safe for now.
     /// </remarks>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that completes when the container has been deleted.</returns>
@@ -388,7 +388,7 @@ namespace DotNet.Testcontainers.Containers
     /// Starts the container.
     /// </summary>
     /// <remarks>
-    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync"/> are thread-safe for now.
+    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync" /> are thread-safe for now.
     /// </remarks>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that completes when the container has been started.</returns>
@@ -440,7 +440,7 @@ namespace DotNet.Testcontainers.Containers
     /// Stops the container.
     /// </summary>
     /// <remarks>
-    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync"/> are thread-safe for now.
+    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync" /> are thread-safe for now.
     /// </remarks>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that completes when the container has been stopped.</returns>

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -20,15 +20,17 @@ namespace DotNet.Testcontainers.Containers
   {
     private const TestcontainersStates ContainerHasBeenCreatedStates = TestcontainersStates.Created | TestcontainersStates.Running | TestcontainersStates.Exited;
 
+    private const TestcontainersHealthStatus ContainerHasHealthCheck = TestcontainersHealthStatus.Starting | TestcontainersHealthStatus.Healthy | TestcontainersHealthStatus.Unhealthy;
+
     private readonly SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1, 1);
 
     private readonly ITestcontainersClient client;
 
     private readonly IContainerConfiguration configuration;
 
-    private int disposed;
-
     private ContainerInspectResponse container = new ContainerInspectResponse();
+
+    private int disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerContainer" /> class.
@@ -41,6 +43,24 @@ namespace DotNet.Testcontainers.Containers
       this.configuration = configuration;
       this.Logger = logger;
     }
+
+    /// <inheritdoc />
+    public event EventHandler Creating;
+
+    /// <inheritdoc />
+    public event EventHandler Starting;
+
+    /// <inheritdoc />
+    public event EventHandler Stopping;
+
+    /// <inheritdoc />
+    public event EventHandler Created;
+
+    /// <inheritdoc />
+    public event EventHandler Started;
+
+    /// <inheritdoc />
+    public event EventHandler Stopped;
 
     /// <inheritdoc />
     public ILogger Logger { get; }
@@ -95,19 +115,38 @@ namespace DotNet.Testcontainers.Containers
           return TestcontainersSettings.DockerHostOverride;
         }
 
-        var dockerHostUri = this.configuration.DockerEndpointAuthConfig.Endpoint;
+        var dockerEndpoint = this.configuration.DockerEndpointAuthConfig.Endpoint;
 
-        switch (dockerHostUri.Scheme)
+        switch (dockerEndpoint.Scheme)
         {
           case "http":
           case "https":
           case "tcp":
-            return dockerHostUri.Host;
+          {
+            return dockerEndpoint.Host;
+          }
+
           case "npipe":
           case "unix":
-            return this.GetContainerGateway();
+          {
+            const string localhost = "127.0.0.1";
+
+            if (!this.Exists())
+            {
+              return localhost;
+            }
+
+            if (!this.client.IsRunningInsideDocker)
+            {
+              return localhost;
+            }
+
+            var endpointSettings = this.container.NetworkSettings.Networks.First().Value;
+            return endpointSettings.Gateway;
+          }
+
           default:
-            throw new InvalidOperationException($"Docker endpoint {dockerHostUri} is not supported.");
+            throw new InvalidOperationException($"Docker endpoint {dockerEndpoint} is not supported.");
         }
       }
     }
@@ -173,8 +212,7 @@ namespace DotNet.Testcontainers.Containers
     {
       get
       {
-        this.ThrowIfResourceNotFound();
-        return this.container.State.Health.FailingStreak;
+        return ContainerHasHealthCheck.HasFlag(this.Health) ? this.container.State.Health.FailingStreak : 0;
       }
     }
 
@@ -189,7 +227,7 @@ namespace DotNet.Testcontainers.Containers
     {
       this.ThrowIfResourceNotFound();
 
-      if (this.container.NetworkSettings.Ports.TryGetValue($"{containerPort}/tcp", out var portMap) && ushort.TryParse(portMap.First().HostPort, out var publicPort))
+      if (this.container.NetworkSettings.Ports.TryGetValue($"{containerPort}/tcp", out var portBindings) && ushort.TryParse(portBindings.First().HostPort, out var publicPort))
       {
         return publicPort;
       }
@@ -212,43 +250,43 @@ namespace DotNet.Testcontainers.Containers
     }
 
     /// <inheritdoc />
-    public virtual async Task StartAsync(CancellationToken ct = default)
+    public async ValueTask DisposeAsync()
     {
-      await this.semaphoreSlim.WaitAsync(ct)
+      await this.DisposeAsyncCore()
         .ConfigureAwait(false);
 
-      try
-      {
-        this.container = await this.Create(ct)
-          .ConfigureAwait(false);
+      GC.SuppressFinalize(this);
+    }
 
-        this.container = await this.Start(this.Id, ct)
-          .ConfigureAwait(false);
-      }
-      finally
+    /// <summary>
+    /// Deletes the container.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been deleted.</returns>
+    [Obsolete("Use DisposeAsync() instead.")]
+    public Task CleanUpAsync(CancellationToken ct = default)
+    {
+      using (_ = new AcquireLock(this.semaphoreSlim))
       {
-        this.semaphoreSlim.Release();
+        return this.UnsafeDeleteAsync(ct);
       }
     }
 
     /// <inheritdoc />
-    public virtual async Task StopAsync(CancellationToken ct = default)
+    public virtual Task StartAsync(CancellationToken ct = default)
     {
-      await this.semaphoreSlim.WaitAsync(ct)
-        .ConfigureAwait(false);
+      using (_ = new AcquireLock(this.semaphoreSlim))
+      {
+        return this.UnsafeStartAsync(ct);
+      }
+    }
 
-      try
+    /// <inheritdoc />
+    public virtual Task StopAsync(CancellationToken ct = default)
+    {
+      using (_ = new AcquireLock(this.semaphoreSlim))
       {
-        this.container = await this.Stop(this.Id, ct)
-          .ConfigureAwait(false);
-      }
-      catch (DockerContainerNotFoundException)
-      {
-        this.container = new ContainerInspectResponse();
-      }
-      finally
-      {
-        this.semaphoreSlim.Release();
+        return this.UnsafeStopAsync(ct);
       }
     }
 
@@ -270,34 +308,167 @@ namespace DotNet.Testcontainers.Containers
       return this.client.ExecAsync(this.Id, command, ct);
     }
 
-    /// <summary>
-    /// Removes the Testcontainers.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>A task that represents the asynchronous clean up operation of a Testcontainers.</returns>
-    public async Task CleanUpAsync(CancellationToken ct = default)
+    /// <inheritdoc cref="IAsyncDisposable.DisposeAsync" />
+    protected virtual async ValueTask DisposeAsyncCore()
     {
-      await this.semaphoreSlim.WaitAsync(ct)
+      if (1.Equals(Interlocked.CompareExchange(ref this.disposed, 1, 0)))
+      {
+        return;
+      }
+
+      using (_ = new AcquireLock(this.semaphoreSlim))
+      {
+        if (Guid.Empty.Equals(this.configuration.SessionId))
+        {
+          await this.UnsafeStopAsync()
+            .ConfigureAwait(false);
+        }
+        else
+        {
+          await this.UnsafeDeleteAsync()
+            .ConfigureAwait(false);
+        }
+      }
+
+      this.semaphoreSlim.Dispose();
+    }
+
+    /// <summary>
+    /// Creates the container.
+    /// </summary>
+    /// <remarks>
+    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync"/> are thread-safe for now.
+    /// </remarks>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been created.</returns>
+    protected virtual async Task UnsafeCreateAsync(CancellationToken ct = default)
+    {
+      this.ThrowIfLockNotAcquired();
+
+      if (this.Exists())
+      {
+        return;
+      }
+
+      this.Creating?.Invoke(this, EventArgs.Empty);
+
+      var id = await this.client.RunAsync(this.configuration, ct)
+        .ConfigureAwait(false);
+
+      this.container = await this.client.InspectContainer(id, ct)
+        .ConfigureAwait(false);
+
+      this.Created?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Deletes the container.
+    /// </summary>
+    /// <remarks>
+    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync"/> are thread-safe for now.
+    /// </remarks>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been deleted.</returns>
+    protected virtual async Task UnsafeDeleteAsync(CancellationToken ct = default)
+    {
+      this.ThrowIfLockNotAcquired();
+
+      if (!this.Exists())
+      {
+        return;
+      }
+
+      await this.client.RemoveAsync(this.container.ID, ct)
+        .ConfigureAwait(false);
+
+      this.container = new ContainerInspectResponse();
+    }
+
+    /// <summary>
+    /// Starts the container.
+    /// </summary>
+    /// <remarks>
+    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync"/> are thread-safe for now.
+    /// </remarks>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been started.</returns>
+    protected virtual async Task UnsafeStartAsync(CancellationToken ct = default)
+    {
+      this.ThrowIfLockNotAcquired();
+
+      await this.UnsafeCreateAsync(ct)
+        .ConfigureAwait(false);
+
+      await this.client.AttachAsync(this.container.ID, this.configuration.OutputConsumer, ct)
+        .ConfigureAwait(false);
+
+      await this.client.StartAsync(this.container.ID, ct)
+        .ConfigureAwait(false);
+
+      this.container = await this.client.InspectContainer(this.container.ID, ct)
+        .ConfigureAwait(false);
+
+      this.Starting?.Invoke(this, EventArgs.Empty);
+
+      await this.configuration.StartupCallback(this, ct)
+        .ConfigureAwait(false);
+
+      // Do not use a too small frequency. The Docker endpoint cancels too many concurrent operations (requests).
+      var frequency = (int)TimeSpan.FromSeconds(1).TotalMilliseconds;
+
+      const int timeout = -1;
+
+      async Task<bool> CheckReadiness(IWaitUntil wait)
+      {
+        this.container = await this.client.InspectContainer(this.container.ID, ct)
+          .ConfigureAwait(false);
+
+        return await wait.UntilAsync(this)
+          .ConfigureAwait(false);
+      }
+
+      foreach (var waitStrategy in this.configuration.WaitStrategies)
+      {
+        await WaitStrategy.WaitUntilAsync(() => CheckReadiness(waitStrategy), frequency, timeout, ct)
+          .ConfigureAwait(false);
+      }
+
+      this.Started?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Stops the container.
+    /// </summary>
+    /// <remarks>
+    /// Only the public members <see cref="StartAsync" /> and <see cref="StopAsync"/> are thread-safe for now.
+    /// </remarks>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been stopped.</returns>
+    protected virtual async Task UnsafeStopAsync(CancellationToken ct = default)
+    {
+      this.ThrowIfLockNotAcquired();
+
+      if (!this.Exists())
+      {
+        return;
+      }
+
+      this.Stopping?.Invoke(this, EventArgs.Empty);
+
+      await this.client.StopAsync(this.container.ID, ct)
         .ConfigureAwait(false);
 
       try
       {
-        this.container = await this.CleanUp(this.Id, ct)
+        this.container = await this.client.InspectContainer(this.container.ID, ct)
           .ConfigureAwait(false);
       }
-      finally
+      catch (DockerContainerNotFoundException)
       {
-        this.semaphoreSlim.Release();
+        this.container = new ContainerInspectResponse();
       }
-    }
 
-    /// <inheritdoc />
-    public async ValueTask DisposeAsync()
-    {
-      await this.DisposeAsyncCore()
-        .ConfigureAwait(false);
-
-      GC.SuppressFinalize(this);
+      this.Stopped?.Invoke(this, EventArgs.Empty);
     }
 
     /// <inheritdoc />
@@ -307,123 +478,29 @@ namespace DotNet.Testcontainers.Containers
     }
 
     /// <summary>
-    /// Releases any resources associated with the instance of <see cref="DockerContainer" />.
+    /// Throws an <see cref="InvalidOperationException" /> when the lock is not acquired.
     /// </summary>
-    /// <returns>Value task that completes when any resources associated with the instance have been released.</returns>
-    protected virtual async ValueTask DisposeAsyncCore()
+    /// <exception cref="InvalidOperationException">The lock is not acquired.</exception>
+    protected virtual void ThrowIfLockNotAcquired()
     {
-      if (1.Equals(Interlocked.CompareExchange(ref this.disposed, 1, 0)))
-      {
-        return;
-      }
-
-      if (!ContainerHasBeenCreatedStates.HasFlag(this.State))
-      {
-        return;
-      }
-
-      // If someone calls `DisposeAsync`, we can immediately remove the container. We do not need to wait for the Resource Reaper.
-      if (Guid.Empty.Equals(this.configuration.SessionId))
-      {
-        await this.StopAsync()
-          .ConfigureAwait(false);
-      }
-      else
-      {
-        await this.CleanUpAsync()
-          .ConfigureAwait(false);
-      }
-
-      this.semaphoreSlim.Dispose();
+      _ = Guard.Argument(this.semaphoreSlim, nameof(this.semaphoreSlim))
+        .ThrowIf(argument => argument.Value.CurrentCount > 0, _ => new InvalidOperationException("Unsafe method call requires lock."));
     }
 
-    private async Task<ContainerInspectResponse> Create(CancellationToken ct = default)
+    private sealed class AcquireLock : IDisposable
     {
-      if (ContainerHasBeenCreatedStates.HasFlag(this.State))
+      private readonly SemaphoreSlim semaphoreSlim;
+
+      public AcquireLock(SemaphoreSlim semaphoreSlim)
       {
-        return this.container;
+        this.semaphoreSlim = semaphoreSlim;
+        this.semaphoreSlim.Wait();
       }
 
-      var id = await this.client.RunAsync(this.configuration, ct)
-        .ConfigureAwait(false);
-
-      return await this.client.InspectContainer(id, ct)
-        .ConfigureAwait(false);
-    }
-
-    private async Task<ContainerInspectResponse> Start(string id, CancellationToken ct = default)
-    {
-      await this.client.AttachAsync(id, this.configuration.OutputConsumer, ct)
-        .ConfigureAwait(false);
-
-      await this.client.StartAsync(id, ct)
-        .ConfigureAwait(false);
-
-      this.container = await this.client.InspectContainer(id, ct)
-        .ConfigureAwait(false);
-
-      await this.configuration.StartupCallback(this, ct)
-        .ConfigureAwait(false);
-
-      // Do not use a too small frequency. Especially with a lot of containers,
-      // we send many operations to the Docker endpoint. The endpoint may cancel operations.
-      var frequency = (int)TimeSpan.FromSeconds(1).TotalMilliseconds;
-
-      const int timeout = -1;
-
-      foreach (var waitStrategy in this.configuration.WaitStrategies)
+      public void Dispose()
       {
-        await WaitStrategy.WaitUntil(
-            async () =>
-            {
-              this.container = await this.client.InspectContainer(id, ct)
-                .ConfigureAwait(false);
-
-              return await waitStrategy.Until(this, this.Logger)
-                .ConfigureAwait(false);
-            },
-            frequency,
-            timeout,
-            ct)
-          .ConfigureAwait(false);
+        this.semaphoreSlim.Release();
       }
-
-      return this.container;
-    }
-
-    private async Task<ContainerInspectResponse> Stop(string id, CancellationToken ct = default)
-    {
-      await this.client.StopAsync(id, ct)
-        .ConfigureAwait(false);
-
-      return await this.client.InspectContainer(id, ct)
-        .ConfigureAwait(false);
-    }
-
-    private async Task<ContainerInspectResponse> CleanUp(string id, CancellationToken ct = default)
-    {
-      await this.client.RemoveAsync(id, ct)
-        .ConfigureAwait(false);
-
-      return new ContainerInspectResponse();
-    }
-
-    private string GetContainerGateway()
-    {
-      const string localhost = "127.0.0.1";
-
-      if (!ContainerHasBeenCreatedStates.HasFlag(this.State))
-      {
-        return localhost;
-      }
-
-      if (!this.client.IsRunningInsideDocker)
-      {
-        return localhost;
-      }
-
-      var endpointSettings = this.container.NetworkSettings.Networks.Values.FirstOrDefault();
-      return endpointSettings == null ? localhost : endpointSettings.Gateway;
     }
   }
 }

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -15,6 +15,42 @@
   public interface IContainer : ITestcontainersContainer
   {
     /// <summary>
+    /// Subscribes to the creating event.
+    /// </summary>
+    [CanBeNull]
+    event EventHandler Creating;
+
+    /// <summary>
+    /// Subscribes to the starting event.
+    /// </summary>
+    [CanBeNull]
+    event EventHandler Starting;
+
+    /// <summary>
+    /// Subscribes to the stopping event.
+    /// </summary>
+    [CanBeNull]
+    event EventHandler Stopping;
+
+    /// <summary>
+    /// Subscribes to the created event.
+    /// </summary>
+    [CanBeNull]
+    event EventHandler Created;
+
+    /// <summary>
+    /// Subscribes to the started event.
+    /// </summary>
+    [CanBeNull]
+    event EventHandler Started;
+
+    /// <summary>
+    /// Subscribes to the stopped event.
+    /// </summary>
+    [CanBeNull]
+    event EventHandler Stopped;
+
+    /// <summary>
     /// Gets the logger.
     /// </summary>
     [NotNull]

--- a/src/Testcontainers/Guard.Argument.cs
+++ b/src/Testcontainers/Guard.Argument.cs
@@ -1,37 +1,39 @@
 namespace DotNet.Testcontainers
 {
   using System.Diagnostics;
-  using System.Runtime.CompilerServices;
+  using JetBrains.Annotations;
 
   /// <summary>
-  /// Validates an argument preconditions.
+  /// A guard to determine if one or more conditions are not met.
   /// </summary>
-  internal static partial class Guard
+  [DebuggerStepThrough]
+  [PublicAPI]
+  public static partial class Guard
   {
     /// <summary>
-    /// Creates a Guard object that validates argument preconditions.
+    /// Initializes a new instance of the <see cref="ArgumentInfo{TType}" /> struct.
     /// </summary>
-    /// <param name="value">Argument value.</param>
-    /// <param name="name">Argument name.</param>
-    /// <typeparam name="TType">Type of the argument.</typeparam>
-    /// <returns>A Guard object that validates argument preconditions.</returns>
+    /// <param name="value">The value.</param>
+    /// <param name="name">The name.</param>
+    /// <typeparam name="TType">The type.</typeparam>
+    /// <returns>A new instance of the <see cref="ArgumentInfo{TType}" /> struct.</returns>
     public static ArgumentInfo<TType> Argument<TType>(TType value, string name)
     {
       return new ArgumentInfo<TType>(value, name);
     }
 
     /// <summary>
-    /// Represents an argument.
+    /// An argument.
     /// </summary>
-    /// <typeparam name="TType">Type of the argument.</typeparam>
+    /// <typeparam name="TType">The type.</typeparam>
+    [DebuggerStepThrough]
     public readonly struct ArgumentInfo<TType>
     {
       /// <summary>
       /// Initializes a new instance of the <see cref="ArgumentInfo{TType}" /> struct.
       /// </summary>
-      /// <param name="value">Argument value.</param>
-      /// <param name="name">Argument name.</param>
-      [DebuggerStepThrough]
+      /// <param name="value">The value.</param>
+      /// <param name="name">The name.</param>
       public ArgumentInfo(TType value, string name)
       {
         this.Value = value;
@@ -39,21 +41,19 @@ namespace DotNet.Testcontainers
       }
 
       /// <summary>
-      /// Gets the argument value.
+      /// Gets the value.
       /// </summary>
       public TType Value { get; }
 
       /// <summary>
-      /// Gets the argument name.
+      /// Gets the name.
       /// </summary>
       public string Name { get; }
 
       /// <summary>
-      /// Checks whether the argument value is null or not.
+      /// Checks whether the argument has a value or not.
       /// </summary>
-      /// <returns>True if the argument value is not null, otherwise false.</returns>
-      [DebuggerStepThrough]
-      [MethodImpl(MethodImplOptions.AggressiveInlining)]
+      /// <returns>True if the argument has a value; otherwise, false.</returns>
       public bool HasValue()
       {
         return this.Value != null;

--- a/src/Testcontainers/Guard.Null.cs
+++ b/src/Testcontainers/Guard.Null.cs
@@ -1,74 +1,65 @@
 namespace DotNet.Testcontainers
 {
   using System;
-  using System.Diagnostics;
-  using DotNet.Testcontainers.Configurations;
-  using JetBrains.Annotations;
+  using System.Globalization;
 
   /// <summary>
-  /// Nullability preconditions.
+  /// A guard collection of nullability preconditions.
   /// </summary>
-  internal static partial class Guard
+  public static partial class Guard
   {
     /// <summary>
-    /// Ensures that an argument value is null.
+    /// Ensures the argument value is null.
     /// </summary>
-    /// <param name="argument">Argument to validate.</param>
-    /// <typeparam name="TType">Type of the argument.</typeparam>
-    /// <returns>Reference to the Guard object that validates the argument preconditions.</returns>
-    /// <exception cref="ArgumentException">Thrown when argument is not null.</exception>
-    [PublicAPI]
-    [DebuggerStepThrough]
-    public static ref readonly ArgumentInfo<TType> Null<TType>(in this ArgumentInfo<TType> argument)
-      where TType : class
-    {
-      if (argument.HasValue())
-      {
-        throw new ArgumentException($"{argument.Name} must be null.", argument.Name);
-      }
-
-      return ref argument;
-    }
-
-    /// <summary>
-    /// Ensures that an argument value is not null.
-    /// </summary>
-    /// <param name="argument">Argument to validate.</param>
-    /// <typeparam name="TType">Type of the argument.</typeparam>
-    /// <returns>Reference to the Guard object that validates the argument preconditions.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when argument is null.</exception>
-    [PublicAPI]
-    [DebuggerStepThrough]
-    public static ref readonly ArgumentInfo<TType> NotNull<TType>(in this ArgumentInfo<TType> argument)
+    /// <param name="argument">The argument.</param>
+    /// <param name="exceptionMessage">The exception message.</param>
+    /// <typeparam name="TType">The type.</typeparam>
+    /// <returns>An instance of the <see cref="ArgumentInfo{TType}" /> struct.</returns>
+    /// <exception cref="ArgumentException">Thrown when the condition is not met.</exception>
+    public static ref readonly ArgumentInfo<TType> Null<TType>(in this ArgumentInfo<TType> argument, string exceptionMessage = null)
       where TType : class
     {
       if (!argument.HasValue())
       {
-        throw new ArgumentNullException(argument.Name, $"{argument.Name} cannot be null.");
+        return ref argument;
       }
 
-      return ref argument;
+      const string message = "'{0}' must be null.";
+      throw new ArgumentException(exceptionMessage ?? string.Format(CultureInfo.InvariantCulture, message, argument.Name), argument.Name);
     }
 
     /// <summary>
-    /// Ensures that the Docker endpoint authentication configuration is set.
+    /// Ensures the argument value is not null.
     /// </summary>
-    /// <param name="argument">The Docker endpoint authentication configuration.</param>
-    /// <typeparam name="TType">An implementation of <see cref="IDockerEndpointAuthenticationConfiguration" />.</typeparam>
-    /// <returns>Reference to the Guard object that validates the argument preconditions.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when argument is null.</exception>
-    [PublicAPI]
-    [DebuggerStepThrough]
-    public static ref readonly ArgumentInfo<TType> DockerEndpointAuthConfigIsSet<TType>(in this ArgumentInfo<TType> argument)
-      where TType : IDockerEndpointAuthenticationConfiguration
+    /// <param name="argument">The argument.</param>
+    /// <param name="exceptionMessage">The exception message.</param>
+    /// <typeparam name="TType">The type.</typeparam>
+    /// <returns>An instance of the <see cref="ArgumentInfo{TType}" /> struct.</returns>
+    /// <exception cref="ArgumentException">Thrown when the condition is not met.</exception>
+    public static ref readonly ArgumentInfo<TType> NotNull<TType>(in this ArgumentInfo<TType> argument, string exceptionMessage = null)
+      where TType : class
     {
       if (argument.HasValue())
       {
         return ref argument;
       }
 
-      const string message = "Cannot detect the Docker endpoint. Use either the environment variables or the ~/.testcontainers.properties file to customize your configuration:\nhttps://dotnet.testcontainers.org/custom_configuration/";
-      throw new ArgumentNullException(argument.Name, message);
+      const string message = "'{0}' cannot be null.";
+      throw new ArgumentException(exceptionMessage ?? string.Format(CultureInfo.InvariantCulture, message, argument.Name), argument.Name);
+    }
+
+    /// <summary>
+    /// Ensures the argument value not pass the predicate.
+    /// </summary>
+    /// <param name="argument">The argument.</param>
+    /// <param name="condition">The condition that raises the exception.</param>
+    /// <param name="ifClause">The function to invoke to create the exception object.</param>
+    /// <typeparam name="TType">The type.</typeparam>
+    /// <returns>An instance of the <see cref="ArgumentInfo{TType}" /> struct.</returns>
+    /// <exception cref="ArgumentException">Thrown when the condition is not met.</exception>
+    public static ArgumentInfo<TType> ThrowIf<TType>(in this ArgumentInfo<TType> argument, Func<ArgumentInfo<TType>, bool> condition, Func<ArgumentInfo<TType>, Exception> ifClause)
+    {
+      return condition(argument) ? throw ifClause(argument) : argument;
     }
   }
 }

--- a/src/Testcontainers/Guard.String.cs
+++ b/src/Testcontainers/Guard.String.cs
@@ -1,67 +1,66 @@
 namespace DotNet.Testcontainers
 {
   using System;
-  using System.Diagnostics;
+  using System.Globalization;
   using System.Linq;
-  using JetBrains.Annotations;
 
   /// <summary>
-  /// String preconditions.
+  /// A guard collection of string preconditions.
   /// </summary>
-  internal static partial class Guard
+  public static partial class Guard
   {
     /// <summary>
-    /// Ensures that an argument string value is empty.
+    /// Ensures the argument value is empty.
     /// </summary>
-    /// <param name="argument">String argument to validate.</param>
-    /// <returns>Reference to the Guard object that validates the argument preconditions.</returns>
-    /// <exception cref="ArgumentException">Thrown when argument is not empty.</exception>
-    [PublicAPI]
-    [DebuggerStepThrough]
-    public static ref readonly ArgumentInfo<string> Empty(in this ArgumentInfo<string> argument)
-    {
-      if (argument.Value.Length > 0)
-      {
-        throw new ArgumentException($"{argument.Name} must be empty.", argument.Name);
-      }
-
-      return ref argument;
-    }
-
-    /// <summary>
-    /// Ensure that an argument string value is not empty.
-    /// </summary>
-    /// <param name="argument">String argument to validate.</param>
-    /// <returns>Reference to the Guard object that validates the argument preconditions.</returns>
-    /// <exception cref="ArgumentException">Thrown when argument is empty.</exception>
-    [PublicAPI]
-    [DebuggerStepThrough]
-    public static ref readonly ArgumentInfo<string> NotEmpty(in this ArgumentInfo<string> argument)
+    /// <param name="argument">The argument.</param>
+    /// <param name="exceptionMessage">The exception message.</param>
+    /// <returns>An instance of the <see cref="ArgumentInfo{TType}" /> struct.</returns>
+    /// <exception cref="ArgumentException">Thrown when the condition is not met.</exception>
+    public static ref readonly ArgumentInfo<string> Empty(in this ArgumentInfo<string> argument, string exceptionMessage = null)
     {
       if (argument.Value.Length == 0)
       {
-        throw new ArgumentException($"{argument.Name} cannot be empty.", argument.Name);
+        return ref argument;
       }
 
-      return ref argument;
+      const string message = "'{0}' must be empty.";
+      throw new ArgumentException(exceptionMessage ?? string.Format(CultureInfo.InvariantCulture, message, argument.Name), argument.Name);
     }
 
     /// <summary>
-    /// Ensures that an argument string value does not have uppercase characters.
+    /// Ensures the argument value is not empty.
     /// </summary>
-    /// <param name="argument">String argument to validate.</param>
-    /// <returns>Reference to the Guard object that validates the argument preconditions.</returns>
-    /// <exception cref="ArgumentException">Thrown when argument has uppercase characters.</exception>
-    [PublicAPI]
-    [DebuggerStepThrough]
-    public static ref readonly ArgumentInfo<string> NotUppercase(in this ArgumentInfo<string> argument)
+    /// <param name="argument">The argument.</param>
+    /// <param name="exceptionMessage">The exception message.</param>
+    /// <returns>An instance of the <see cref="ArgumentInfo{TType}" /> struct.</returns>
+    /// <exception cref="ArgumentException">Thrown when the condition is not met.</exception>
+    public static ref readonly ArgumentInfo<string> NotEmpty(in this ArgumentInfo<string> argument, string exceptionMessage = null)
     {
-      if (argument.Value.Any(char.IsUpper))
+      if (argument.Value.Length > 0)
       {
-        throw new ArgumentException(argument.Name, $"{argument.Name} cannot have uppercase characters.");
+        return ref argument;
       }
 
-      return ref argument;
+      const string message = "'{0}' cannot be empty.";
+      throw new ArgumentException(exceptionMessage ?? string.Format(CultureInfo.InvariantCulture, message, argument.Name), argument.Name);
+    }
+
+    /// <summary>
+    /// Ensures the argument value does not contain uppercase characters.
+    /// </summary>
+    /// <param name="argument">The argument.</param>
+    /// <param name="exceptionMessage">The exception message.</param>
+    /// <returns>An instance of the <see cref="ArgumentInfo{TType}" /> struct.</returns>
+    /// <exception cref="ArgumentException">Thrown when the condition is not met.</exception>
+    public static ref readonly ArgumentInfo<string> NotUppercase(in this ArgumentInfo<string> argument, string exceptionMessage = null)
+    {
+      if (!argument.Value.Any(char.IsUpper))
+      {
+        return ref argument;
+      }
+
+      const string message = "'{0}' cannot contain uppercase characters.";
+      throw new ArgumentException(exceptionMessage ?? string.Format(CultureInfo.InvariantCulture, message, argument.Name), argument.Name);
     }
   }
 }

--- a/src/Testcontainers/Resource.cs
+++ b/src/Testcontainers/Resource.cs
@@ -1,6 +1,7 @@
 ﻿namespace DotNet.Testcontainers
 {
   using System;
+  using System.Globalization;
   using JetBrains.Annotations;
 
   /// <summary>
@@ -21,13 +22,9 @@
     /// <exception cref="InvalidOperationException">The resource was not found.</exception>
     protected virtual void ThrowIfResourceNotFound()
     {
-      if (this.Exists())
-      {
-        return;
-      }
-
-      var resourceType = this.GetType().Name;
-      throw new InvalidOperationException($"Could not find resource '{resourceType}'. Please create the resource by calling StartAsync(CancellationToken) or CreateAsync(CancellationToken) first.");
+      const string message = "Could not find resource '{0}'. Please create the resource by calling StartAsync(CancellationToken) or CreateAsync(CancellationToken).";
+      _ = Guard.Argument(this, this.GetType().Name)
+        .ThrowIf(argument => !argument.Value.Exists(), argument => new InvalidOperationException(string.Format(CultureInfo.InvariantCulture, message, argument.Name)));
     }
   }
 }

--- a/src/Testcontainers/_OBSOLETE_/Modules/MessageBrokers/LocalStackTestcontainerConfiguration.cs
+++ b/src/Testcontainers/_OBSOLETE_/Modules/MessageBrokers/LocalStackTestcontainerConfiguration.cs
@@ -4,7 +4,6 @@ namespace DotNet.Testcontainers.Configurations
   using DotNet.Testcontainers.Builders;
   using DotNet.Testcontainers.Containers;
   using JetBrains.Annotations;
-  using Microsoft.Extensions.Logging;
 
   /// <inheritdoc cref="TestcontainerMessageBrokerConfiguration" />
   [PublicAPI]
@@ -39,7 +38,7 @@ namespace DotNet.Testcontainers.Configurations
 
     private sealed class UntilReady : IWaitUntil
     {
-      public async Task<bool> Until(IContainer container, ILogger logger)
+      public async Task<bool> UntilAsync(IContainer container)
       {
         var (stdout, _) = await container.GetLogs()
           .ConfigureAwait(false);

--- a/tests/Testcontainers.Tests/Fixtures/Configurations/WaitUntilFiveSecondsPassedFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Configurations/WaitUntilFiveSecondsPassedFixture.cs
@@ -4,13 +4,12 @@ namespace DotNet.Testcontainers.Tests.Fixtures
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
-  using Microsoft.Extensions.Logging;
 
   public sealed class WaitUntilFiveSecondsPassedFixture : IWaitUntil
   {
     private readonly long timestamp = new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds();
 
-    public Task<bool> Until(IContainer container, ILogger logger)
+    public Task<bool> UntilAsync(IContainer container)
     {
       return Task.FromResult(new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds() > this.timestamp + 5);
     }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
@@ -8,7 +8,6 @@
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Images;
-  using Microsoft.Extensions.Logging;
   using Xunit;
 
   public abstract class ProtectDockerDaemonSocket : IAsyncLifetime
@@ -71,7 +70,7 @@
 
     private sealed class UntilListenOn : IWaitUntil
     {
-      public async Task<bool> Until(IContainer container, ILogger logger)
+      public async Task<bool> UntilAsync(IContainer container)
       {
         var (_, stderr) = await container.GetLogs()
           .ConfigureAwait(false);

--- a/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersAccessInformationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersAccessInformationTest.cs
@@ -86,7 +86,6 @@ namespace DotNet.Testcontainers.Tests.Unit
           Assert.Throws<InvalidOperationException>(() => testcontainer.IpAddress);
           Assert.Throws<InvalidOperationException>(() => testcontainer.MacAddress);
           Assert.Throws<InvalidOperationException>(() => testcontainer.GetMappedPublicPort(0));
-          await Assert.ThrowsAsync<InvalidOperationException>(() => testcontainer.StopAsync());
         }
       }
 

--- a/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersWaitStrategyTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersWaitStrategyTest.cs
@@ -4,7 +4,6 @@ namespace DotNet.Testcontainers.Tests.Unit
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
-  using Microsoft.Extensions.Logging;
   using Xunit;
 
   public static class TestcontainersWaitStrategyTest
@@ -14,23 +13,23 @@ namespace DotNet.Testcontainers.Tests.Unit
       [Fact]
       public async Task UntilImmediately()
       {
-        var exception = await Record.ExceptionAsync(() => WaitStrategy.WaitUntil(() => this.Until(null, null)));
+        var exception = await Record.ExceptionAsync(() => WaitStrategy.WaitUntilAsync(() => this.UntilAsync(null)));
         Assert.Null(exception);
       }
 
       [Fact]
       public async Task WhileImmediately()
       {
-        var exception = await Record.ExceptionAsync(() => WaitStrategy.WaitWhile(() => this.While(null, null)));
+        var exception = await Record.ExceptionAsync(() => WaitStrategy.WaitWhileAsync(() => this.WhileAsync(null)));
         Assert.Null(exception);
       }
 
-      public Task<bool> Until(IContainer container, ILogger logger)
+      public Task<bool> UntilAsync(IContainer container)
       {
         return Task.FromResult(true);
       }
 
-      public Task<bool> While(IContainer container, ILogger logger)
+      public Task<bool> WhileAsync(IContainer container)
       {
         return Task.FromResult(false);
       }
@@ -41,21 +40,21 @@ namespace DotNet.Testcontainers.Tests.Unit
       [Fact]
       public async Task UntilAfter1Ms()
       {
-        await Assert.ThrowsAsync<TimeoutException>(() => WaitStrategy.WaitUntil(() => this.Until(null, null), 1000, 1));
+        await Assert.ThrowsAsync<TimeoutException>(() => WaitStrategy.WaitUntilAsync(() => this.UntilAsync(null), 1000, 1));
       }
 
       [Fact]
       public async Task WhileAfter1Ms()
       {
-        await Assert.ThrowsAsync<TimeoutException>(() => WaitStrategy.WaitWhile(() => this.While(null, null), 1000, 1));
+        await Assert.ThrowsAsync<TimeoutException>(() => WaitStrategy.WaitWhileAsync(() => this.WhileAsync(null), 1000, 1));
       }
 
-      public Task<bool> Until(IContainer container, ILogger logger)
+      public Task<bool> UntilAsync(IContainer container)
       {
         return Task.FromResult(false);
       }
 
-      public Task<bool> While(IContainer container, ILogger logger)
+      public Task<bool> WhileAsync(IContainer container)
       {
         return Task.FromResult(true);
       }
@@ -66,21 +65,21 @@ namespace DotNet.Testcontainers.Tests.Unit
       [Fact]
       public async Task RethrowUntil()
       {
-        await Assert.ThrowsAsync<NotImplementedException>(() => WaitStrategy.WaitUntil(() => this.Until(null, null)));
+        await Assert.ThrowsAsync<NotImplementedException>(() => WaitStrategy.WaitUntilAsync(() => this.UntilAsync(null)));
       }
 
       [Fact]
       public async Task RethrowWhile()
       {
-        await Assert.ThrowsAsync<NotImplementedException>(() => WaitStrategy.WaitWhile(() => this.While(null, null)));
+        await Assert.ThrowsAsync<NotImplementedException>(() => WaitStrategy.WaitWhileAsync(() => this.WhileAsync(null)));
       }
 
-      public Task<bool> Until(IContainer container, ILogger logger)
+      public Task<bool> UntilAsync(IContainer container)
       {
         throw new NotImplementedException();
       }
 
-      public Task<bool> While(IContainer container, ILogger logger)
+      public Task<bool> WhileAsync(IContainer container)
       {
         throw new NotImplementedException();
       }

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
@@ -9,7 +9,6 @@
   using DotNet.Testcontainers.Commons;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
-  using Microsoft.Extensions.Logging.Abstractions;
   using Xunit;
 
   public sealed class WaitUntilHttpRequestIsSucceededTest : IAsyncLifetime
@@ -46,7 +45,7 @@
     [MemberData(nameof(GetHttpWaitStrategies))]
     public async Task HttpWaitStrategyReceivesStatusCode(HttpWaitStrategy httpWaitStrategy)
     {
-      var succeeded = await httpWaitStrategy.Until(this.container, NullLogger.Instance)
+      var succeeded = await httpWaitStrategy.UntilAsync(this.container)
         .ConfigureAwait(false);
 
       Assert.True(succeeded);
@@ -61,7 +60,7 @@
       var httpWaitStrategy = new HttpWaitStrategy().WithHeaders(httpHeaders);
 
       // When
-      var succeeded = await httpWaitStrategy.Until(this.container, NullLogger.Instance)
+      var succeeded = await httpWaitStrategy.UntilAsync(this.container)
         .ConfigureAwait(false);
 
       await Task.Delay(TimeSpan.FromSeconds(1))

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilMessageIsLoggedTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilMessageIsLoggedTest.cs
@@ -29,7 +29,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         .First();
 
       // Then
-      var exception = await Record.ExceptionAsync(() => WaitStrategy.WaitUntil(() => wait.Until(null, null)));
+      var exception = await Record.ExceptionAsync(() => WaitStrategy.WaitUntilAsync(() => wait.UntilAsync(null)));
       Assert.Null(exception);
     }
   }

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilOperationIsSucceededTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilOperationIsSucceededTest.cs
@@ -33,7 +33,7 @@ namespace DotNet.Testcontainers.Tests.Unit
             },
             maxCallCount);
 
-          await WaitStrategy.WaitUntil(() => wait.Build().Skip(1).First().Until(null, null));
+          await WaitStrategy.WaitUntilAsync(() => wait.Build().Skip(1).First().UntilAsync(null));
         });
 
       // Then
@@ -56,7 +56,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       // When
       var wait = Wait.ForUnixContainer().UntilOperationIsSucceeded(() => ++callCounter >= expectedCallsCount, maxCallCount);
-      await WaitStrategy.WaitUntil(() => wait.Build().Skip(1).First().Until(null, null));
+      await WaitStrategy.WaitUntilAsync(() => wait.Build().Skip(1).First().UntilAsync(null));
 
       // Then
       Assert.Equal(expectedCallsCount, callCounter);

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -37,7 +37,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
       [Fact]
       public void ShouldThrowArgumentNullExceptionWhenBuildConfigurationHasNoImage()
       {
-        Assert.Throws<ArgumentNullException>(() => _ = new TestcontainersBuilder<TestcontainersContainer>().Build());
+        Assert.Throws<ArgumentException>(() => _ = new TestcontainersBuilder<TestcontainersContainer>().Build());
       }
 
       [Fact]

--- a/tests/Testcontainers.Tests/Unit/GuardTest.cs
+++ b/tests/Testcontainers.Tests/Unit/GuardTest.cs
@@ -1,7 +1,6 @@
 namespace DotNet.Testcontainers.Tests.Unit
 {
   using System;
-  using DotNet.Testcontainers.Configurations;
   using Xunit;
 
   public static class GuardTest
@@ -25,34 +24,31 @@ namespace DotNet.Testcontainers.Tests.Unit
         }
 
         [Fact]
-        public void IfDockerEndpointAuthConfigIsSet()
+        public void ThrowIf()
         {
-          var exception = Record.Exception(() => Guard.Argument(new DockerEndpointAuthenticationConfiguration(new Uri("tcp://127.0.0.1:2375")), nameof(this.IfDockerEndpointAuthConfigIsSet)).DockerEndpointAuthConfigIsSet());
+          var exception = Record.Exception(() => Guard.Argument(new object(), nameof(this.ThrowIf)).ThrowIf(_ => false, _ => new ArgumentException()));
           Assert.Null(exception);
-        }
-      }
-
-      public sealed class ThrowArgumentNullException
-      {
-        [Fact]
-        public void IfNull()
-        {
-          Assert.Throws<ArgumentNullException>(() => Guard.Argument((object)null, nameof(this.IfNull)).NotNull());
-        }
-
-        [Fact]
-        public void IfDockerEndpointAuthConfigIsSet()
-        {
-          Assert.Throws<ArgumentNullException>(() => Guard.Argument((IDockerEndpointAuthenticationConfiguration)null, nameof(this.IfDockerEndpointAuthConfigIsSet)).DockerEndpointAuthConfigIsSet());
         }
       }
 
       public sealed class ThrowArgumentException
       {
         [Fact]
+        public void IfNull()
+        {
+          Assert.Throws<ArgumentException>(() => Guard.Argument((object)null, nameof(this.IfNull)).NotNull());
+        }
+
+        [Fact]
         public void IfNotNull()
         {
           Assert.Throws<ArgumentException>(() => Guard.Argument(new object(), nameof(this.IfNotNull)).Null());
+        }
+
+        [Fact]
+        public void ThrowIf()
+        {
+          Assert.Throws<ArgumentException>(() => Guard.Argument(new object(), nameof(this.ThrowIf)).ThrowIf(_ => true, _ => new ArgumentException()));
         }
       }
     }

--- a/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
@@ -10,9 +10,9 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public void ShouldThrowArgumentNullExceptionWhenInstantiateDockerImage()
     {
-      Assert.Throws<ArgumentNullException>(() => new DockerImage((string)null));
-      Assert.Throws<ArgumentNullException>(() => new DockerImage(null, null, null));
-      Assert.Throws<ArgumentNullException>(() => new DockerImage("fedora", null, null));
+      Assert.Throws<ArgumentException>(() => new DockerImage((string)null));
+      Assert.Throws<ArgumentException>(() => new DockerImage(null, null, null));
+      Assert.Throws<ArgumentException>(() => new DockerImage("fedora", null, null));
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

The PR allows to override the `DockerContainer` lifecycle members (`StartAsync`, `StopAsync`, `UnsafeCreateAsync`, `UnsafeDeleteAsync`, `UnsafeStartAsync`, `UnsafeStopAsync`). This allows modules to extend or change the default lifecycle behavior to the module requirements. The `Unsafe*` members are `protected` and not thread-safe. Their public entrypoints are thread-safe though. This is necessary otherwise we end up with nested locks which are bad. The implementation takes care that the `Unsafe*` members are called in a thread-safe environment.

The PR adds the events `Creating`, `Starting`, `Stopping`, `Created`, `Started`, `Stopped` to the `IContainer` interfaces. Developers can subscribe to those events and get notified soon as the container reached the respected state.

Refactors the Guard implementation to support various different use cases. PR makes Guard public.

## Why is it important?

To allow developers access to the different resource lifecycles.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #493

## Breaking Changes

The interface `IWaitUntil.Until(IContainer, ILogger)` has changed to `IWaitUntil.UntilAsync(IContainer)`. The logger is now available through the Docker resource instance. Providing backwards compatibility is cumbersome. Adding an interface member requires a change anyway. It is easier to simply change the interface name and remove the `ILogger` arg.

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
