### PR TITLE
feat: Replace output consumer with `IContainer.GetLogsAsync(DateTime, DateTime, bool, CancellationToken)`

### DIFF
--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -118,7 +118,6 @@ Assert.Equal(MagicNumber, magicNumber);
 | `WithNetwork`                           | Assigns a network to the container e.g. `--network "bridge"`.                                                                          |
 | `WithNetworkAliases`                    | Assigns a network-scoped aliases to the container e.g. `--network-alias "alias"`.                                                      |
 | `WithPrivileged`                        | Sets the `--privileged` flag.                                                                                                          |
-| `WithOutputConsumer`                    | Redirects `stdout` and `stderr` to capture the container output.                                                                       |
 | `WithWaitStrategy`                      | Sets the wait strategy to complete the container start and indicates when it is ready.                                                 |
 | `WithStartupCallback`                   | Sets the startup callback to invoke after the container start.                                                                         |
 | `WithCreateParameterModifier`           | Allows low level modifications of the Docker container create parameter.                                                               |

--- a/src/Testcontainers.Elasticsearch/ElasticsearchBuilder.cs
+++ b/src/Testcontainers.Elasticsearch/ElasticsearchBuilder.cs
@@ -121,7 +121,7 @@ public sealed class ElasticsearchBuilder : ContainerBuilder<ElasticsearchBuilder
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var (stdout, _) = await container.GetLogs()
+            var (stdout, _) = await container.GetLogs(timestampsEnabled: false)
                 .ConfigureAwait(false);
 
             return _pattern.IsMatch(stdout);

--- a/src/Testcontainers.Elasticsearch/ElasticsearchBuilder.cs
+++ b/src/Testcontainers.Elasticsearch/ElasticsearchBuilder.cs
@@ -121,7 +121,7 @@ public sealed class ElasticsearchBuilder : ContainerBuilder<ElasticsearchBuilder
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var (stdout, _) = await container.GetLogs(timestampsEnabled: false)
+            var (stdout, _) = await container.GetLogsAsync(timestampsEnabled: false)
                 .ConfigureAwait(false);
 
             return _pattern.IsMatch(stdout);

--- a/src/Testcontainers.EventStoreDb/EventStoreDbBuilder.cs
+++ b/src/Testcontainers.EventStoreDb/EventStoreDbBuilder.cs
@@ -1,5 +1,7 @@
 ﻿namespace Testcontainers.EventStoreDb;
 
+/// <inheritdoc cref="ContainerBuilder{TBuilderEntity, TContainerEntity, TConfigurationEntity}" />
+[PublicAPI]
 public sealed class EventStoreDbBuilder : ContainerBuilder<EventStoreDbBuilder, EventStoreDbContainer, EventStoreDbConfiguration>
 {
     public const string EventStoreDbImage = "eventstore/eventstore:22.10.1-buster-slim";

--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -114,7 +114,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
         /// <param name="configuration">The container configuration.</param>
         public WaitUntil(MongoDbConfiguration configuration)
         {
-            const string js = "db.runCommand({ping:1})";
+            const string js = "db.runCommand({hello:1}).isWritablePrimary";
             _mongoDbShellCommand = new MongoDbShellCommand(js, configuration.Username, configuration.Password);
         }
 
@@ -124,7 +124,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
             var execResult = await container.ExecAsync(_mongoDbShellCommand)
                 .ConfigureAwait(false);
 
-            return 0L.Equals(execResult.ExitCode);
+            return 0L.Equals(execResult.ExitCode) && "true\n".Equals(execResult.Stdout, StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Testcontainers.Oracle/OracleBuilder.cs
+++ b/src/Testcontainers.Oracle/OracleBuilder.cs
@@ -122,7 +122,7 @@ public sealed class OracleBuilder : ContainerBuilder<OracleBuilder, OracleContai
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var (stdout, _) = await container.GetLogs(timestampsEnabled: false)
+            var (stdout, _) = await container.GetLogsAsync(timestampsEnabled: false)
                 .ConfigureAwait(false);
 
             return stdout.Contains("DATABASE IS READY TO USE!");

--- a/src/Testcontainers.Oracle/OracleBuilder.cs
+++ b/src/Testcontainers.Oracle/OracleBuilder.cs
@@ -122,7 +122,7 @@ public sealed class OracleBuilder : ContainerBuilder<OracleBuilder, OracleContai
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var (stdout, _) = await container.GetLogs()
+            var (stdout, _) = await container.GetLogs(timestampsEnabled: false)
                 .ConfigureAwait(false);
 
             return stdout.Contains("DATABASE IS READY TO USE!");

--- a/src/Testcontainers.RabbitMq/RabbitMqBuilder.cs
+++ b/src/Testcontainers.RabbitMq/RabbitMqBuilder.cs
@@ -108,7 +108,7 @@ public sealed class RabbitMqBuilder : ContainerBuilder<RabbitMqBuilder, RabbitMq
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var (stdout, _) = await container.GetLogs()
+            var (stdout, _) = await container.GetLogs(timestampsEnabled: false)
                 .ConfigureAwait(false);
 
             return stdout.Contains("Server startup complete");

--- a/src/Testcontainers.RabbitMq/RabbitMqBuilder.cs
+++ b/src/Testcontainers.RabbitMq/RabbitMqBuilder.cs
@@ -108,7 +108,7 @@ public sealed class RabbitMqBuilder : ContainerBuilder<RabbitMqBuilder, RabbitMq
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var (stdout, _) = await container.GetLogs(timestampsEnabled: false)
+            var (stdout, _) = await container.GetLogsAsync(timestampsEnabled: false)
                 .ConfigureAwait(false);
 
             return stdout.Contains("Server startup complete");

--- a/src/Testcontainers.RavenDb/RavenDbBuilder.cs
+++ b/src/Testcontainers.RavenDb/RavenDbBuilder.cs
@@ -70,7 +70,7 @@ public sealed class RavenDbBuilder : ContainerBuilder<RavenDbBuilder, RavenDbCon
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var (stdout, _) = await container.GetLogs()
+            var (stdout, _) = await container.GetLogs(timestampsEnabled: false)
                 .ConfigureAwait(false);
 
             return stdout.Contains("Server started");

--- a/src/Testcontainers.RavenDb/RavenDbBuilder.cs
+++ b/src/Testcontainers.RavenDb/RavenDbBuilder.cs
@@ -70,7 +70,7 @@ public sealed class RavenDbBuilder : ContainerBuilder<RavenDbBuilder, RavenDbCon
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var (stdout, _) = await container.GetLogs(timestampsEnabled: false)
+            var (stdout, _) = await container.GetLogsAsync(timestampsEnabled: false)
                 .ConfigureAwait(false);
 
             return stdout.Contains("Server started");

--- a/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
+++ b/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
@@ -55,12 +55,12 @@ namespace DotNet.Testcontainers
 
       ushort GetMappedPublicPort(string containerPort);
 
-      [Obsolete("Use GetExitCodeAsync(CancellationToken) instead.")]
+      [Obsolete("Use IContainer.GetExitCodeAsync(CancellationToken) instead.")]
       Task<long> GetExitCode(CancellationToken ct = default);
 
       Task<long> GetExitCodeAsync(CancellationToken ct = default);
 
-      [Obsolete("Use GetLogsAsync(DateTime, DateTime, bool, CancellationToken) instead.")]
+      [Obsolete("Use IContainer.GetLogsAsync(DateTime, DateTime, bool, CancellationToken) instead.")]
       Task<(string Stdout, string Stderr)> GetLogs(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
 
       Task<(string Stdout, string Stderr)> GetLogsAsync(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);

--- a/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
+++ b/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
@@ -55,9 +55,15 @@ namespace DotNet.Testcontainers
 
       ushort GetMappedPublicPort(string containerPort);
 
+      [Obsolete("Use GetExitCodeAsync(CancellationToken) instead.")]
       Task<long> GetExitCode(CancellationToken ct = default);
 
+      Task<long> GetExitCodeAsync(CancellationToken ct = default);
+
+      [Obsolete("Use GetLogsAsync(DateTime, DateTime, bool, CancellationToken) instead.")]
       Task<(string Stdout, string Stderr)> GetLogs(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
+
+      Task<(string Stdout, string Stderr)> GetLogsAsync(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
 
       Task StartAsync(CancellationToken ct = default);
 

--- a/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
+++ b/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
@@ -57,7 +57,7 @@ namespace DotNet.Testcontainers
 
       Task<long> GetExitCode(CancellationToken ct = default);
 
-      Task<(string Stdout, string Stderr)> GetLogs(DateTime since = default, DateTime until = default, CancellationToken ct = default);
+      Task<(string Stdout, string Stderr)> GetLogs(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
 
       Task StartAsync(CancellationToken ct = default);
 

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -336,7 +336,7 @@
     /// <param name="outputConsumer">The output consumer.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
-    [Obsolete("It is no longer necessary to assign an output consumer to read the container's log messages.\nUse IContainer.GetLogs(DateTime, DateTime, bool, CancellationToken) instead.")]
+    [Obsolete("It is no longer necessary to assign an output consumer to read the container's log messages.\nUse IContainer.GetLogsAsync(DateTime, DateTime, bool, CancellationToken) instead.")]
     TBuilderEntity WithOutputConsumer(IOutputConsumer outputConsumer);
 
     /// <summary>

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -356,8 +356,6 @@
     /// <param name="startupCallback">The callback method to invoke.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
-
-    // TODO: Set this methode to obsolete and replace it with TAP.
     TBuilderEntity WithStartupCallback(Func<IContainer, CancellationToken, Task> startupCallback);
 
     /// <summary>

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -336,6 +336,7 @@
     /// <param name="outputConsumer">The output consumer.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
+    [Obsolete("It is no longer necessary to assign an output consumer to read the container's log messages.\nUse IContainer.GetLogs(DateTime, DateTime, bool, CancellationToken) instead.")]
     TBuilderEntity WithOutputConsumer(IOutputConsumer outputConsumer);
 
     /// <summary>

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -63,7 +63,7 @@ namespace DotNet.Testcontainers.Clients
         .ConfigureAwait(false)).StatusCode;
     }
 
-    public async Task<(string Stdout, string Stderr)> GetLogs(string id, TimeSpan since, TimeSpan until, CancellationToken ct = default)
+    public async Task<(string Stdout, string Stderr)> GetLogs(string id, TimeSpan since, TimeSpan until, bool timestampsEnabled = true, CancellationToken ct = default)
     {
       var logsParameters = new ContainerLogsParameters
       {
@@ -71,7 +71,7 @@ namespace DotNet.Testcontainers.Clients
         ShowStderr = true,
         Since = since.TotalSeconds.ToString("0", CultureInfo.InvariantCulture),
         Until = until.TotalSeconds.ToString("0", CultureInfo.InvariantCulture),
-        Timestamps = true,
+        Timestamps = timestampsEnabled,
       };
 
       using (var stdOutAndErrStream = await this.Docker.Containers.GetContainerLogsAsync(id, false, logsParameters, ct)

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -57,13 +57,13 @@ namespace DotNet.Testcontainers.Clients
         .ConfigureAwait(false) != null;
     }
 
-    public async Task<long> GetExitCode(string id, CancellationToken ct = default)
+    public async Task<long> GetExitCodeAsync(string id, CancellationToken ct = default)
     {
       return (await this.Docker.Containers.WaitContainerAsync(id, ct)
         .ConfigureAwait(false)).StatusCode;
     }
 
-    public async Task<(string Stdout, string Stderr)> GetLogs(string id, TimeSpan since, TimeSpan until, bool timestampsEnabled = true, CancellationToken ct = default)
+    public async Task<(string Stdout, string Stderr)> GetLogsAsync(string id, TimeSpan since, TimeSpan until, bool timestampsEnabled = true, CancellationToken ct = default)
     {
       var logsParameters = new ContainerLogsParameters
       {

--- a/src/Testcontainers/Clients/IDockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/IDockerContainerOperations.cs
@@ -13,7 +13,7 @@ namespace DotNet.Testcontainers.Clients
   {
     Task<long> GetExitCode(string id, CancellationToken ct = default);
 
-    Task<(string Stdout, string Stderr)> GetLogs(string id, TimeSpan since, TimeSpan until, CancellationToken ct = default);
+    Task<(string Stdout, string Stderr)> GetLogs(string id, TimeSpan since, TimeSpan until, bool timestampsEnabled = true, CancellationToken ct = default);
 
     Task StartAsync(string id, CancellationToken ct = default);
 

--- a/src/Testcontainers/Clients/IDockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/IDockerContainerOperations.cs
@@ -11,9 +11,9 @@ namespace DotNet.Testcontainers.Clients
 
   internal interface IDockerContainerOperations : IHasListOperations<ContainerListResponse>
   {
-    Task<long> GetExitCode(string id, CancellationToken ct = default);
+    Task<long> GetExitCodeAsync(string id, CancellationToken ct = default);
 
-    Task<(string Stdout, string Stderr)> GetLogs(string id, TimeSpan since, TimeSpan until, bool timestampsEnabled = true, CancellationToken ct = default);
+    Task<(string Stdout, string Stderr)> GetLogsAsync(string id, TimeSpan since, TimeSpan until, bool timestampsEnabled = true, CancellationToken ct = default);
 
     Task StartAsync(string id, CancellationToken ct = default);
 

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -41,9 +41,10 @@ namespace DotNet.Testcontainers.Clients
     /// <param name="id">Docker container id.</param>
     /// <param name="since">Only logs since this time.</param>
     /// <param name="until">Only logs until this time.</param>
+    /// <param name="timestampsEnabled">Determines whether every log line contains a timestamp or not.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that gets the Testcontainers logs.</returns>
-    Task<(string Stdout, string Stderr)> GetContainerLogs(string id, DateTime since = default, DateTime until = default, CancellationToken ct = default);
+    Task<(string Stdout, string Stderr)> GetContainerLogs(string id, DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
 
     /// <summary>
     /// Gets the Testcontainers inspect information.

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -21,19 +21,12 @@ namespace DotNet.Testcontainers.Clients
     bool IsRunningInsideDocker { get; }
 
     /// <summary>
-    /// Returns true if the Docker Windows engine is enabled, otherwise false.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that returns true if the Docker Windows engine is enabled, otherwise false.</returns>
-    Task<bool> GetIsWindowsEngineEnabled(CancellationToken ct = default);
-
-    /// <summary>
     /// Gets the Testcontainers exit code.
     /// </summary>
     /// <param name="id">Docker container id.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that gets the Testcontainers exit code.</returns>
-    Task<long> GetContainerExitCode(string id, CancellationToken ct = default);
+    Task<long> GetContainerExitCodeAsync(string id, CancellationToken ct = default);
 
     /// <summary>
     /// Gets the Testcontainers logs.
@@ -44,7 +37,7 @@ namespace DotNet.Testcontainers.Clients
     /// <param name="timestampsEnabled">Determines whether every log line contains a timestamp or not.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that gets the Testcontainers logs.</returns>
-    Task<(string Stdout, string Stderr)> GetContainerLogs(string id, DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
+    Task<(string Stdout, string Stderr)> GetContainerLogsAsync(string id, DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
 
     /// <summary>
     /// Gets the Testcontainers inspect information.
@@ -56,7 +49,7 @@ namespace DotNet.Testcontainers.Clients
     /// <exception cref="DockerApiException">The daemon experienced an error.</exception>
     /// <exception cref="DockerContainerNotFoundException">No such container was found.</exception>
     /// <exception cref="HttpRequestException">The request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or timeout.</exception>
-    Task<ContainerInspectResponse> InspectContainer(string id, CancellationToken ct = default);
+    Task<ContainerInspectResponse> InspectContainerAsync(string id, CancellationToken ct = default);
 
     /// <summary>
     /// Starts a container.

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -100,7 +100,7 @@ namespace DotNet.Testcontainers.Clients
     }
 
     /// <inheritdoc />
-    public Task<(string Stdout, string Stderr)> GetContainerLogs(string id, DateTime since = default, DateTime until = default, CancellationToken ct = default)
+    public Task<(string Stdout, string Stderr)> GetContainerLogs(string id, DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default)
     {
       var unixEpoch = new DateTime(1970, 1, 1);
 
@@ -114,7 +114,7 @@ namespace DotNet.Testcontainers.Clients
         until = DateTime.MaxValue;
       }
 
-      return this.containers.GetLogs(id, since.ToUniversalTime().Subtract(unixEpoch), until.ToUniversalTime().Subtract(unixEpoch), ct);
+      return this.containers.GetLogs(id, since.ToUniversalTime().Subtract(unixEpoch), until.ToUniversalTime().Subtract(unixEpoch), timestampsEnabled, ct);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -82,25 +82,13 @@ namespace DotNet.Testcontainers.Clients
     }
 
     /// <inheritdoc />
-    public Task<bool> GetIsWindowsEngineEnabled(CancellationToken ct = default)
+    public Task<long> GetContainerExitCodeAsync(string id, CancellationToken ct = default)
     {
-      return this.system.GetIsWindowsEngineEnabled(ct);
+      return this.containers.GetExitCodeAsync(id, ct);
     }
 
     /// <inheritdoc />
-    public Task<ContainerInspectResponse> InspectContainer(string id, CancellationToken ct = default)
-    {
-      return this.containers.InspectAsync(id, ct);
-    }
-
-    /// <inheritdoc />
-    public Task<long> GetContainerExitCode(string id, CancellationToken ct = default)
-    {
-      return this.containers.GetExitCode(id, ct);
-    }
-
-    /// <inheritdoc />
-    public Task<(string Stdout, string Stderr)> GetContainerLogs(string id, DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default)
+    public Task<(string Stdout, string Stderr)> GetContainerLogsAsync(string id, DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default)
     {
       var unixEpoch = new DateTime(1970, 1, 1);
 
@@ -114,7 +102,13 @@ namespace DotNet.Testcontainers.Clients
         until = DateTime.MaxValue;
       }
 
-      return this.containers.GetLogs(id, since.ToUniversalTime().Subtract(unixEpoch), until.ToUniversalTime().Subtract(unixEpoch), timestampsEnabled, ct);
+      return this.containers.GetLogsAsync(id, since.ToUniversalTime().Subtract(unixEpoch), until.ToUniversalTime().Subtract(unixEpoch), timestampsEnabled, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<ContainerInspectResponse> InspectContainerAsync(string id, CancellationToken ct = default)
+    {
+      return this.containers.InspectAsync(id, ct);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
@@ -3,6 +3,7 @@ namespace DotNet.Testcontainers.Configurations
   using System;
   using System.Collections.Generic;
   using System.IO;
+  using System.Text.RegularExpressions;
   using JetBrains.Annotations;
 
   /// <summary>
@@ -58,12 +59,29 @@ namespace DotNet.Testcontainers.Configurations
     IWaitForContainerOS UntilFileExists(string file);
 
     /// <summary>
+    /// Waits until the message is logged.
+    /// </summary>
+    /// <param name="pattern">The regular expression that matches the log message.</param>
+    /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
+    [PublicAPI]
+    IWaitForContainerOS UntilMessageIsLogged(string pattern);
+
+    /// <summary>
+    /// Waits until the message is logged.
+    /// </summary>
+    /// <param name="pattern">The regular expression that matches the log message.</param>
+    /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
+    [PublicAPI]
+    IWaitForContainerOS UntilMessageIsLogged(Regex pattern);
+
+    /// <summary>
     /// Waits until the message is logged in the steam.
     /// </summary>
     /// <param name="stream">The stream to be searched.</param>
     /// <param name="message">The message to be checked.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     [PublicAPI]
+    [Obsolete("It is no longer necessary to assign an output consumer to read the container's log messages.\nUse IWaitForContainerOS.UntilMessageIsLogged(string) or IWaitForContainerOS.UntilMessageIsLogged(Regex) instead.")]
     IWaitForContainerOS UntilMessageIsLogged(Stream stream, string message);
 
     /// <summary>

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
@@ -21,7 +21,7 @@ namespace DotNet.Testcontainers.Configurations
 
     public async Task<bool> UntilAsync(IContainer container)
     {
-      var (stdout, stderr) = await container.GetLogs(timestampsEnabled: false)
+      var (stdout, stderr) = await container.GetLogsAsync(timestampsEnabled: false)
         .ConfigureAwait(false);
 
       return this.pattern.IsMatch(stdout) || this.pattern.IsMatch(stderr);

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
@@ -1,35 +1,30 @@
 namespace DotNet.Testcontainers.Configurations
 {
   using System;
-  using System.IO;
-  using System.Text;
   using System.Text.RegularExpressions;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
 
   internal class UntilMessageIsLogged : IWaitUntil
   {
-    private readonly string message;
+    private readonly Regex pattern;
 
-    private readonly Stream stream;
-
-    public UntilMessageIsLogged(Stream stream, string message)
+    public UntilMessageIsLogged(string pattern)
+      : this(new Regex(pattern, RegexOptions.None, TimeSpan.FromSeconds(5)))
     {
-      this.stream = stream;
-      this.message = message;
+    }
+
+    public UntilMessageIsLogged(Regex pattern)
+    {
+      this.pattern = pattern;
     }
 
     public async Task<bool> UntilAsync(IContainer container)
     {
-      this.stream.Seek(0, SeekOrigin.Begin);
+      var (stdout, stderr) = await container.GetLogs(timestampsEnabled: false)
+        .ConfigureAwait(false);
 
-      using (var streamReader = new StreamReader(this.stream, Encoding.UTF8, false, 4096, true))
-      {
-        var output = await streamReader.ReadToEndAsync()
-          .ConfigureAwait(false);
-
-        return Regex.IsMatch(output, this.message, RegexOptions.None, TimeSpan.FromSeconds(1));
-      }
+      return this.pattern.IsMatch(stdout) || this.pattern.IsMatch(stderr);
     }
   }
 }

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
@@ -3,6 +3,7 @@ namespace DotNet.Testcontainers.Configurations
   using System;
   using System.Collections.Generic;
   using System.IO;
+  using System.Text.RegularExpressions;
 
   /// <inheritdoc cref="IWaitForContainerOS" />
   internal abstract class WaitForContainerOS : IWaitForContainerOS
@@ -40,9 +41,21 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
+    public IWaitForContainerOS UntilMessageIsLogged(string pattern)
+    {
+      return this.AddCustomWaitStrategy(new UntilMessageIsLogged(pattern));
+    }
+
+    /// <inheritdoc />
+    public IWaitForContainerOS UntilMessageIsLogged(Regex pattern)
+    {
+      return this.AddCustomWaitStrategy(new UntilMessageIsLogged(pattern));
+    }
+
+    /// <inheritdoc />
     public virtual IWaitForContainerOS UntilMessageIsLogged(Stream stream, string message)
     {
-      return this.AddCustomWaitStrategy(new UntilMessageIsLogged(stream, message));
+      return this.AddCustomWaitStrategy(new UntilMessageIsLogged(message));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -244,9 +244,9 @@ namespace DotNet.Testcontainers.Containers
     }
 
     /// <inheritdoc />
-    public Task<(string Stdout, string Stderr)> GetLogs(DateTime since = default, DateTime until = default, CancellationToken ct = default)
+    public Task<(string Stdout, string Stderr)> GetLogs(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default)
     {
-      return this.client.GetContainerLogs(this.Id, since, until, ct);
+      return this.client.GetContainerLogs(this.Id, since, until, timestampsEnabled, ct);
     }
 
     /// <inheritdoc />
@@ -383,9 +383,6 @@ namespace DotNet.Testcontainers.Containers
       this.ThrowIfLockNotAcquired();
 
       await this.UnsafeCreateAsync(ct)
-        .ConfigureAwait(false);
-
-      await this.client.AttachAsync(this.container.ID, this.configuration.OutputConsumer, ct)
         .ConfigureAwait(false);
 
       await this.client.StartAsync(this.container.ID, ct)

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -240,13 +240,25 @@ namespace DotNet.Testcontainers.Containers
     /// <inheritdoc />
     public Task<long> GetExitCode(CancellationToken ct = default)
     {
-      return this.client.GetContainerExitCode(this.Id, ct);
+      return this.GetExitCodeAsync(ct);
+    }
+
+    /// <inheritdoc />
+    public Task<long> GetExitCodeAsync(CancellationToken ct = default)
+    {
+      return this.client.GetContainerExitCodeAsync(this.Id, ct);
     }
 
     /// <inheritdoc />
     public Task<(string Stdout, string Stderr)> GetLogs(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default)
     {
-      return this.client.GetContainerLogs(this.Id, since, until, timestampsEnabled, ct);
+      return this.GetLogsAsync(since, until, timestampsEnabled, ct);
+    }
+
+    /// <inheritdoc />
+    public Task<(string Stdout, string Stderr)> GetLogsAsync(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default)
+    {
+      return this.client.GetContainerLogsAsync(this.Id, since, until, timestampsEnabled, ct);
     }
 
     /// <inheritdoc />
@@ -341,7 +353,7 @@ namespace DotNet.Testcontainers.Containers
       var id = await this.client.RunAsync(this.configuration, ct)
         .ConfigureAwait(false);
 
-      this.container = await this.client.InspectContainer(id, ct)
+      this.container = await this.client.InspectContainerAsync(id, ct)
         .ConfigureAwait(false);
 
       this.Created?.Invoke(this, EventArgs.Empty);
@@ -388,7 +400,7 @@ namespace DotNet.Testcontainers.Containers
       await this.client.StartAsync(this.container.ID, ct)
         .ConfigureAwait(false);
 
-      this.container = await this.client.InspectContainer(this.container.ID, ct)
+      this.container = await this.client.InspectContainerAsync(this.container.ID, ct)
         .ConfigureAwait(false);
 
       this.Starting?.Invoke(this, EventArgs.Empty);
@@ -403,7 +415,7 @@ namespace DotNet.Testcontainers.Containers
 
       async Task<bool> CheckReadiness(IWaitUntil wait)
       {
-        this.container = await this.client.InspectContainer(this.container.ID, ct)
+        this.container = await this.client.InspectContainerAsync(this.container.ID, ct)
           .ConfigureAwait(false);
 
         return await wait.UntilAsync(this)
@@ -443,7 +455,7 @@ namespace DotNet.Testcontainers.Containers
 
       try
       {
-        this.container = await this.client.InspectContainer(this.container.ID, ct)
+        this.container = await this.client.InspectContainerAsync(this.container.ID, ct)
           .ConfigureAwait(false);
       }
       catch (DockerContainerNotFoundException)

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -140,9 +140,10 @@
     /// </summary>
     /// <param name="since">Only logs since this time.</param>
     /// <param name="until">Only logs until this time.</param>
+    /// <param name="timestampsEnabled">Determines whether every log line contains a timestamp or not.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Returns the container logs.</returns>
-    new Task<(string Stdout, string Stderr)> GetLogs(DateTime since = default, DateTime until = default, CancellationToken ct = default);
+    new Task<(string Stdout, string Stderr)> GetLogs(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
 
     /// <summary>
     /// Starts the container.

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -128,12 +128,18 @@
     /// <exception cref="InvalidOperationException">Container has not been created.</exception>
     new ushort GetMappedPublicPort(string containerPort);
 
+    /// <inheritdoc cref="GetExitCodeAsync" />
+    new Task<long> GetExitCode(CancellationToken ct = default);
+
     /// <summary>
     /// Gets the container exit code.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Returns the container exit code.</returns>
-    new Task<long> GetExitCode(CancellationToken ct = default);
+    new Task<long> GetExitCodeAsync(CancellationToken ct = default);
+
+    /// <inheritdoc cref="GetLogsAsync" />
+    new Task<(string Stdout, string Stderr)> GetLogs(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
 
     /// <summary>
     /// Gets the container logs.
@@ -143,7 +149,7 @@
     /// <param name="timestampsEnabled">Determines whether every log line contains a timestamp or not.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Returns the container logs.</returns>
-    new Task<(string Stdout, string Stderr)> GetLogs(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
+    new Task<(string Stdout, string Stderr)> GetLogsAsync(DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
 
     /// <summary>
     /// Starts the container.

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -1,7 +1,6 @@
 namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
 {
   using System;
-  using System.Globalization;
   using System.IO;
   using System.Net;
   using System.Net.Http;
@@ -311,44 +310,6 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         await using (var testcontainer = testcontainersBuilder.Build())
         {
           Assert.Equal(expectedHostname, testcontainer.Hostname);
-        }
-      }
-
-      [Fact]
-      public async Task OutputConsumer()
-      {
-        // Given
-        var unixTimeInMilliseconds = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture);
-
-        using (var consumer = Consume.RedirectStdoutAndStderrToStream(new MemoryStream(), new MemoryStream()))
-        {
-          // When
-          var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
-            .WithImage("alpine")
-            .WithEntrypoint("/bin/sh", "-c", $"printf \"{unixTimeInMilliseconds}\" | tee /dev/stderr && tail -f /dev/null")
-            .WithOutputConsumer(consumer)
-            .WithWaitStrategy(Wait.ForUnixContainer()
-              .UntilMessageIsLogged(consumer.Stdout, unixTimeInMilliseconds)
-              .UntilMessageIsLogged(consumer.Stderr, unixTimeInMilliseconds));
-
-          await using (ITestcontainersContainer testcontainer = testcontainersBuilder.Build())
-          {
-            await testcontainer.StartAsync();
-          }
-
-          consumer.Stdout.Seek(0, SeekOrigin.Begin);
-          consumer.Stderr.Seek(0, SeekOrigin.Begin);
-
-          // Then
-          using (var streamReader = new StreamReader(consumer.Stdout, leaveOpen: true))
-          {
-            Assert.Equal(unixTimeInMilliseconds, await streamReader.ReadToEndAsync());
-          }
-
-          using (var streamReader = new StreamReader(consumer.Stderr, leaveOpen: true))
-          {
-            Assert.Equal(unixTimeInMilliseconds, await streamReader.ReadToEndAsync());
-          }
         }
       }
 

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -27,13 +27,6 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
     public sealed class WithConfiguration
     {
       [Fact]
-      public async Task IsLinuxEngineEnabled()
-      {
-        var client = new TestcontainersClient();
-        Assert.False(await client.GetIsWindowsEngineEnabled());
-      }
-
-      [Fact]
       public void ShouldThrowArgumentNullExceptionWhenBuildConfigurationHasNoImage()
       {
         Assert.Throws<ArgumentException>(() => _ = new TestcontainersBuilder<TestcontainersContainer>().Build());

--- a/tests/Testcontainers.Tests/Unit/Containers/Windows/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Windows/TestcontainersContainerTest.cs
@@ -11,13 +11,6 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Windows
     public sealed class WithConfiguration
     {
       [SkipOnLinuxEngine]
-      public async Task IsWindowsEngineEnabled()
-      {
-        var client = new TestcontainersClient();
-        Assert.True(await client.GetIsWindowsEngineEnabled());
-      }
-
-      [SkipOnLinuxEngine]
       public async Task UntilCommandIsCompleted()
       {
         // Given


### PR DESCRIPTION
## What does this PR do?

This pull request sets the `WithOutputConsumer(IOutputConsumer)` member obsolete, as it is no longer necessary to attach a stream to consume the output of a container. Instead, getting `stdout` or `stderr` is much easier now, as developers can simply call `IContainer.GetLogsAsync(DateTime, DateTime, bool, CancellationToken)`.

## Why is it important?

This PR is an important step in continuing the clean up of the API, as it further reduces the amount of configuration necessary to get log messages.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
