### PR TITLE
fix: Move MsSqlContainerTest class to namespace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: nuget
-    directory: '/'
+    directory: /
     schedule:
       interval: monthly
     reviewers:

--- a/build.cake
+++ b/build.cake
@@ -74,24 +74,21 @@ Task("Build")
 Task("Tests")
   .Does(() =>
 {
-  foreach(var testProject in param.Projects.OnlyTests)
+  DotNetTest(param.Solution, new DotNetTestSettings
   {
-    DotNetTest(testProject.Path.FullPath, new DotNetTestSettings
-    {
-      Configuration = param.Configuration,
-      Verbosity = param.Verbosity,
-      NoRestore = true,
-      NoBuild = true,
-      Loggers = new[] { "trx" },
-      Filter = param.TestFilter,
-      ResultsDirectory = param.Paths.Directories.TestResultsDirectoryPath,
-      ArgumentCustomization = args => args
-        .Append("/p:CollectCoverage=true")
-        .Append("/p:CoverletOutputFormat=\"json%2copencover\"") // https://github.com/coverlet-coverage/coverlet/pull/220#issuecomment-431507570.
-        .Append($"/p:MergeWith=\"{MakeAbsolute(param.Paths.Directories.TestCoverageDirectoryPath)}/coverage.net6.0.json\"")
-        .Append($"/p:CoverletOutput=\"{MakeAbsolute(param.Paths.Directories.TestCoverageDirectoryPath)}/\"")
-    });
-  }
+    Configuration = param.Configuration,
+    Verbosity = param.Verbosity,
+    NoRestore = true,
+    NoBuild = true,
+    Loggers = new[] { "trx" },
+    Filter = param.TestFilter,
+    ResultsDirectory = param.Paths.Directories.TestResultsDirectoryPath,
+    ArgumentCustomization = args => args
+      .Append("/p:CollectCoverage=true")
+      .Append("/p:CoverletOutputFormat=\"json%2copencover\"") // https://github.com/coverlet-coverage/coverlet/pull/220#issuecomment-431507570.
+      .Append($"/p:MergeWith=\"{MakeAbsolute(param.Paths.Directories.TestCoverageDirectoryPath)}/coverage.net6.0.json\"")
+      .Append($"/p:CoverletOutput=\"{MakeAbsolute(param.Paths.Directories.TestCoverageDirectoryPath)}/\"")
+  });
 });
 
 Task("Sonar-Begin")

--- a/src/Testcontainers.MsSql/MsSqlContainer.cs
+++ b/src/Testcontainers.MsSql/MsSqlContainer.cs
@@ -40,7 +40,7 @@ public sealed class MsSqlContainer : DockerContainer
     /// <returns>Task that completes when the SQL script has been executed.</returns>
     public async Task<ExecResult> ExecScriptAsync(string scriptContent, CancellationToken ct = default)
     {
-        var scriptFilePath = string.Join("/", Guid.NewGuid().ToString("D"), Path.GetRandomFileName());
+        var scriptFilePath = string.Join("/", string.Empty, "tmp", Guid.NewGuid().ToString("D"), Path.GetRandomFileName());
 
         await CopyFileAsync(scriptFilePath, Encoding.Default.GetBytes(scriptContent), 493, 0, 0, ct)
             .ConfigureAwait(false);

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -1,4 +1,4 @@
-﻿using Testcontainers.MsSql;
+﻿namespace Testcontainers.MsSql;
 
 public sealed class MsSqlContainerTest : IAsyncLifetime
 {

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -40,6 +40,6 @@ public sealed class MsSqlContainerTest : IAsyncLifetime
             .ConfigureAwait(false);
 
         // When
-        Assert.Equal(0, execResult.ExitCode);
+        Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Moves the `MsSqlContainerTest` class to the `Testcontainers.MsSql` namespace.

## Why is it important?

It is necessary to have the tests in the `Testcontainers` namespace. Otherwise, `dotnet test` will not execute the tests (`--test-filter=FullyQualifiedName~` does not apply).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
