### PR TITLE
chore!: Remove legacy TestcontainersNetworkBuilder, IDockerNetwork

### DIFF
--- a/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
+++ b/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
@@ -121,32 +121,6 @@ namespace DotNet.Testcontainers
     }
   }
 
-  namespace Networks
-  {
-    [PublicAPI]
-    [Obsolete("Use the INetwork interface instead.")]
-    public interface IDockerNetwork
-    {
-      [NotNull]
-      string Name { get; }
-
-      Task CreateAsync(CancellationToken ct = default);
-
-      Task DeleteAsync(CancellationToken ct = default);
-    }
-
-    /// <summary>
-    /// Maps the old to the new interface to provide backwards compatibility.
-    /// </summary>
-    internal sealed partial class DockerNetwork
-    {
-      public DockerNetwork(IDockerNetwork network)
-      {
-        this.network.Name = network.Name;
-      }
-    }
-  }
-
   namespace Volumes
   {
     [PublicAPI]
@@ -179,12 +153,6 @@ namespace DotNet.Testcontainers
     [Obsolete("Use the ContainerBuilder class instead.")]
     public sealed class TestcontainersBuilder<TContainerEntity> : ContainerBuilder<TContainerEntity>
       where TContainerEntity : DockerContainer
-    {
-    }
-
-    [PublicAPI]
-    [Obsolete("Use the NetworkBuilder class instead.")]
-    public sealed class TestcontainersNetworkBuilder : NetworkBuilder
     {
     }
 

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -311,11 +311,6 @@ namespace DotNet.Testcontainers.Builders
       return this.WithImage(new DockerImage(image));
     }
 
-    public TBuilderEntity WithNetwork(IDockerNetwork network)
-    {
-      return this.WithNetwork(new DockerNetwork(network));
-    }
-
     public TBuilderEntity WithVolumeMount(IDockerVolume volume, string destination)
     {
       return this.WithVolumeMount(new DockerVolume(volume), destination);

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -372,9 +372,6 @@
     [Obsolete("Use WithImage(IImage) instead.")]
     TBuilderEntity WithImage(IDockerImage image);
 
-    [Obsolete("Use WithNetwork(INetwork) instead.")]
-    TBuilderEntity WithNetwork(IDockerNetwork network);
-
     [Obsolete("Use WithVolumeMount(IVolume, string) instead.")]
     TBuilderEntity WithVolumeMount(IDockerVolume volume, string destination);
 

--- a/src/Testcontainers/Networks/DockerNetwork.cs
+++ b/src/Testcontainers/Networks/DockerNetwork.cs
@@ -10,7 +10,7 @@ namespace DotNet.Testcontainers.Networks
 
   /// <inheritdoc cref="INetwork" />
   [PublicAPI]
-  internal sealed partial class DockerNetwork : Resource, INetwork
+  internal sealed class DockerNetwork : Resource, INetwork
   {
     private readonly IDockerNetworkOperations dockerNetworkOperations;
 

--- a/src/Testcontainers/Networks/INetwork.cs
+++ b/src/Testcontainers/Networks/INetwork.cs
@@ -1,35 +1,19 @@
 ﻿namespace DotNet.Testcontainers.Networks
 {
   using System;
-  using System.Threading;
-  using System.Threading.Tasks;
   using JetBrains.Annotations;
 
   /// <summary>
   /// A network instance.
   /// </summary>
   [PublicAPI]
-  public interface INetwork : IDockerNetwork, IFutureResource
+  public interface INetwork : IFutureResource
   {
     /// <summary>
     /// Gets the name.
     /// </summary>
     /// <exception cref="InvalidOperationException">Network has not been created.</exception>
     [NotNull]
-    new string Name { get; }
-
-    /// <summary>
-    /// Creates the network.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the network has been created.</returns>
-    new Task CreateAsync(CancellationToken ct = default);
-
-    /// <summary>
-    /// Deletes the network.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the network has been deleted.</returns>
-    new Task DeleteAsync(CancellationToken ct = default);
+    string Name { get; }
   }
 }

--- a/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
+++ b/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0"/>
+        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
         <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Confluent.Kafka" Version="2.0.2"/>

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/NetworkFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/NetworkFixture.cs
@@ -11,8 +11,8 @@
   [UsedImplicitly]
   public sealed class NetworkFixture : IAsyncLifetime
   {
-    public IDockerNetwork Network { get; }
-      = new TestcontainersNetworkBuilder()
+    public INetwork Network { get; }
+      = new NetworkBuilder()
         .WithDriver(NetworkDriver.Bridge)
         .WithName(Guid.NewGuid().ToString("D"))
         .Build();

--- a/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersAccessInformationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersAccessInformationTest.cs
@@ -114,7 +114,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       public void QueryNetworkInformationOfNotCreatedNetwork()
       {
         // Given
-        var networkBuilder = new TestcontainersNetworkBuilder()
+        var networkBuilder = new NetworkBuilder()
           .WithName(Guid.NewGuid().ToString("D"));
 
         // When

--- a/tests/Testcontainers.Tests/Unit/Networks/TestcontainerNetworkBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Networks/TestcontainerNetworkBuilderTest.cs
@@ -23,7 +23,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     private static readonly KeyValuePair<string, string> ParameterModifier = new KeyValuePair<string, string>(TestcontainersClient.TestcontainersLabel + ".parameter.modifier", Guid.NewGuid().ToString("D"));
 
-    private readonly IDockerNetwork network;
+    private readonly INetwork network;
 
     public TestcontainerNetworkBuilderTest(DockerNetwork network)
     {
@@ -33,7 +33,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public void GetNameThrowsInvalidOperationException()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => new TestcontainersNetworkBuilder()
+      _ = Assert.Throws<InvalidOperationException>(() => new NetworkBuilder()
         .WithName(NetworkName)
         .Build()
         .Name);
@@ -74,9 +74,9 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [UsedImplicitly]
-    public sealed class DockerNetwork : IDockerNetwork, IAsyncLifetime
+    public sealed class DockerNetwork : INetwork, IAsyncLifetime
     {
-      private readonly IDockerNetwork network = new TestcontainersNetworkBuilder()
+      private readonly INetwork network = new NetworkBuilder()
         .WithName(NetworkName)
         .WithOption(Option.Key, Option.Value)
         .WithLabel(Label.Key, Label.Value)


### PR DESCRIPTION
## What does this PR do?

This pull request replaces the legacy class `TestcontainersNetworkBuilder`, including its corresponding interface `IDockerNetwork`, with `NetworkBuilder` and `INetwork`.

## Why is it important?

It removes obsolete code and prepares the next Testcontainers for .NET release.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
