### PR TITLE
fix: InvalidOperationException when adding future volume

### DIFF
--- a/src/Testcontainers/Configurations/Volumes/VolumeMount.cs
+++ b/src/Testcontainers/Configurations/Volumes/VolumeMount.cs
@@ -5,6 +5,10 @@ namespace DotNet.Testcontainers.Configurations
   /// <inheritdoc cref="IMount" />
   internal readonly struct VolumeMount : IMount
   {
+    // Do not set the volume name immediately in the constructor. This may raise an InvalidOperationException too early.
+    // Depending on when the developer passes the instance to VolumeMount it may not exist yet.
+    private readonly IVolume volume;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="VolumeMount" /> struct.
     /// </summary>
@@ -13,8 +17,8 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="accessMode">The Docker volume access mode.</param>
     public VolumeMount(IVolume volume, string containerPath, AccessMode accessMode)
     {
+      this.volume = volume;
       this.Type = MountType.Volume;
-      this.Source = volume.Name;
       this.Target = containerPath;
       this.AccessMode = accessMode;
     }
@@ -26,7 +30,7 @@ namespace DotNet.Testcontainers.Configurations
     public AccessMode AccessMode { get; }
 
     /// <inheritdoc />
-    public string Source { get; }
+    public string Source => this.volume.Name;
 
     /// <inheritdoc />
     public string Target { get; }


### PR DESCRIPTION
## What does this PR do?

Defers the resolution of the future volume name to a later point.

## Why is it important?

Accessing the property (name) immediately will raise `InvalidOperationException`. Depending on when the developer passes the instance to VolumeMount (the builder) it may not, nor is it necessary to exist yet.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #810

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
