### PR TITLE
chore!: Remove legacy TestcontainersVolumeBuilder, IDockerVolume

### DIFF
--- a/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
+++ b/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
@@ -121,44 +121,12 @@ namespace DotNet.Testcontainers
     }
   }
 
-  namespace Volumes
-  {
-    [PublicAPI]
-    [Obsolete("Use the IVolume interface instead.")]
-    public interface IDockerVolume
-    {
-      [NotNull]
-      string Name { get; }
-
-      Task CreateAsync(CancellationToken ct = default);
-
-      Task DeleteAsync(CancellationToken ct = default);
-    }
-
-    /// <summary>
-    /// Maps the old to the new interface to provide backwards compatibility.
-    /// </summary>
-    internal sealed partial class DockerVolume
-    {
-      public DockerVolume(IDockerVolume volume)
-      {
-        this.volume.Name = volume.Name;
-      }
-    }
-  }
-
   namespace Builders
   {
     [PublicAPI]
     [Obsolete("Use the ContainerBuilder class instead.")]
     public sealed class TestcontainersBuilder<TContainerEntity> : ContainerBuilder<TContainerEntity>
       where TContainerEntity : DockerContainer
-    {
-    }
-
-    [PublicAPI]
-    [Obsolete("Use the VolumeBuilder class instead.")]
-    public sealed class TestcontainersVolumeBuilder : VolumeBuilder
     {
     }
   }

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -149,16 +149,14 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc cref="IContainerBuilder{TBuilderEntity, TContainerEntity}" />
     public TBuilderEntity WithPortBinding(string port, bool assignRandomHostPort = false)
     {
-      var hostPort = assignRandomHostPort ? "0" : port;
+      // Use an empty string instead of "0": https://github.com/docker/for-mac/issues/5588#issuecomment-934600089.
+      var hostPort = assignRandomHostPort ? string.Empty : port;
       return this.WithPortBinding(hostPort, port);
     }
 
     /// <inheritdoc cref="IContainerBuilder{TBuilderEntity, TContainerEntity}" />
     public TBuilderEntity WithPortBinding(string hostPort, string containerPort)
     {
-      // Prepare Java alignment. Use an empty string instead of 0: https://github.com/docker/for-mac/issues/5588#issuecomment-934600089.
-      hostPort = "0".Equals(hostPort, StringComparison.OrdinalIgnoreCase) ? string.Empty : hostPort;
-
       var portBindings = new Dictionary<string, string> { { containerPort, hostPort } };
       return this.Clone(new ContainerConfiguration(portBindings: portBindings)).WithExposedPort(containerPort);
     }
@@ -309,16 +307,6 @@ namespace DotNet.Testcontainers.Builders
     public TBuilderEntity WithImage(IDockerImage image)
     {
       return this.WithImage(new DockerImage(image));
-    }
-
-    public TBuilderEntity WithVolumeMount(IDockerVolume volume, string destination)
-    {
-      return this.WithVolumeMount(new DockerVolume(volume), destination);
-    }
-
-    public TBuilderEntity WithVolumeMount(IDockerVolume volume, string destination, AccessMode accessMode)
-    {
-      return this.WithVolumeMount(new DockerVolume(volume), destination, accessMode);
     }
 
     /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TResourceEntity, TCreateResourceEntity}" />

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -371,11 +371,5 @@
 
     [Obsolete("Use WithImage(IImage) instead.")]
     TBuilderEntity WithImage(IDockerImage image);
-
-    [Obsolete("Use WithVolumeMount(IVolume, string) instead.")]
-    TBuilderEntity WithVolumeMount(IDockerVolume volume, string destination);
-
-    [Obsolete("Use WithVolumeMount(IVolume, string, AccessMode) instead.")]
-    TBuilderEntity WithVolumeMount(IDockerVolume volume, string destination, AccessMode accessMode);
   }
 }

--- a/src/Testcontainers/Volumes/DockerVolume.cs
+++ b/src/Testcontainers/Volumes/DockerVolume.cs
@@ -10,7 +10,7 @@ namespace DotNet.Testcontainers.Volumes
 
   /// <inheritdoc cref="IVolume" />
   [PublicAPI]
-  internal sealed partial class DockerVolume : Resource, IVolume
+  internal sealed class DockerVolume : Resource, IVolume
   {
     private readonly IDockerVolumeOperations dockerVolumeOperations;
 

--- a/src/Testcontainers/Volumes/IVolume.cs
+++ b/src/Testcontainers/Volumes/IVolume.cs
@@ -1,35 +1,19 @@
 ﻿namespace DotNet.Testcontainers.Volumes
 {
   using System;
-  using System.Threading;
-  using System.Threading.Tasks;
   using JetBrains.Annotations;
 
   /// <summary>
   /// A volume instance.
   /// </summary>
   [PublicAPI]
-  public interface IVolume : IDockerVolume, IFutureResource
+  public interface IVolume : IFutureResource
   {
     /// <summary>
     /// Gets the name.
     /// </summary>
     /// <exception cref="InvalidOperationException">Volume has not been created.</exception>
     [NotNull]
-    new string Name { get; }
-
-    /// <summary>
-    /// Creates the volume.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the volume has been created.</returns>
-    new Task CreateAsync(CancellationToken ct = default);
-
-    /// <summary>
-    /// Deletes the volume.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the volume has been deleted.</returns>
-    new Task DeleteAsync(CancellationToken ct = default);
+    string Name { get; }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/VolumeFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/VolumeFixture.cs
@@ -10,21 +10,19 @@ namespace DotNet.Testcontainers.Tests.Fixtures
   [UsedImplicitly]
   public sealed class VolumeFixture : IAsyncLifetime
   {
-    private readonly IDockerVolume volume = new TestcontainersVolumeBuilder()
-      .WithName(Guid.NewGuid().ToString("D"))
-      .Build();
-
-    public string Name
-      => this.volume.Name;
+    public IVolume Volume { get; }
+      = new VolumeBuilder()
+        .WithName(Guid.NewGuid().ToString("D"))
+        .Build();
 
     public Task InitializeAsync()
     {
-      return this.volume.CreateAsync();
+      return this.Volume.CreateAsync();
     }
 
     public Task DisposeAsync()
     {
-      return this.volume.DeleteAsync();
+      return this.Volume.DeleteAsync();
     }
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersAccessInformationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersAccessInformationTest.cs
@@ -128,7 +128,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       public void QueryVolumeInformationOfNotCreatedVolume()
       {
         // Given
-        var volumeBuilder = new TestcontainersVolumeBuilder()
+        var volumeBuilder = new VolumeBuilder()
           .WithName(Guid.NewGuid().ToString("D"));
 
         // When

--- a/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeBuilderTest.cs
@@ -21,7 +21,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     private static readonly KeyValuePair<string, string> ParameterModifier = new KeyValuePair<string, string>(TestcontainersClient.TestcontainersLabel + ".parameter.modifier", Guid.NewGuid().ToString("D"));
 
-    private readonly IDockerVolume volume;
+    private readonly IVolume volume;
 
     public TestcontainersVolumeBuilderTest(DockerVolume volume)
     {
@@ -31,7 +31,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public void GetNameThrowsInvalidOperationException()
     {
-      _ = Assert.Throws<InvalidOperationException>(() => new TestcontainersVolumeBuilder()
+      _ = Assert.Throws<InvalidOperationException>(() => new VolumeBuilder()
         .WithName(VolumeName)
         .Build()
         .Name);
@@ -59,9 +59,9 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [UsedImplicitly]
-    public sealed class DockerVolume : IDockerVolume, IAsyncLifetime
+    public sealed class DockerVolume : IVolume, IAsyncLifetime
     {
-      private readonly IDockerVolume volume = new TestcontainersVolumeBuilder()
+      private readonly IVolume volume = new VolumeBuilder()
         .WithName(VolumeName)
         .WithLabel(Label.Key, Label.Value)
         .WithCreateParameterModifier(parameterModifier => parameterModifier.Labels.Add(ParameterModifier.Key, ParameterModifier.Value))

--- a/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeTest.cs
@@ -24,7 +24,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         .WithImage(CommonImages.Alpine)
         .WithEntrypoint("/bin/sh", "-c")
         .WithCommand("touch /tmp/$(uname -n) && tail -f /dev/null")
-        .WithVolumeMount(volumeFixture.Name, Destination)
+        .WithVolumeMount(volumeFixture.Volume.Name, Destination)
         .WithTmpfsMount(TmpfsDestination);
 
       this.testcontainer1 = testcontainersBuilder


### PR DESCRIPTION
## What does this PR do?

This pull request replaces the legacy class `TestcontainersVolumeBuilder`, including its corresponding interface `IDockerVolume`, with `VolumeBuilder` and `IVolume`.

## Why is it important?

It removes obsolete code and prepares the next Testcontainers for .NET release.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
