### PR TITLE
chore!: Remove legacy WithCreateContainerParametersModifier(Action<CreateContainerParameters>)

### DIFF
--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -298,12 +298,6 @@ namespace DotNet.Testcontainers.Builders
       return this.Clone(new ContainerConfiguration(startupCallback: startupCallback));
     }
 
-    /// <inheritdoc cref="IContainerBuilder{TBuilderEntity, TContainerEntity}" />
-    public TBuilderEntity WithCreateContainerParametersModifier(Action<CreateContainerParameters> parameterModifier)
-    {
-      return this.WithCreateParameterModifier(parameterModifier);
-    }
-
     /// <inheritdoc cref="IAbstractBuilder{TBuilderEntity, TResourceEntity, TCreateResourceEntity}" />
     protected override TBuilderEntity Init()
     {

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -357,16 +357,5 @@
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithStartupCallback(Func<IContainer, CancellationToken, Task> startupCallback);
-
-    /// <summary>
-    /// Allows low level modifications of <see cref="CreateContainerParameters" /> after the builder configuration has been applied. Multiple low level modifications will be executed in order of insertion.
-    /// </summary>
-    /// <remarks>
-    /// This exposes the underlying Docker.DotNet API. Changes are outside of this project.
-    /// </remarks>
-    /// <param name="parameterModifier">The action that invokes modifying the <see cref="CreateContainerParameters" /> instance.</param>
-    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
-    [Obsolete("Use WithCreateParameterModifier(Action<CreateContainerParameters>) instead.")]
-    TBuilderEntity WithCreateContainerParametersModifier(Action<CreateContainerParameters> parameterModifier);
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -461,8 +461,8 @@ namespace DotNet.Testcontainers.Tests.Unit.Containers.Unix
         var testcontainersBuilder = new TestcontainersBuilder<TestcontainersContainer>()
           .WithImage("alpine")
           .WithEntrypoint(CommonCommands.SleepInfinity)
-          .WithCreateContainerParametersModifier(parameters => parameters.Name = "placeholder")
-          .WithCreateContainerParametersModifier(parameters => parameters.Name = name);
+          .WithCreateParameterModifier(parameters => parameters.Name = "placeholder")
+          .WithCreateParameterModifier(parameters => parameters.Name = name);
 
         // Then
         await using (ITestcontainersContainer testcontainer = testcontainersBuilder.Build())


### PR DESCRIPTION
## What does this PR do?

This pull request replaces the legacy member `WithCreateContainerParametersModifier(Action<CreateContainerParameters>)` with `WithCreateParameterModifier(Action<TCreateResourceParameters>)`.

## Why is it important?

It removes obsolete code and prepares the next Testcontainers for .NET release.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
