### PR TITLE
feat(#493): Prepare module NuGet support, sign NuGet

### DIFF
--- a/.cake-scripts/credentials.cake
+++ b/.cake-scripts/credentials.cake
@@ -62,7 +62,7 @@ internal sealed class NuGetCredentials
     return new NuGetCredentials
     (
       context.EnvironmentVariable("FEED_SOURCE"),
-      context.EnvironmentVariable("FEED_APIKEY")
+      context.EnvironmentVariable("FEED_API_KEY")
     );
   }
 }

--- a/.cake-scripts/version.cake
+++ b/.cake-scripts/version.cake
@@ -25,6 +25,8 @@ internal sealed class BuildInformation
 
     var environment = buildSystem.GitHubActions.Environment;
 
+    var publishNuGetPackage = context.EnvironmentVariable("PUBLISH_NUGET_PACKAGE");
+
     var version = context.XmlPeek(propertiesFilePath, "/Project/PropertyGroup[2]/Version/text()");
 
     var git = context.GitBranchCurrent(".");
@@ -67,7 +69,7 @@ internal sealed class BuildInformation
 
     var isReleaseBuild = GetIsReleaseBuild(branch);
 
-    var shouldPublish = GetShouldPublish(branch) && "true".Equals(context.EnvironmentVariable("PUBLISH_NUGET_PACKAGE"), StringComparison.OrdinalIgnoreCase);
+    var shouldPublish = GetShouldPublish(branch) && ("1".Equals(publishNuGetPackage, StringComparison.Ordinal) || (bool.TryParse(publishNuGetPackage, out var result) && result));
 
     if (isFork && isPullRequest && shouldPublish)
     {

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.3.0",
+      "version": "3.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -86,12 +86,15 @@ jobs:
       pull-requests: read
 
     env:
+      CODE_SIGNING_CERTIFICATE_BASE64: ${{ secrets.CODE_SIGNING_CERTIFICATE_BASE64 }}
+      CODE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CERTIFICATE_PASSWORD }}
       FEED_SOURCE: https://api.nuget.org/v3/index.json
-      FEED_APIKEY: ${{ secrets.FEED_APIKEY }}
+      FEED_API_KEY: ${{ secrets.FEED_API_KEY }}
       SONARCLOUD_URL: https://sonarcloud.io
       SONARCLOUD_ORGANIZATION: testcontainers
       SONARCLOUD_KEY: testcontainers_testcontainers-dotnet
       SONARCLOUD_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+      PUBLISH_NUGET_PACKAGE: ${{ inputs.publish_nuget_package }}
 
     steps:
       - name: Checkout Repository
@@ -115,6 +118,9 @@ jobs:
           Get-ChildItem -Path 'test-coverage' -Filter *.xml | % { (Get-Content $_) -Replace '[A-Za-z0-9:\-\/\\]+src', '${{ github.workspace }}/src' | Set-Content $_ }
           Get-ChildItem -Path 'test-coverage' -Filter *.xml | % { (Get-Content $_) -Replace '[A-Za-z0-9:\-\/\\]+tests', '${{ github.workspace }}/tests' | Set-Content $_ }
         shell: pwsh
+
+      - name: Decode Code Signing Certificate
+        run: echo $CODE_SIGNING_CERTIFICATE_BASE64 | base64 --decode > code-signing-certificate.pfx
 
       - name: Cache NuGet Packages
         uses: actions/cache@v3
@@ -142,8 +148,6 @@ jobs:
 
       - name: Publish NuGet Package
         run: dotnet cake --target=Publish
-        env:
-          PUBLISH_NUGET_PACKAGE: ${{ inputs.publish_nuget_package }}
 
       - uses: release-drafter/release-drafter@6df64e4ba4842c203c604c1f45246c5863410adb
         with:

--- a/Testcontainers.sln
+++ b/Testcontainers.sln
@@ -1,11 +1,11 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AF017206-CE20-4DDF-8301-CAC68CED1BE6}"
-ProjectSection(SolutionItems) = preProject
-	CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
-	CONTRIBUTING.md = CONTRIBUTING.md
-	README.md = README.md
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
+		CONTRIBUTING.md = CONTRIBUTING.md
+		README.md = README.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{673F23AE-7694-4BB9-ABD4-136D6C13634E}"
 EndProject

--- a/build.cake
+++ b/build.cake
@@ -1,8 +1,8 @@
-#tool nuget:?package=dotnet-sonarscanner&version=5.8.0
+#tool nuget:?package=dotnet-sonarscanner&version=5.10.0
 
-#addin nuget:?package=Cake.Sonar&version=1.1.29
+#addin nuget:?package=Cake.Sonar&version=1.1.31
 
-#addin nuget:?package=Cake.Git&version=2.0.0
+#addin nuget:?package=Cake.Git&version=3.0.0
 
 #load ".cake-scripts/parameters.cake"
 
@@ -132,7 +132,7 @@ Task("Create-NuGet-Packages")
   .WithCriteria(() => param.ShouldPublish)
   .Does(() =>
 {
-  DotNetPack(param.Projects.Testcontainers.Path.FullPath, new DotNetPackSettings
+  DotNetPack(param.Solution, new DotNetPackSettings
   {
     Configuration = param.Configuration,
     Verbosity = param.Verbosity,
@@ -192,6 +192,7 @@ Task("Sonar")
 
 Task("Publish")
   .IsDependentOn("Create-NuGet-Packages")
+  .IsDependentOn("Sign-NuGet-Packages")
   .IsDependentOn("Publish-NuGet-Packages");
 
 RunTarget(param.Target);

--- a/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
+++ b/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
@@ -2,6 +2,8 @@
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
     <Configurations>Debug;Release</Configurations>
     <RootNamespace>DotNet.Testcontainers.Commons</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
## What does this PR do?

Creates NuGets (dependencies) for all solution projects instead of just for the Testcontainers project. This allows us to publish moduls as independent dependencies. The PR signs NuGets too.

## Why is it important?

To publish moduls as independent dependencies.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #493

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
