### PR TITLE
feat: Prepare next release cycle (2.5.0)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -120,8 +120,8 @@ jobs:
         shell: pwsh
 
       - name: Decode Code Signing Certificate
-        shell: bash
         run: echo $CODE_SIGNING_CERTIFICATE_BASE64 | base64 --decode > code-signing-certificate.pfx
+        shell: bash
 
       - name: Cache NuGet Packages
         uses: actions/cache@v3

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>$(AssemblyName)</PackageId>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Product>Testcontainers</Product>


### PR DESCRIPTION
## What does this PR do?

Sets the version of the next Testcontainers for .NET release.

## Why is it important?

The next release will be all about removing obsolete code and migration modules to individual projects and dependencies.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
