### PR TITLE
fix: Set NuGet auth token permission to accept packages other than Testcontainers

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -161,15 +161,11 @@ Task("Publish-NuGet-Packages")
 {
   foreach(var package in GetFiles($"{param.Paths.Directories.NuGetDirectoryPath}/*.(nupkg|snupkgs)"))
   {
-    if (package.FullPath.Contains("Testcontainers.3.0.0"))
-    {
-      continue;
-    }
-
     DotNetNuGetPush(package.FullPath, new DotNetNuGetPushSettings
     {
       Source = param.NuGetCredentials.Source,
-      ApiKey = param.NuGetCredentials.ApiKey
+      ApiKey = param.NuGetCredentials.ApiKey,
+      SkipDuplicate = true
     });
   }
 });

--- a/build.cake
+++ b/build.cake
@@ -161,6 +161,11 @@ Task("Publish-NuGet-Packages")
 {
   foreach(var package in GetFiles($"{param.Paths.Directories.NuGetDirectoryPath}/*.(nupkg|snupkgs)"))
   {
+    if (package.FullPath.Contains("Testcontainers.3.0.0"))
+    {
+      continue;
+    }
+
     DotNetNuGetPush(package.FullPath, new DotNetNuGetPushSettings
     {
       Source = param.NuGetCredentials.Source,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Continue with the next module, if a version already exists.

## Why is it important?

Due to NuGet auth token permissions, the token was not allowed to publish other packages than Testcontainers.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
