### PR TITLE
docs: Replace obsolete builders

### DIFF
--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -9,7 +9,7 @@ Both `ENTRYPOINT` and `CMD` allows you to configure an executable and parameters
 Instead of running the NGINX application, the following container configuration overrides the default start procedure of the image and just tests the NGINX configuration file.
 
 ```csharp
-_ = new TestcontainersBuilder<TestcontainersContainer>()
+_ = new ContainerBuilder()
   .WithEntrypoint("nginx")
   .WithCommand("-t");
 ```
@@ -25,7 +25,7 @@ Apps or services running inside a container are usually configured either with e
 To configure an ASP.NET Core application, either one or both mechanisms can be used.
 
 ```csharp
-_ = new TestcontainersBuilder<TestcontainersContainer>()
+_ = new ContainerBuilder()
   .WithEnvironment("ASPNETCORE_URLS", "https://+")
   .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Path", "/app/certificate.crt")
   .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Password", "password")
@@ -41,7 +41,7 @@ An NGINX container that binds the HTTP port to a random host port and hosts stat
 ```csharp
 const ushort HttpPort = 80;
 
-var nginxContainer = new TestcontainersBuilder<TestcontainersContainer>()
+var nginxContainer = new ContainerBuilder()
   .WithName(Guid.NewGuid().ToString("D"))
   .WithImage("nginx")
   .WithPortBinding(HttpPort, true)
@@ -66,7 +66,7 @@ const string MagicNumber = "42";
 
 const ushort MagicNumberPort = 80;
 
-var deepThoughtContainer = new TestcontainersBuilder<TestcontainersContainer>()
+var deepThoughtContainer = new ContainerBuilder()
   .WithName(Guid.NewGuid().ToString("D"))
   .WithImage("alpine")
   .WithExposedPort(MagicNumberPort)
@@ -100,7 +100,6 @@ Assert.Equal(MagicNumber, magicNumber);
 | `WithAutoRemove`                        | Will remove the stopped container automatically, similar to `--rm`.                                                                    |
 | `WithCleanUp`                           | Will remove the container automatically after all tests have been run.                                                                 |
 | `WithLabel`                             | Applies metadata to the container e.g. `-l`, `--label "testcontainers=awesome"`.                                                       |
-| `WithResourceReaperSessionId`           | Assigns a Resource Reaper session id to the container. The assigned Resource Reaper takes care of the cleanup.                         |
 | `WithImage`                             | Specifies an image for which to create the container.                                                                                  |
 | `WithImagePullPolicy`                   | Specifies an image pull policy to determine when an image is pulled e.g. <code>--pull "always" &vert; "missing" &vert; "never"</code>. |
 | `WithName`                              | Sets the container name e.g. `--name "testcontainers"`.                                                                                |
@@ -122,7 +121,7 @@ Assert.Equal(MagicNumber, magicNumber);
 | `WithOutputConsumer`                    | Redirects `stdout` and `stderr` to capture the container output.                                                                       |
 | `WithWaitStrategy`                      | Sets the wait strategy to complete the container start and indicates when it is ready.                                                 |
 | `WithStartupCallback`                   | Sets the startup callback to invoke after the container start.                                                                         |
-| `WithCreateContainerParametersModifier` | Allows low level modifications of the Docker container create parameter.                                                               |
+| `WithCreateParameterModifier`           | Allows low level modifications of the Docker container create parameter.                                                               |
 
 !!!tip
 

--- a/docs/api/create_docker_image.md
+++ b/docs/api/create_docker_image.md
@@ -7,11 +7,13 @@ Testcontainers for .NET uses the builder design pattern to configure, create and
 Builds and tags a new container image. The `Dockerfile` is located inside the `src` directory in the solution (`.sln`) directory.
 
 ```csharp
-_ = await new ImageFromDockerfileBuilder()
+await new ImageFromDockerfileBuilder()
   .WithName(Guid.NewGuid().ToString("D"))
   .WithDockerfileDirectory(CommonDirectoryPath.GetSolutionDirectory(), "src")
   .WithDockerfile("Dockerfile")
-  .Build();
+  .Build()
+  .CreateAsync()
+  .ConfigureAwait(false);
 ```
 
 !!!tip
@@ -25,12 +27,12 @@ _ = await new ImageFromDockerfileBuilder()
 | `WithDockerEndpoint`          | Sets the Docker daemon socket to connect to.                                                               |
 | `WithCleanUp`                 | Will remove the image automatically after all tests have been run.                                         |
 | `WithLabel`                   | Applies metadata to the image e.g. `-l`, `--label "testcontainers=awesome"`.                               |
-| `WithResourceReaperSessionId` | Assigns a Resource Reaper session id to the image. The assigned Resource Reaper takes care of the cleanup. |
 | `WithName`                    | Sets the image name e.g. `-t`, `--tag "testcontainers:0.1.0"`.                                             |
 | `WithDockerfile`              | Sets the name of the `Dockerfile`.                                                                         |
 | `WithDockerfileDirectory`     | Sets the build context (directory path that contains the `Dockerfile`).                                    |
 | `WithDeleteIfExists`          | Will remove the image if it already exists.                                                                |
 | `WithBuildArgument`           | Sets build-time variables e.g `--build-arg "MAGIC_NUMBER=42"`.                                             |
+| `WithCreateParameterModifier` | Allows low level modifications of the Docker image build parameter.                                        |
 
 !!!tip
 

--- a/docs/api/create_docker_network.md
+++ b/docs/api/create_docker_network.md
@@ -60,12 +60,12 @@ Assert.Equal(MagicNumber, execResult.Stdout.Trim());
 
 ## Supported commands
 
-| Builder method                          | Description                                                                                      |
-|-----------------------------------------|--------------------------------------------------------------------------------------------------|
-| `WithDockerEndpoint`                    | Sets the Docker daemon socket to connect to.                                                     |
-| `WithCleanUp`                           | Will remove the network automatically after all tests have been run.                             |
-| `WithLabel`                             | Applies metadata to the network e.g. `-l`, `--label "testcontainers=awesome"`.                   |
-| `WithName`                              | Sets the network name e.g. `docker network create "testcontainers"`.                             |
-| `WithDriver`                            | Sets the network driver e.g. `-d`, `--driver "bridge"`                                           |
-| `WithOption`                            | Adds a driver specific option `-o`, `--opt "com.docker.network.driver.mtu=1350"`                 |
-| `WithCreateContainerParametersModifier` | Allows low level modifications of the Docker network create parameter.                           |
+| Builder method                | Description                                                                                      |
+|-------------------------------|--------------------------------------------------------------------------------------------------|
+| `WithDockerEndpoint`          | Sets the Docker daemon socket to connect to.                                                     |
+| `WithCleanUp`                 | Will remove the network automatically after all tests have been run.                             |
+| `WithLabel`                   | Applies metadata to the network e.g. `-l`, `--label "testcontainers=awesome"`.                   |
+| `WithName`                    | Sets the network name e.g. `docker network create "testcontainers"`.                             |
+| `WithDriver`                  | Sets the network driver e.g. `-d`, `--driver "bridge"`                                           |
+| `WithOption`                  | Adds a driver specific option `-o`, `--opt "com.docker.network.driver.mtu=1350"`                 |
+| `WithCreateParameterModifier` | Allows low level modifications of the Docker network create parameter.                           |

--- a/docs/api/create_docker_network.md
+++ b/docs/api/create_docker_network.md
@@ -16,7 +16,7 @@ This is considered a best practice and prevents port collisions.
 
 ## Custom network
 
-A more advanced case, places one or more containers on custom networks. The communication between those containers won't require exposing ports through the host anymore. To configure and create Docker networks use `TestcontainersNetworkBuilder`. The following example creates a network and assigns it to two containers. The second container establishes a network connection to Deep Thought by using its network alias and receives the magic number `42`.
+A more advanced case, places one or more containers on custom networks. The communication between those containers won't require exposing ports through the host anymore. To configure and create Docker networks use `NetworkBuilder`. The following example creates a network and assigns it to two containers. The second container establishes a network connection to Deep Thought by using its network alias and receives the magic number `42`.
 
 ```csharp
 const string MagicNumber = "42";
@@ -25,11 +25,11 @@ const string MagicNumberHost = "deep-thought";
 
 const ushort MagicNumberPort = 80;
 
-var network = new TestcontainersNetworkBuilder()
+var network = new NetworkBuilder()
   .WithName(Guid.NewGuid().ToString("D"))
   .Build();
 
-var deepThoughtContainer = new TestcontainersBuilder<TestcontainersContainer>()
+var deepThoughtContainer = new ContainerBuilder()
   .WithName(Guid.NewGuid().ToString("D"))
   .WithImage("alpine")
   .WithEnvironment("MAGIC_NUMBER", MagicNumber)
@@ -39,7 +39,7 @@ var deepThoughtContainer = new TestcontainersBuilder<TestcontainersContainer>()
   .WithNetworkAliases(MagicNumberHost)
   .Build();
 
-var ultimateQuestionContainer = new TestcontainersBuilder<TestcontainersContainer>()
+var ultimateQuestionContainer = new ContainerBuilder()
   .WithName(Guid.NewGuid().ToString("D"))
   .WithImage("alpine")
   .WithEntrypoint("top")
@@ -60,12 +60,12 @@ Assert.Equal(MagicNumber, execResult.Stdout.Trim());
 
 ## Supported commands
 
-| Builder method                | Description                                                                                                |
-|-------------------------------|------------------------------------------------------------------------------------------------------------|
-| `WithDockerEndpoint`          | Sets the Docker daemon socket to connect to.                                                               |
-| `WithCleanUp`                 | Will remove the network automatically after all tests have been run.                                       |
-| `WithLabel`                   | Applies metadata to the network e.g. `-l`, `--label "testcontainers=awesome"`.                             |
-| `WithResourceReaperSessionId` | Assigns a Resource Reaper session id to the image. The assigned Resource Reaper takes care of the cleanup. |
-| `WithName`                    | Sets the network name e.g. `docker network create "testcontainers"`.                                       |
-| `WithDriver`                  | Sets the network driver e.g. `-d`, `--driver "bridge"`                                                     |
-| `WithOption`                  | Adds a driver specific option `-o`, `--opt "com.docker.network.driver.mtu=1350"`                           |
+| Builder method                          | Description                                                                                      |
+|-----------------------------------------|--------------------------------------------------------------------------------------------------|
+| `WithDockerEndpoint`                    | Sets the Docker daemon socket to connect to.                                                     |
+| `WithCleanUp`                           | Will remove the network automatically after all tests have been run.                             |
+| `WithLabel`                             | Applies metadata to the network e.g. `-l`, `--label "testcontainers=awesome"`.                   |
+| `WithName`                              | Sets the network name e.g. `docker network create "testcontainers"`.                             |
+| `WithDriver`                            | Sets the network driver e.g. `-d`, `--driver "bridge"`                                           |
+| `WithOption`                            | Adds a driver specific option `-o`, `--opt "com.docker.network.driver.mtu=1350"`                 |
+| `WithCreateContainerParametersModifier` | Allows low level modifications of the Docker network create parameter.                           |

--- a/docs/api/resource-reaper.md
+++ b/docs/api/resource-reaper.md
@@ -14,7 +14,7 @@ Creates a scoped Resource Reaper and assigns its session id to a container (Dock
 var resourceReaper = await ResourceReaper.GetAndStartNewAsync()
   .ConfigureAwait(false);
 
-await new TestcontainersBuilder<TestcontainersContainer>()
+await new ContainerBuilder()
   .WithImage("alpine")
   .WithResourceReaperSessionId(resourceReaper.SessionId)
   .Build()

--- a/docs/api/wait_strategies.md
+++ b/docs/api/wait_strategies.md
@@ -13,10 +13,7 @@ _ = Wait.ForUnixContainer()
 
 ## Wait until an HTTP(S) endpoint is available
 
-You can choose to wait for an HTTP(S) endpoint to return a particular HTTP response status code or to match a predicate. 
-The default configuration tries to access the HTTP endpoint running inside the container. Chose `ForPort(ushort)` or `ForPath(string)` to adjust the endpoint or `UsingTls()` to switch to HTTPS.
-When using `UsingTls()` port 443 is used as a default. 
-If your container exposes a different HTTPS port, make sure that the correct waiting port is configured accordingly.
+You can choose to wait for an HTTP(S) endpoint to return a particular HTTP response status code or to match a predicate. The default configuration tries to access the HTTP endpoint running inside the container. Chose `ForPort(ushort)` or `ForPath(string)` to adjust the endpoint or `UsingTls()` to switch to HTTPS. When using `UsingTls()` port 443 is used as a default. If your container exposes a different HTTPS port, make sure that the correct waiting port is configured accordingly.
 
 ### Waiting for HTTP response status code _200 OK_ on port 80
 
@@ -57,7 +54,7 @@ HEALTHCHECK --interval=1s CMD test -e /healthcheck
 You can leverage the container's health status as your wait strategy to report readiness of your application or service:
 
 ```csharp
-_ = new TestcontainersBuilder<TestcontainersContainer>()
+_ = new ContainerBuilder()
   .WithWaitStrategy(Wait.ForUnixContainer().UntilContainerIsHealthy());
 ```
 

--- a/docs/examples/aspnet.md
+++ b/docs/examples/aspnet.md
@@ -15,17 +15,17 @@ mssqlConfiguration.Database = Guid.NewGuid().ToString("D");
 
 var connectionString = $"server={weatherForecastStorage};user id=sa;password={mssqlConfiguration.Password};database={mssqlConfiguration.Database}";
 
-_weatherForecastNetwork = new TestcontainersNetworkBuilder()
+_weatherForecastNetwork = new NetworkBuilder()
   .WithName(Guid.NewGuid().ToString("D"))
   .Build();
 
-_mssqlContainer = new TestcontainersBuilder<MsSqlTestcontainer>()
+_mssqlContainer = new ContainerBuilder<MsSqlTestcontainer>()
   .WithDatabase(mssqlConfiguration)
   .WithNetwork(_weatherForecastNetwork)
   .WithNetworkAliases(weatherForecastStorage)
   .Build();
 
-_weatherForecastContainer = new TestcontainersBuilder<TestcontainersContainer>()
+_weatherForecastContainer = new ContainerBuilder()
   .WithImage(Image)
   .WithNetwork(_weatherForecastNetwork)
   .WithPortBinding(WeatherForecastImage.HttpsPort, true)

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -4,7 +4,7 @@ Modules are a great example of the capabilities of Testcontainers for .NET. Choo
 
 !!!warning
 
-    We are redesigning modules and removing the extension method in the future. Modules will become independent projects that allow more complex and advanced features. Due to an old design flaw, we cannot distinguish between a generic and module builder. If you rely on a module you will get an obsolete warning until the next version of Testcontainers gets released. You will find more information [here](https://github.com/testcontainers/testcontainers-dotnet/issues/750#issuecomment-1412257694).
+    We are redesigning modules and removing the extension method in the future. Modules will become independent projects that allow more complex and advanced features. Due to a design flaw in the current module system, we cannot distinguish between a generic and module builder. If you rely on a module you will get an obsolete warning until the next version of Testcontainers gets released. You will find more information [here](https://github.com/testcontainers/testcontainers-dotnet/issues/750#issuecomment-1412257694).
 
 | Module                     | Container image                                                  |
 |----------------------------|------------------------------------------------------------------|

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -2,6 +2,10 @@
 
 Modules are a great example of the capabilities of Testcontainers for .NET. Choose one of the pre-configurations below or find further examples in [TestcontainersContainerTest][testcontainers-container-tests] as well as in the [database][testcontainers-database-tests] or [message broker][testcontainers-message-broker-tests] tests to set up your test environment.
 
+!!!warning
+
+    We are redesigning modules and removing the extension method in the future. Modules will become independent projects that allow more complex and advanced features. Due to an old design flaw, we cannot distinguish between a generic and module builder. If you rely on a module you will get an obsolete warning until the next version of Testcontainers gets released. You will find more information [here](https://github.com/testcontainers/testcontainers-dotnet/issues/750#issuecomment-1412257694).
+
 | Module                     | Container image                                                  |
 |----------------------------|------------------------------------------------------------------|
 | LocalStack                 | `localstack/localstack:1.2.0`                                    |
@@ -24,7 +28,7 @@ Modules are a great example of the capabilities of Testcontainers for .NET. Choo
 Due to a design flaw in the current module system, pre-configured containers must be configured through their corresponding extension method (`WithDatabase` or `WithMessageBroker`):
 
 ```csharp
-await new TestcontainersBuilder<PostgreSqlTestcontainer>()
+await new ContainerBuilder<PostgreSqlTestcontainer>()
   .WithDatabase(new PostgreSqlTestcontainerConfiguration())
   .Build()
   .StartAsync()

--- a/docs/modules/postgres.md
+++ b/docs/modules/postgres.md
@@ -5,7 +5,7 @@ Here is an example of a pre-configured PostgreSQL container. In the example, Tes
 ```csharp
 public sealed class PostgreSqlTest : IAsyncLifetime
 {
-  private readonly TestcontainerDatabase _postgresqlContainer = new TestcontainersBuilder<PostgreSqlTestcontainer>()
+  private readonly TestcontainerDatabase _postgresqlContainer = new ContainerBuilder<PostgreSqlTestcontainer>()
     .WithDatabase(new PostgreSqlTestcontainerConfiguration
     {
       Database = "db",


### PR DESCRIPTION
## What does this PR do?

Removes the obsolete classes and interfaces in the documentation. For the module builder, we need to stick to the obsolete builder until the new modules are finished. Due to the old generic and module builder uses the same syntax, we cannot distinguish between them.

## Why is it important?

To keep the documentation up-to-date and not rely on obsolete classes or interfaces.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
