### PR TITLE
chore: Remove obsolete property IDockerNetwork.Id

### DIFF
--- a/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
+++ b/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
@@ -122,9 +122,6 @@ namespace DotNet.Testcontainers
     public interface IDockerNetwork
     {
       [NotNull]
-      string Id { get; }
-
-      [NotNull]
       string Name { get; }
 
       Task CreateAsync(CancellationToken ct = default);
@@ -139,7 +136,6 @@ namespace DotNet.Testcontainers
     {
       public DockerNetwork(IDockerNetwork network)
       {
-        this.network.ID = network.Id;
         this.network.Name = network.Name;
       }
     }

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -388,12 +388,8 @@
         /// <param name="name">The name.</param>
         public DockerNetwork(string name)
         {
-          this.Id = string.Empty;
           this.Name = name;
         }
-
-        /// <inheritdoc cref="INetwork" />
-        public string Id { get; }
 
         /// <inheritdoc cref="INetwork" />
         public string Name { get; }

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -282,16 +282,6 @@
     /// <summary>
     /// Assigns the specified network to the container.
     /// </summary>
-    /// <param name="id">The network's id to connect to.</param>
-    /// <param name="name">The network's name to connect to.</param>
-    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
-    [PublicAPI]
-    [Obsolete("Use WithNetwork(string) instead.")]
-    TBuilderEntity WithNetwork(string id, string name);
-
-    /// <summary>
-    /// Assigns the specified network to the container.
-    /// </summary>
     /// <param name="name">The network's name to connect to.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]

--- a/src/Testcontainers/Networks/DockerNetwork.cs
+++ b/src/Testcontainers/Networks/DockerNetwork.cs
@@ -31,17 +31,6 @@
     }
 
     /// <inheritdoc />
-    [Obsolete("The property is not necessary anymore. Use WithNetwork(string) instead.")]
-    public string Id
-    {
-      get
-      {
-        this.ThrowIfResourceNotFound();
-        return this.network.ID;
-      }
-    }
-
-    /// <inheritdoc />
     public string Name
     {
       get

--- a/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersAccessInformationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersAccessInformationTest.cs
@@ -121,7 +121,6 @@ namespace DotNet.Testcontainers.Tests.Unit
         var network = networkBuilder.Build();
 
         // Then
-        Assert.Throws<InvalidOperationException>(() => network.Id);
         Assert.Throws<InvalidOperationException>(() => network.Name);
       }
 

--- a/tests/Testcontainers.Tests/Unit/Networks/TestcontainerNetworkBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Networks/TestcontainerNetworkBuilderTest.cs
@@ -31,20 +31,12 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [Fact]
-    public void GetIdOrNameThrowsInvalidOperationException()
+    public void GetNameThrowsInvalidOperationException()
     {
-      var noSuchNetwork = new TestcontainersNetworkBuilder()
+      _ = Assert.Throws<InvalidOperationException>(() => new TestcontainersNetworkBuilder()
         .WithName(NetworkName)
-        .Build();
-
-      Assert.Throws<InvalidOperationException>(() => noSuchNetwork.Id);
-      Assert.Throws<InvalidOperationException>(() => noSuchNetwork.Name);
-    }
-
-    [Fact]
-    public void GetIdReturnsNetworkId()
-    {
-      Assert.NotEmpty(this.network.Id);
+        .Build()
+        .Name);
     }
 
     [Fact]
@@ -90,14 +82,6 @@ namespace DotNet.Testcontainers.Tests.Unit
         .WithLabel(Label.Key, Label.Value)
         .WithCreateParameterModifier(parameterModifier => parameterModifier.Labels.Add(ParameterModifier.Key, ParameterModifier.Value))
         .Build();
-
-      public string Id
-      {
-        get
-        {
-          return this.network.Id;
-        }
-      }
 
       public string Name
       {

--- a/tests/Testcontainers.Tests/Unit/Networks/TestcontainersNetworkTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Networks/TestcontainersNetworkTest.cs
@@ -20,7 +20,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
         .WithImage("alpine")
         .WithEntrypoint(CommonCommands.SleepInfinity)
-        .WithNetwork(networkFixture.Network.Id, networkFixture.Network.Name);
+        .WithNetwork(networkFixture.Network.Name);
 
       this.testcontainer1 = testcontainersBuilder
         .WithHostname(nameof(this.testcontainer1))

--- a/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeBuilderTest.cs
@@ -29,13 +29,12 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [Fact]
-    public void GetIdOrNameThrowsInvalidOperationException()
+    public void GetNameThrowsInvalidOperationException()
     {
-      var noSuchVolume = new TestcontainersVolumeBuilder()
+      _ = Assert.Throws<InvalidOperationException>(() => new TestcontainersVolumeBuilder()
         .WithName(VolumeName)
-        .Build();
-
-      Assert.Throws<InvalidOperationException>(() => noSuchVolume.Name);
+        .Build()
+        .Name);
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

Removes the obsolete property `IDockerNetwork.Id`.

## Why is it important?

The property is no longer necessary and supported.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
