### PR TITLE
chore: Clean up MinIO module

### DIFF
--- a/src/Testcontainers.MariaDb/MariaDbBuilder.cs
+++ b/src/Testcontainers.MariaDb/MariaDbBuilder.cs
@@ -77,8 +77,8 @@ public sealed class MariaDbBuilder : ContainerBuilder<MariaDbBuilder, MariaDbCon
 
         // By default, the base builder waits until the container is running. However, for MariaDb, a more advanced waiting strategy is necessary that requires access to the configured database, username and password.
         // If the user does not provide a custom waiting strategy, append the default MariaDb waiting strategy.
-        var mySqlBuilder = DockerResourceConfiguration.WaitStrategies.Count() > 1 ? this : WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil(DockerResourceConfiguration)));
-        return new MariaDbContainer(mySqlBuilder.DockerResourceConfiguration, TestcontainersSettings.Logger);
+        var mariaDbBuilder = DockerResourceConfiguration.WaitStrategies.Count() > 1 ? this : WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil(DockerResourceConfiguration)));
+        return new MariaDbContainer(mariaDbBuilder.DockerResourceConfiguration, TestcontainersSettings.Logger);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Minio/MinioConfiguration.cs
+++ b/src/Testcontainers.Minio/MinioConfiguration.cs
@@ -5,23 +5,16 @@ namespace Testcontainers.Minio;
 public sealed class MinioConfiguration : ContainerConfiguration
 {
     /// <summary>
-    /// Minio UserName
-    /// </summary>
-    public string Username { get; }
-    /// <summary>
-    /// Minio Password
-    /// </summary>
-    public string Password { get; }
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="MinioConfiguration" /> class.
     /// </summary>
     /// <param name="username">The Minio database.</param>
     /// <param name="password">The Minio username.</param>
-    public MinioConfiguration([CanBeNull] string username = null, [CanBeNull] string password = null)
+    public MinioConfiguration(
+        string username = null,
+        string password = null)
     {
-        this.Username = username;
-        this.Password = password;
+        Username = username;
+        Password = password;
     }
 
     /// <summary>
@@ -65,4 +58,14 @@ public sealed class MinioConfiguration : ContainerConfiguration
         Username = BuildConfiguration.Combine(oldValue.Username, newValue.Username);
         Password = BuildConfiguration.Combine(oldValue.Password, newValue.Password);
     }
+
+    /// <summary>
+    /// Gets the Mino username.
+    /// </summary>
+    public string Username { get; }
+
+    /// <summary>
+    /// Gets the Mino password.
+    /// </summary>
+    public string Password { get; }
 }

--- a/src/Testcontainers.Minio/MinioConfiguration.cs
+++ b/src/Testcontainers.Minio/MinioConfiguration.cs
@@ -60,12 +60,12 @@ public sealed class MinioConfiguration : ContainerConfiguration
     }
 
     /// <summary>
-    /// Gets the Mino username.
+    /// Gets the Minio username.
     /// </summary>
     public string Username { get; }
 
     /// <summary>
-    /// Gets the Mino password.
+    /// Gets the Minio password.
     /// </summary>
     public string Password { get; }
 }

--- a/src/Testcontainers.Minio/MinioContainer.cs
+++ b/src/Testcontainers.Minio/MinioContainer.cs
@@ -2,45 +2,45 @@ namespace Testcontainers.Minio;
 
 /// <inheritdoc cref="DockerContainer" />
 [PublicAPI]
-public sealed class MinioContainer: DockerContainer
+public sealed class MinioContainer : DockerContainer
 {
     private readonly MinioConfiguration _configuration;
-    
+
     /// <summary>
     /// Initializes a new instance of the <see cref="MinioContainer" /> class.
     /// </summary>
     /// <param name="configuration">The container configuration.</param>
     /// <param name="logger">The logger.</param>
-    public MinioContainer(MinioConfiguration configuration, ILogger logger) : base(configuration, logger)
+    public MinioContainer(MinioConfiguration configuration, ILogger logger)
+        : base(configuration, logger)
     {
         _configuration = configuration;
     }
 
     /// <summary>
-    /// Gets the Minio AccessKeyid for the AmazonS3 purpose.
+    /// Gets the AWS access key id.
     /// </summary>
-    /// <returns>The Minio AccessKeyid.</returns>
-    public string GetAccessId()
+    /// <returns>The AWS access key id.</returns>
+    public string GetAccessKeyId()
     {
         return _configuration.Username;
     }
-    
+
     /// <summary>
-    /// Gets the Minio AccessKeySecret for the AmazonS3 purpose.
+    /// Gets the AWS access secret.
     /// </summary>
-    /// <returns>The Minio AccessKeySecret.</returns>
-    public string GetAccessKey()
+    /// <returns>The AWS access secret.</returns>
+    public string GetAccessSecret()
     {
         return _configuration.Password;
     }
-    
+
     /// <summary>
-    /// Gets the Minio Url.
+    /// Gets the Mino endpoint.
     /// </summary>
-    /// <returns>The Minio Url.</returns>
-    public string GetMinioUrl()
+    /// <returns>The Mino endpoint.</returns>
+    public string GetMinoEndpoint()
     {
-        var port = GetMappedPublicPort(MinioBuilder.MinioPort);
-        return $"http://{Hostname}:{port}";
+        return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(MinioBuilder.MinioPort)).ToString();
     }
 }

--- a/src/Testcontainers.Minio/MinioContainer.cs
+++ b/src/Testcontainers.Minio/MinioContainer.cs
@@ -36,10 +36,10 @@ public sealed class MinioContainer : DockerContainer
     }
 
     /// <summary>
-    /// Gets the Mino endpoint.
+    /// Gets the Minio endpoint.
     /// </summary>
-    /// <returns>The Mino endpoint.</returns>
-    public string GetMinoEndpoint()
+    /// <returns>The Minio endpoint.</returns>
+    public string GetEndpoint()
     {
         return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(MinioBuilder.MinioPort)).ToString();
     }

--- a/src/Testcontainers.Minio/Usings.cs
+++ b/src/Testcontainers.Minio/Usings.cs
@@ -1,10 +1,4 @@
 global using System;
-global using System.Collections.Generic;
-global using System.IO;
-global using System.Linq;
-global using System.Text;
-global using System.Threading;
-global using System.Threading.Tasks;
 global using Docker.DotNet.Models;
 global using DotNet.Testcontainers;
 global using DotNet.Testcontainers.Builders;

--- a/tests/Testcontainers.Minio.Tests/MinioContainerTests.cs
+++ b/tests/Testcontainers.Minio.Tests/MinioContainerTests.cs
@@ -1,92 +1,11 @@
 ﻿namespace Testcontainers.Minio;
 
-public sealed class MinioContainerTests : IAsyncLifetime, IDisposable
+public sealed class MinioContainerTest : IAsyncLifetime
 {
-    private const string TestFileContent = "👋";
-    private readonly string _testFileName;
-    private readonly string _testFileContentFilePath;
-    
     private readonly MinioContainer _minioContainer = new MinioBuilder().Build();
-
-    public MinioContainerTests()
-    {
-        var tmpFile = Path.GetTempFileName();
-        _testFileName = Path.GetFileName(tmpFile);
-        _testFileContentFilePath = Path.Combine(Path.GetTempPath(), tmpFile);
-    }
-
-    [Fact]
-    public async Task TestMinio()
-    {
-        const string bucketName = "somebucket";
-        var config = new AmazonS3Config
-        {
-            AuthenticationRegion = "eu-west-1",
-            ServiceURL = _minioContainer.GetMinioUrl(),
-            UseHttp = true,
-            ForcePathStyle = true,
-        };
-        var s3 = new AmazonS3Client(_minioContainer.GetAccessId(), _minioContainer.GetAccessKey(), config);
-
-        await s3.PutBucketAsync(bucketName);
-
-        var buckets = await s3.ListBucketsAsync();
-
-        Assert.NotNull(buckets);
-        Assert.NotNull(buckets.Buckets);
-        Assert.NotEmpty(buckets.Buckets);
-        Assert.Contains(buckets.Buckets, bucket => bucket.BucketName == bucketName);
-    }
-    
-    [Fact]
-    public async Task TestInsertAndGetDataFromMinio()
-    {
-        const string bucketName = "somebucket2";
-        var config = new AmazonS3Config
-        {
-            AuthenticationRegion = "eu-west-1",
-            ServiceURL = _minioContainer.GetMinioUrl(),
-            UseHttp = true,
-            ForcePathStyle = true,
-        };
-        var s3 = new AmazonS3Client(_minioContainer.GetAccessId(), _minioContainer.GetAccessKey(), config);
-
-        await s3.PutBucketAsync(bucketName);
-        await using var file = File.OpenRead(_testFileContentFilePath);
-
-        await s3.PutObjectAsync(new PutObjectRequest()
-        {
-            Key = _testFileName,
-            BucketName = bucketName,
-            InputStream = file,
-        });
-
-        var subject = await s3.GetObjectAsync(new GetObjectRequest() { Key = _testFileName, BucketName = bucketName });
-
-        Assert.NotNull(subject);
-        Assert.NotEqual(0, subject.ContentLength);
-    }
-    
-    
-    [Fact]
-    public void TestMinioWithEmptyUsername()
-    {
-        var ct = new MinioBuilder().WithUsername(string.Empty);
-
-        Assert.Throws<ArgumentException>(() => ct.Build());
-    }
-    
-    [Fact]
-    public void TestMinioWithEmptyPassword()
-    {
-        var ct = new MinioBuilder().WithPassword(string.Empty);
-
-        Assert.Throws<ArgumentException>(() => ct.Build());
-    }
 
     public Task InitializeAsync()
     {
-        File.WriteAllText(_testFileContentFilePath, TestFileContent); 
         return _minioContainer.StartAsync();
     }
 
@@ -95,11 +14,52 @@ public sealed class MinioContainerTests : IAsyncLifetime, IDisposable
         return _minioContainer.DisposeAsync().AsTask();
     }
 
-    public void Dispose()
+    [Fact]
+    [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+    public async Task ListBucketsReturnsHttpStatusCodeOk()
     {
-        if (File.Exists(_testFileContentFilePath))
-        {
-            File.Delete(_testFileContentFilePath);
-        }
+        // Given
+        var config = new AmazonS3Config();
+        config.ServiceURL = _minioContainer.GetMinoEndpoint();
+
+        var client = new AmazonS3Client(_minioContainer.GetAccessKeyId(), _minioContainer.GetAccessSecret(), config);
+
+        // When
+        var buckets = await client.ListBucketsAsync()
+            .ConfigureAwait(false);
+
+        // Then
+        Assert.Equal(HttpStatusCode.OK, buckets.HttpStatusCode);
+    }
+
+    [Fact]
+    [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+    public async Task GetObjectReturnsPutObject()
+    {
+        // Given
+        using var inputStream = new MemoryStream(new byte[byte.MaxValue]);
+
+        var config = new AmazonS3Config();
+        config.ServiceURL = _minioContainer.GetMinoEndpoint();
+
+        var client = new AmazonS3Client(_minioContainer.GetAccessKeyId(), _minioContainer.GetAccessSecret(), config);
+
+        var objectRequest = new PutObjectRequest();
+        objectRequest.BucketName = Guid.NewGuid().ToString("D");
+        objectRequest.Key = Guid.NewGuid().ToString("D");
+        objectRequest.InputStream = inputStream;
+
+        // When
+        _ = await client.PutBucketAsync(objectRequest.BucketName)
+            .ConfigureAwait(false);
+
+        _ = await client.PutObjectAsync(objectRequest)
+            .ConfigureAwait(false);
+
+        var objectResponse = await client.GetObjectAsync(objectRequest.BucketName, objectRequest.Key)
+            .ConfigureAwait(false);
+
+        // Then
+        Assert.Equal(byte.MaxValue, objectResponse.ContentLength);
     }
 }

--- a/tests/Testcontainers.Minio.Tests/MinioContainerTests.cs
+++ b/tests/Testcontainers.Minio.Tests/MinioContainerTests.cs
@@ -20,7 +20,7 @@ public sealed class MinioContainerTest : IAsyncLifetime
     {
         // Given
         var config = new AmazonS3Config();
-        config.ServiceURL = _minioContainer.GetMinoEndpoint();
+        config.ServiceURL = _minioContainer.GetEndpoint();
 
         var client = new AmazonS3Client(_minioContainer.GetAccessKeyId(), _minioContainer.GetAccessSecret(), config);
 
@@ -40,7 +40,7 @@ public sealed class MinioContainerTest : IAsyncLifetime
         using var inputStream = new MemoryStream(new byte[byte.MaxValue]);
 
         var config = new AmazonS3Config();
-        config.ServiceURL = _minioContainer.GetMinoEndpoint();
+        config.ServiceURL = _minioContainer.GetEndpoint();
 
         var client = new AmazonS3Client(_minioContainer.GetAccessKeyId(), _minioContainer.GetAccessSecret(), config);
 

--- a/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
+++ b/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
@@ -1,19 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFrameworks>net6.0</TargetFrameworks>
-		<IsPackable>false</IsPackable>
-		<IsPublishable>false</IsPublishable>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="AWSSDK.S3" Version="3.7.103.3" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-		<PackageReference Include="coverlet.msbuild" Version="3.2.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj" />
-		<ProjectReference Include="$(SolutionDir)src/Testcontainers.Minio/Testcontainers.Minio.csproj" />
-	</ItemGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net6.0</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
+        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
+        <PackageReference Include="AWSSDK.S3" Version="3.7.103.3"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Minio/Testcontainers.Minio.csproj"/>
+        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+    </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Minio.Tests/Usings.cs
+++ b/tests/Testcontainers.Minio.Tests/Usings.cs
@@ -1,9 +1,8 @@
-global using System.Data;
-global using System.Data.Common;
-global using System.Threading.Tasks;
-global using DotNet.Testcontainers.Commons;
-global using Xunit;
 global using System;
 global using System.IO;
+global using System.Threading.Tasks;
 global using Amazon.S3;
 global using Amazon.S3.Model;
+global using Xunit;
+global using System.Net;
+global using DotNet.Testcontainers.Commons;


### PR DESCRIPTION
## What does this PR do?

Applies (common) Testcontainers conventions (code styles) to the MinIO module implementation. Simplifies the tests. A file is not necessary to test port and get the object. The guard is covered by unit tests.

## Why is it important?

To keep the modules consistent.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #760

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
