### PR TITLE
feat: Invoke create parameter modifier for image, network, volume build or create

### DIFF
--- a/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
@@ -25,7 +25,7 @@
   ///   </code>
   /// </example>
   [PublicAPI]
-  public class ImageFromDockerfileBuilder : AbstractBuilder<ImageFromDockerfileBuilder, IFutureDockerImage, ImagesCreateParameters, IImageFromDockerfileConfiguration>, IImageFromDockerfileBuilder<ImageFromDockerfileBuilder>
+  public class ImageFromDockerfileBuilder : AbstractBuilder<ImageFromDockerfileBuilder, IFutureDockerImage, ImageBuildParameters, IImageFromDockerfileConfiguration>, IImageFromDockerfileBuilder<ImageFromDockerfileBuilder>
   {
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageFromDockerfileBuilder" /> class.
@@ -112,7 +112,7 @@
     }
 
     /// <inheritdoc />
-    protected override ImageFromDockerfileBuilder Clone(IResourceConfiguration<ImagesCreateParameters> resourceConfiguration)
+    protected override ImageFromDockerfileBuilder Clone(IResourceConfiguration<ImageBuildParameters> resourceConfiguration)
     {
       return this.Merge(this.DockerResourceConfiguration, new ImageFromDockerfileConfiguration(resourceConfiguration));
     }

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -106,10 +106,18 @@ namespace DotNet.Testcontainers.Clients
       var buildParameters = new ImageBuildParameters
       {
         Dockerfile = configuration.Dockerfile,
-        Tags = new[] { image.FullName },
+        Tags = new List<string> { image.FullName },
         BuildArgs = configuration.BuildArguments?.ToDictionary(item => item.Key, item => item.Value),
         Labels = configuration.Labels?.ToDictionary(item => item.Key, item => item.Value),
       };
+
+      if (configuration.ParameterModifiers != null)
+      {
+        foreach (var parameterModifier in configuration.ParameterModifiers)
+        {
+          parameterModifier(buildParameters);
+        }
+      }
 
       var dockerfileArchiveFilePath = await dockerfileArchive.Tar(ct)
         .ConfigureAwait(false);

--- a/src/Testcontainers/Clients/DockerNetworkOperations.cs
+++ b/src/Testcontainers/Clients/DockerNetworkOperations.cs
@@ -65,6 +65,14 @@ namespace DotNet.Testcontainers.Clients
         Labels = configuration.Labels?.ToDictionary(item => item.Key, item => item.Value),
       };
 
+      if (configuration.ParameterModifiers != null)
+      {
+        foreach (var parameterModifier in configuration.ParameterModifiers)
+        {
+          parameterModifier(createParameters);
+        }
+      }
+
       var createNetworkResponse = await this.Docker.Networks.CreateNetworkAsync(createParameters, ct)
         .ConfigureAwait(false);
 

--- a/src/Testcontainers/Clients/DockerVolumeOperations.cs
+++ b/src/Testcontainers/Clients/DockerVolumeOperations.cs
@@ -61,6 +61,14 @@ namespace DotNet.Testcontainers.Clients
         Labels = configuration.Labels?.ToDictionary(item => item.Key, item => item.Value),
       };
 
+      if (configuration.ParameterModifiers != null)
+      {
+        foreach (var parameterModifier in configuration.ParameterModifiers)
+        {
+          parameterModifier(createParameters);
+        }
+      }
+
       var createVolumeResponse = await this.Docker.Volumes.CreateAsync(createParameters, ct)
         .ConfigureAwait(false);
 

--- a/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
@@ -9,7 +9,7 @@
   /// An image configuration.
   /// </summary>
   [PublicAPI]
-  public interface IImageFromDockerfileConfiguration : IResourceConfiguration<ImagesCreateParameters>
+  public interface IImageFromDockerfileConfiguration : IResourceConfiguration<ImageBuildParameters>
   {
     /// <summary>
     /// Gets a value indicating whether Testcontainers removes an existing image or not.

--- a/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
@@ -8,7 +8,7 @@
 
   /// <inheritdoc cref="IImageFromDockerfileConfiguration" />
   [PublicAPI]
-  internal sealed class ImageFromDockerfileConfiguration : ResourceConfiguration<ImagesCreateParameters>, IImageFromDockerfileConfiguration
+  internal sealed class ImageFromDockerfileConfiguration : ResourceConfiguration<ImageBuildParameters>, IImageFromDockerfileConfiguration
   {
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageFromDockerfileConfiguration" /> class.
@@ -36,7 +36,7 @@
     /// Initializes a new instance of the <see cref="ImageFromDockerfileConfiguration" /> class.
     /// </summary>
     /// <param name="resourceConfiguration">The Docker resource configuration.</param>
-    public ImageFromDockerfileConfiguration(IResourceConfiguration<ImagesCreateParameters> resourceConfiguration)
+    public ImageFromDockerfileConfiguration(IResourceConfiguration<ImageBuildParameters> resourceConfiguration)
       : base(resourceConfiguration)
     {
     }

--- a/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersAccessInformationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersAccessInformationTest.cs
@@ -68,6 +68,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           Assert.NotEmpty(testcontainer.Name);
           Assert.NotEmpty(testcontainer.IpAddress);
           Assert.NotEmpty(testcontainer.MacAddress);
+          Assert.NotEmpty(testcontainer.Hostname);
         }
       }
 
@@ -82,10 +83,13 @@ namespace DotNet.Testcontainers.Tests.Unit
         // Then
         await using (ITestcontainersContainer testcontainer = testcontainersBuilder.Build())
         {
+          Assert.Throws<InvalidOperationException>(() => testcontainer.Id);
           Assert.Throws<InvalidOperationException>(() => testcontainer.Name);
           Assert.Throws<InvalidOperationException>(() => testcontainer.IpAddress);
           Assert.Throws<InvalidOperationException>(() => testcontainer.MacAddress);
           Assert.Throws<InvalidOperationException>(() => testcontainer.GetMappedPublicPort(0));
+          Assert.Equal(TestcontainersStates.Undefined, testcontainer.State);
+          Assert.Equal(TestcontainersHealthStatus.Undefined, testcontainer.Health);
         }
       }
 

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -84,11 +84,16 @@ namespace DotNet.Testcontainers.Tests.Unit
     public async Task BuildsDockerImage()
     {
       // Given
+      IImage tag1 = new DockerImage("localhost/testcontainers", Guid.NewGuid().ToString("D"), string.Empty);
+
+      IImage tag2 = new DockerImage("localhost/testcontainers", Guid.NewGuid().ToString("D"), string.Empty);
+
       var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
-        .WithName("alpine:custom")
+        .WithName(tag1)
         .WithDockerfile("Dockerfile")
         .WithDockerfileDirectory("Assets")
         .WithDeleteIfExists(true)
+        .WithCreateParameterModifier(parameterModifier => parameterModifier.Tags.Add(tag2.FullName))
         .Build();
 
       // When
@@ -99,12 +104,13 @@ namespace DotNet.Testcontainers.Tests.Unit
         .ConfigureAwait(false);
 
       // Then
-      Assert.True(DockerCli.ResourceExists(DockerCli.DockerResource.Image, imageFromDockerfileBuilder.FullName));
-      Assert.Null(Record.Exception(() => imageFromDockerfileBuilder.Repository));
-      Assert.Null(Record.Exception(() => imageFromDockerfileBuilder.Name));
-      Assert.Null(Record.Exception(() => imageFromDockerfileBuilder.Tag));
-      Assert.Null(Record.Exception(() => imageFromDockerfileBuilder.FullName));
-      Assert.Null(Record.Exception(() => imageFromDockerfileBuilder.GetHostname()));
+      Assert.True(DockerCli.ResourceExists(DockerCli.DockerResource.Image, tag1.FullName));
+      Assert.True(DockerCli.ResourceExists(DockerCli.DockerResource.Image, tag2.FullName));
+      Assert.NotNull(imageFromDockerfileBuilder.Repository);
+      Assert.NotNull(imageFromDockerfileBuilder.Name);
+      Assert.NotNull(imageFromDockerfileBuilder.Tag);
+      Assert.NotNull(imageFromDockerfileBuilder.FullName);
+      Assert.Null(imageFromDockerfileBuilder.GetHostname());
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Invokes the create parameter modifier action for image, network, volume build or create.

## Why is it important?

Until now, developers could define a create parameter modification, but we never invoked the modification.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
