### PR TITLE
fix: Use TCP to connect to the MySQL module

### DIFF
--- a/src/Testcontainers.MariaDb/MariaDbBuilder.cs
+++ b/src/Testcontainers.MariaDb/MariaDbBuilder.cs
@@ -135,7 +135,7 @@ public sealed class MariaDbBuilder : ContainerBuilder<MariaDbBuilder, MariaDbCon
         /// <param name="configuration">The container configuration.</param>
         public WaitUntil(MariaDbConfiguration configuration)
         {
-            _command = new List<string> { "mysql", $"--port={MariaDbPort}", $"--user={configuration.Username}", $"--password={configuration.Password}", configuration.Database, "--wait", "--silent", "--execute=SELECT 1;" };
+            _command = new List<string> { "mysql", "--protocol=TCP", $"--port={MariaDbPort}", $"--user={configuration.Username}", $"--password={configuration.Password}", configuration.Database, "--wait", "--silent", "--execute=SELECT 1;" };
         }
 
         /// <inheritdoc />

--- a/src/Testcontainers.MariaDb/MariaDbContainer.cs
+++ b/src/Testcontainers.MariaDb/MariaDbContainer.cs
@@ -45,7 +45,7 @@ public sealed class MariaDbContainer : DockerContainer
         await CopyFileAsync(scriptFilePath, Encoding.Default.GetBytes(scriptContent), 493, 0, 0, ct)
             .ConfigureAwait(false);
 
-        return await ExecAsync(new[] { "mysql", $"--port={MariaDbBuilder.MariaDbPort}", $"--user={_configuration.Username}", $"--password={_configuration.Password}", _configuration.Database, $"--execute=source {scriptFilePath}" }, ct)
+        return await ExecAsync(new[] { "mysql", "--protocol=TCP", $"--port={MariaDbBuilder.MariaDbPort}", $"--user={_configuration.Username}", $"--password={_configuration.Password}", _configuration.Database, $"--execute=source {scriptFilePath};" }, ct)
             .ConfigureAwait(false);
     }
 }

--- a/src/Testcontainers.MySql/MySqlBuilder.cs
+++ b/src/Testcontainers.MySql/MySqlBuilder.cs
@@ -135,7 +135,7 @@ public sealed class MySqlBuilder : ContainerBuilder<MySqlBuilder, MySqlContainer
         /// <param name="configuration">The container configuration.</param>
         public WaitUntil(MySqlConfiguration configuration)
         {
-            _command = new List<string> { "mysql", $"--port={MySqlPort}", $"--user={configuration.Username}", $"--password={configuration.Password}", configuration.Database, "--wait", "--silent", "--execute=SELECT 1;" };
+            _command = new List<string> { "mysql", "--protocol=TCP", $"--port={MySqlPort}", $"--user={configuration.Username}", $"--password={configuration.Password}", configuration.Database, "--wait", "--silent", "--execute=SELECT 1;" };
         }
 
         /// <inheritdoc />

--- a/src/Testcontainers.MySql/MySqlContainer.cs
+++ b/src/Testcontainers.MySql/MySqlContainer.cs
@@ -45,7 +45,7 @@ public sealed class MySqlContainer : DockerContainer
         await CopyFileAsync(scriptFilePath, Encoding.Default.GetBytes(scriptContent), 493, 0, 0, ct)
             .ConfigureAwait(false);
 
-        return await ExecAsync(new[] { "mysql", $"--port={MySqlBuilder.MySqlPort}", $"--user={_configuration.Username}", $"--password={_configuration.Password}", _configuration.Database, $"--execute=source {scriptFilePath}" }, ct)
+        return await ExecAsync(new[] { "mysql", "--protocol=TCP", $"--port={MySqlBuilder.MySqlPort}", $"--user={_configuration.Username}", $"--password={_configuration.Password}", _configuration.Database, $"--execute=source {scriptFilePath};" }, ct)
             .ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Changes the MySQL connection protocol to TCP. Somehow SOCKET does not work reliably: https://stackoverflow.com/a/23471897/690017. The previous module configuration used TCP too.

## Why is it important?

Fix flaky MySQL test.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
