### PR TITLE
fix(#783): Dispose container while Resource Reaper is disabled

### DIFF
--- a/src/Testcontainers/Clients/DefaultLabels.cs
+++ b/src/Testcontainers/Clients/DefaultLabels.cs
@@ -1,10 +1,8 @@
 namespace DotNet.Testcontainers.Clients
 {
-  using System;
   using System.Collections.Generic;
   using System.Collections.ObjectModel;
   using System.Reflection;
-  using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
 
   internal sealed class DefaultLabels : ReadOnlyDictionary<string, string>
@@ -13,18 +11,18 @@ namespace DotNet.Testcontainers.Clients
     {
     }
 
-    private DefaultLabels(Guid resourceReaperSessionId)
+    private DefaultLabels()
       : base(new Dictionary<string, string>
       {
         { TestcontainersClient.TestcontainersLabel, bool.TrueString.ToLowerInvariant() },
         { TestcontainersClient.TestcontainersLangLabel, "dotnet" },
         { TestcontainersClient.TestcontainersVersionLabel, typeof(DefaultLabels).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion },
-        { ResourceReaper.ResourceReaperSessionLabel, resourceReaperSessionId.ToString("D") },
+        { ResourceReaper.ResourceReaperSessionLabel, ResourceReaper.DefaultSessionId.ToString("D") },
       })
     {
     }
 
     public static IReadOnlyDictionary<string, string> Instance { get; }
-      = new DefaultLabels(TestcontainersSettings.ResourceReaperEnabled ? ResourceReaper.DefaultSessionId : Guid.Empty);
+      = new DefaultLabels();
   }
 }

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -266,7 +266,7 @@ namespace DotNet.Testcontainers.Clients
           .ConfigureAwait(false);
       }
 
-      if (TestcontainersSettings.ResourceReaperEnabled)
+      if (TestcontainersSettings.ResourceReaperEnabled && ResourceReaper.DefaultSessionId.Equals(configuration.SessionId))
       {
         _ = await ResourceReaper.GetAndStartDefaultAsync(configuration.DockerEndpointAuthConfig, ct)
           .ConfigureAwait(false);

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -266,7 +266,7 @@ namespace DotNet.Testcontainers.Clients
           .ConfigureAwait(false);
       }
 
-      if (ResourceReaper.DefaultSessionId.Equals(configuration.SessionId))
+      if (TestcontainersSettings.ResourceReaperEnabled)
       {
         _ = await ResourceReaper.GetAndStartDefaultAsync(configuration.DockerEndpointAuthConfig, ct)
           .ConfigureAwait(false);

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -258,20 +258,6 @@ namespace DotNet.Testcontainers.Containers
       GC.SuppressFinalize(this);
     }
 
-    /// <summary>
-    /// Deletes the container.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the container has been deleted.</returns>
-    [Obsolete("Use DisposeAsync() instead.")]
-    public Task CleanUpAsync(CancellationToken ct = default)
-    {
-      using (_ = new AcquireLock(this.semaphoreSlim))
-      {
-        return this.UnsafeDeleteAsync(ct);
-      }
-    }
-
     /// <inheritdoc />
     public virtual Task StartAsync(CancellationToken ct = default)
     {


### PR DESCRIPTION
## What does this PR do?

Assigns the Resource Reaper session ID to all resources, but starts the Resource Reaper only if it is enabled.

## Why is it important?

Sometimes it is necessary to disable Ryuk. Some CI enviroments cannot run Ryuk. Disabling Ryuk disabled `DisposeAsync()` too. Calling `DisposeAsync()` did not remove containers on a successful test run. Although, `DisposeAsync()` is not reliable and Ryuk is **preferred** to clean up test environments, we can at least try to clean up resources for environments that do not support Ryuk.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #783

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
