### PR TITLE
fix: Coverlet 'Unable to read beyond end of stream' IOException

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -67,7 +67,7 @@ jobs:
           path: test-results
 
   publish:
-    if: ${{ contains(fromJson('["develop", "main", "bugfix/fix-unable-to-read-beyond-the-end-of-the-stream"]'), github.ref_name) }}
+    if: ${{ contains(fromJson('["develop", "main"]'), github.ref_name) }}
 
     needs: build
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -60,20 +60,14 @@ jobs:
       - name: Run Tests
         run: dotnet cake --target=Tests --test-filter=FullyQualifiedName~${{ startsWith(matrix.os, 'ubuntu') && 'Testcontainers' || 'DotNet.Testcontainers.Tests.Unit.Containers.Windows' }}
 
-      - name: Rename Test And Coverage Results
-        run: Get-ChildItem -Path 'test-coverage' -Filter *.xml | Rename-Item -NewName { $_.Name -Replace 'coverage', '${{ matrix.os }}'.ToLower() }
-        shell: pwsh
-
       - name: Upload Test And Coverage Results
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.os }}
-          path: |
-            test-coverage
-            test-results
+          path: test-results
 
   publish:
-    if: ${{ contains(fromJson('["develop", "main"]'), github.ref_name) }}
+    if: ${{ contains(fromJson('["develop", "main", "bugfix/fix-unable-to-read-beyond-the-end-of-the-stream"]'), github.ref_name) }}
 
     needs: build
 
@@ -107,16 +101,16 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ubuntu-22.04
+          path: test-results
 
       - name: Download Test And Coverage Results (windows-2022)
         uses: actions/download-artifact@v3
         with:
           name: windows-2022
+          path: test-results
 
       - name: Fix Absolute Code Coverage Paths
-        run: |
-          Get-ChildItem -Path 'test-coverage' -Filter *.xml | % { (Get-Content $_) -Replace '[A-Za-z0-9:\-\/\\]+src', '${{ github.workspace }}/src' | Set-Content $_ }
-          Get-ChildItem -Path 'test-coverage' -Filter *.xml | % { (Get-Content $_) -Replace '[A-Za-z0-9:\-\/\\]+tests', '${{ github.workspace }}/tests' | Set-Content $_ }
+        run: Get-ChildItem -Path 'test-results' -Filter *.xml -Recurse | Select-Object -ExpandProperty FullName | % { (Get-Content $_) -Replace 'fullPath="[A-Za-z0-9:\-\/\\]+(src|tests)', 'fullPath="${{ github.workspace }}/$1' | Set-Content $_ }
         shell: pwsh
 
       - name: Decode Code Signing Certificate

--- a/Packages.props
+++ b/Packages.props
@@ -14,7 +14,7 @@
     <PackageReference Update="System.Text.Json" Version="6.0.7" />
     <!-- Unit and integration test dependencies: -->
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Update="coverlet.msbuild" Version="3.2.0" />
+    <PackageReference Update="coverlet.collector" Version="3.2.0" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Update="xunit" Version="2.4.2" />
     <!-- 3rd party client dependencies -->

--- a/Testcontainers.sln
+++ b/Testcontainers.sln
@@ -1,4 +1,4 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1

--- a/Testcontainers.sln.DotSettings
+++ b/Testcontainers.sln.DotSettings
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <wpf:ResourceDictionary xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xml:space="preserve">
   <s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
   <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OS/@EntryIndexedValue">OS</s:String>

--- a/build.cake
+++ b/build.cake
@@ -80,15 +80,12 @@ Task("Tests")
     Verbosity = param.Verbosity,
     NoRestore = true,
     NoBuild = true,
+    Collectors = new[] { "XPlat Code Coverage;Format=opencover" },
     Loggers = new[] { "trx" },
     Filter = param.TestFilter,
     ResultsDirectory = param.Paths.Directories.TestResultsDirectoryPath,
     ArgumentCustomization = args => args
       .Append("/m:1") // https://github.com/coverlet-coverage/coverlet/blob/a014bf0cd0fdb5a65a24df393d254ae98f7f45f9/Documentation/Examples/MSBuild/MergeWith/HowTo.md
-      .Append("/p:CollectCoverage=true")
-      .Append("/p:CoverletOutputFormat=\"json%2copencover\"") // https://github.com/coverlet-coverage/coverlet/pull/220#issuecomment-431507570.
-      .Append($"/p:MergeWith=\"{MakeAbsolute(param.Paths.Directories.TestCoverageDirectoryPath)}/coverage.net6.0.json\"")
-      .Append($"/p:CoverletOutput=\"{MakeAbsolute(param.Paths.Directories.TestCoverageDirectoryPath)}/\"")
   });
 });
 
@@ -111,8 +108,8 @@ Task("Sonar-Begin")
     PullRequestKey = param.IsPullRequest && System.Int32.TryParse(param.PullRequestId, out var id) ? id : (int?)null,
     PullRequestBranch = param.SourceBranch,
     PullRequestBase = param.TargetBranch,
-    VsTestReportsPath = $"{MakeAbsolute(param.Paths.Directories.TestResultsDirectoryPath)}/*.trx",
-    OpenCoverReportsPath = $"{MakeAbsolute(param.Paths.Directories.TestCoverageDirectoryPath)}/*.opencover.xml"
+    OpenCoverReportsPath = $"{MakeAbsolute(param.Paths.Directories.TestResultsDirectoryPath)}/**/*.opencover.xml"
+    VsTestReportsPath = $"{MakeAbsolute(param.Paths.Directories.TestResultsDirectoryPath)}/**/*.trx",
   });
 });
 

--- a/build.cake
+++ b/build.cake
@@ -108,8 +108,8 @@ Task("Sonar-Begin")
     PullRequestKey = param.IsPullRequest && System.Int32.TryParse(param.PullRequestId, out var id) ? id : (int?)null,
     PullRequestBranch = param.SourceBranch,
     PullRequestBase = param.TargetBranch,
-    OpenCoverReportsPath = $"{MakeAbsolute(param.Paths.Directories.TestResultsDirectoryPath)}/**/*.opencover.xml"
-    VsTestReportsPath = $"{MakeAbsolute(param.Paths.Directories.TestResultsDirectoryPath)}/**/*.trx",
+    OpenCoverReportsPath = $"{MakeAbsolute(param.Paths.Directories.TestResultsDirectoryPath)}/**/*.opencover.xml",
+    VsTestReportsPath = $"{MakeAbsolute(param.Paths.Directories.TestResultsDirectoryPath)}/**/*.trx"
   });
 });
 

--- a/build.cake
+++ b/build.cake
@@ -85,7 +85,6 @@ Task("Tests")
     Filter = param.TestFilter,
     ResultsDirectory = param.Paths.Directories.TestResultsDirectoryPath,
     ArgumentCustomization = args => args
-      .Append("/m:1") // https://github.com/coverlet-coverage/coverlet/blob/a014bf0cd0fdb5a65a24df393d254ae98f7f45f9/Documentation/Examples/MSBuild/MergeWith/HowTo.md
   });
 });
 

--- a/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecast.InProcess.Tests.csproj
+++ b/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecast.InProcess.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3"/>
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>

--- a/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecast.Tests.csproj
+++ b/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecast.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3"/>
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Builders
+namespace DotNet.Testcontainers.Builders
 {
   using System;
   using System.Collections.Generic;

--- a/src/Testcontainers/Networks/DockerNetwork.cs
+++ b/src/Testcontainers/Networks/DockerNetwork.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Networks
+namespace DotNet.Testcontainers.Networks
 {
   using System.Threading;
   using System.Threading.Tasks;

--- a/tests/Testcontainers.Commons/TestSession.cs
+++ b/tests/Testcontainers.Commons/TestSession.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Commons
+namespace DotNet.Testcontainers.Commons
 {
   using System;
   using System.IO;

--- a/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
+++ b/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="MyCouch" Version="7.6.0"/>

--- a/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
+++ b/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="CouchbaseNetClient" Version="3.4.3"/>

--- a/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
+++ b/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.42"/>

--- a/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
+++ b/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.5"/>

--- a/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
+++ b/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0"/>

--- a/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTests.cs
+++ b/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTests.cs
@@ -1,4 +1,4 @@
-﻿namespace Testcontainers.LocalStack;
+namespace Testcontainers.LocalStack;
 
 public sealed class LocalStackContainerTest : IAsyncLifetime
 {
@@ -32,7 +32,7 @@ public sealed class LocalStackContainerTest : IAsyncLifetime
         config.ServiceURL = _localStackContainer.GetConnectionString();
 
         using var client = new AmazonCloudWatchLogsClient(config);
-        
+
         var logGroupRequest = new CreateLogGroupRequest(Guid.NewGuid().ToString("D"));
 
         // When

--- a/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
+++ b/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.104.14"/>

--- a/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
+++ b/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="MySqlConnector" Version="2.2.5"/>

--- a/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
+++ b/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="AWSSDK.S3" Version="3.7.103.3"/>

--- a/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
+++ b/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="MongoDB.Driver" Version="2.19.0"/>

--- a/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
+++ b/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0"/>

--- a/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
+++ b/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="MySqlConnector" Version="2.2.5"/>

--- a/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
+++ b/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Neo4j.Driver" Version="5.5.0"/>

--- a/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
+++ b/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.90"/>

--- a/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
+++ b/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="coverlet.msbuild" />
+    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />
   </ItemGroup>

--- a/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
+++ b/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="coverlet.msbuild" />
+    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />
   </ItemGroup>

--- a/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
+++ b/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Npgsql" Version="6.0.9"/>

--- a/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
+++ b/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="RabbitMQ.Client" Version="6.4.0"/>

--- a/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
+++ b/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="RavenDB.Client" Version="5.4.100"/>

--- a/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
+++ b/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="StackExchange.Redis" Version="2.6.90"/>

--- a/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
+++ b/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Confluent.Kafka" Version="2.0.2"/>

--- a/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
+++ b/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="coverlet.msbuild" />
+    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />
   </ItemGroup>

--- a/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
+++ b/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="coverlet.msbuild" />
+    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />
     <PackageReference Include="Azure.Data.Tables" />


### PR DESCRIPTION
## What does this PR do?

The PR replaces the MSBuild Coverlet driver with the Collector driver.

## Why is it important?

I noticed our pipeline (tests) sometimes run into this error: [Unable to read beyond end of stream](https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/KnownIssues.md#vstest-stops-process-execution-early). Since they recommend using the Collector driver instead, I replaced it and simplified the configuration.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
