### PR TITLE
chore!: Remove legacy IDockerImage

### DIFF
--- a/src/Testcontainers.Couchbase/CouchbaseBuilder.cs
+++ b/src/Testcontainers.Couchbase/CouchbaseBuilder.cs
@@ -7,7 +7,7 @@ namespace Testcontainers.Couchbase;
 [PublicAPI]
 public sealed class CouchbaseBuilder : ContainerBuilder<CouchbaseBuilder, CouchbaseContainer, CouchbaseConfiguration>
 {
-    public const string CouchbaseImage = "couchbase:community-7.1.1";
+    public const string CouchbaseImage = "couchbase:community-7.0.2";
 
     public const ushort MgmtPort = 8091;
 

--- a/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
+++ b/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
@@ -87,40 +87,6 @@ namespace DotNet.Testcontainers
     }
   }
 
-  namespace Images
-  {
-    [PublicAPI]
-    [Obsolete("Use the IImage interface instead.")]
-    public interface IDockerImage
-    {
-      [NotNull]
-      string Repository { get; }
-
-      [NotNull]
-      string Name { get; }
-
-      [NotNull]
-      string Tag { get; }
-
-      [NotNull]
-      string FullName { get; }
-
-      [CanBeNull]
-      string GetHostname();
-    }
-
-    /// <summary>
-    /// Maps the old to the new interface to provide backwards compatibility.
-    /// </summary>
-    public sealed partial class DockerImage
-    {
-      public DockerImage(IDockerImage image)
-        : this(image.Repository, image.Name, image.Tag)
-      {
-      }
-    }
-  }
-
   namespace Builders
   {
     [PublicAPI]

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -304,11 +304,6 @@ namespace DotNet.Testcontainers.Builders
       return this.WithCreateParameterModifier(parameterModifier);
     }
 
-    public TBuilderEntity WithImage(IDockerImage image)
-    {
-      return this.WithImage(new DockerImage(image));
-    }
-
     /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TResourceEntity, TCreateResourceEntity}" />
     protected override TBuilderEntity Init()
     {

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -368,8 +368,5 @@
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [Obsolete("Use WithCreateParameterModifier(Action<CreateContainerParameters>) instead.")]
     TBuilderEntity WithCreateContainerParametersModifier(Action<CreateContainerParameters> parameterModifier);
-
-    [Obsolete("Use WithImage(IImage) instead.")]
-    TBuilderEntity WithImage(IDockerImage image);
   }
 }

--- a/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
+++ b/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
@@ -68,8 +68,5 @@
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithBuildArgument(string name, string value);
-
-    [Obsolete("Use WithName(IImage) instead.")]
-    TBuilderEntity WithName(IDockerImage image);
   }
 }

--- a/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
@@ -93,11 +93,6 @@
       return this.Merge(this.DockerResourceConfiguration, new ImageFromDockerfileConfiguration(buildArguments: buildArguments));
     }
 
-    public ImageFromDockerfileBuilder WithName(IDockerImage image)
-    {
-      return this.WithName(new DockerImage(image));
-    }
-
     /// <inheritdoc />
     public override IFutureDockerImage Build()
     {

--- a/src/Testcontainers/Images/IImage.cs
+++ b/src/Testcontainers/Images/IImage.cs
@@ -6,25 +6,25 @@ namespace DotNet.Testcontainers.Images
   /// An image instance.
   /// </summary>
   [PublicAPI]
-  public interface IImage : IDockerImage
+  public interface IImage
   {
     /// <summary>
     /// Gets the repository.
     /// </summary>
     [NotNull]
-    new string Repository { get; }
+    string Repository { get; }
 
     /// <summary>
     /// Gets the name.
     /// </summary>
     [NotNull]
-    new string Name { get; }
+    string Name { get; }
 
     /// <summary>
     /// Gets the tag.
     /// </summary>
     [NotNull]
-    new string Tag { get; }
+    string Tag { get; }
 
     /// <summary>
     /// Gets the full image name.
@@ -33,13 +33,13 @@ namespace DotNet.Testcontainers.Images
     /// The full image name, like "foo/bar:1.0.0" or "bar:latest" based on the components values.
     /// </remarks>
     [NotNull]
-    new string FullName { get; }
+    string FullName { get; }
 
     /// <summary>
     /// Gets the registry hostname.
     /// </summary>
     /// <returns>The registry hostname.</returns>
     [CanBeNull]
-    new string GetHostname();
+    string GetHostname();
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
@@ -22,7 +22,7 @@
 
     private readonly string containerCertsDirectoryPath = Path.Combine("/", CertsDirectoryName);
 
-    private readonly IDockerImage image = new DockerImage(string.Empty, "docker", DockerVersion + "-dind");
+    private readonly IImage image = new DockerImage(string.Empty, "docker", DockerVersion + "-dind");
 
     private readonly ITestcontainersContainer container;
 

--- a/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixtureSerializable.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixtureSerializable.cs
@@ -9,12 +9,12 @@ namespace DotNet.Testcontainers.Tests.Fixtures
     {
     }
 
-    public DockerImageFixtureSerializable(IDockerImage image)
+    public DockerImageFixtureSerializable(IImage image)
     {
       this.Image = image;
     }
 
-    public IDockerImage Image { get; private set; }
+    public IImage Image { get; private set; }
 
     public void Deserialize(IXunitSerializationInfo info)
     {

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerImageNameSubstitutionTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerImageNameSubstitutionTest.cs
@@ -53,7 +53,7 @@
         // Given
         TestcontainersSettings.HubImageNamePrefix = hubImageNamePrefix;
 
-        IDockerImage image = new DockerImage(imageName);
+        IImage image = new DockerImage(imageName);
 
         // When
         IDockerContainer container = new TestcontainersBuilder<TestcontainersContainer>()
@@ -99,7 +99,7 @@
         // Given
         const string imageName = "bar:latest";
 
-        IDockerImage image = new DockerImage(imageName);
+        IImage image = new DockerImage(imageName);
 
         // When
         IDockerContainer container = new TestcontainersBuilder<TestcontainersContainer>()

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
@@ -38,7 +38,7 @@
     [InlineData("myregistry.azurecr.io/baz:foo/bar:1.0.0", "myregistry.azurecr.io")]
     public void GetHostnameFromDockerImage(string dockerImageName, string hostname)
     {
-      IDockerImage image = new DockerImage(dockerImageName);
+      IImage image = new DockerImage(dockerImageName);
       Assert.Equal(hostname, image.GetHostname());
     }
 
@@ -49,7 +49,7 @@
     public void GetHostnameFromHubImageNamePrefix(string repository, string name, string tag)
     {
       const string hubImageNamePrefix = "myregistry.azurecr.io";
-      IDockerImage image = new DockerImage(repository, name, tag, hubImageNamePrefix);
+      IImage image = new DockerImage(repository, name, tag, hubImageNamePrefix);
       Assert.Equal(hubImageNamePrefix, image.GetHostname());
     }
 

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilContainerIsHealthyTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilContainerIsHealthyTest.cs
@@ -9,7 +9,7 @@ namespace DotNet.Testcontainers.Tests.Unit.Configurations
 
   public sealed class WaitUntilContainerIsHealthyTest : IClassFixture<HealthCheckFixture>
   {
-    private readonly IDockerImage image;
+    private readonly IImage image;
 
     public WaitUntilContainerIsHealthyTest(HealthCheckFixture image)
     {

--- a/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
@@ -51,7 +51,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var expected = serializable.Image;
 
       // When
-      IDockerImage dockerImage = new DockerImage(fullName);
+      IImage dockerImage = new DockerImage(fullName);
 
       // Then
       Assert.Equal(expected.Repository, dockerImage.Repository);


### PR DESCRIPTION
## What does this PR do?

This pull request replaces the legacy interface `IDockerImage` with `IImage`.

## Why is it important?

It removes obsolete code and prepares the next Testcontainers for .NET release.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
