### PR TITLE
docs: Update ASP.NET Core Blazor out-off-process example

### DIFF
--- a/docs/examples/compose.md
+++ b/docs/examples/compose.md
@@ -7,7 +7,7 @@ it is necessary to override Testcontainers' Docker host resolution and set the e
 Otherwise, Testcontainers cannot access sibling containers like the Resource Reaper Ryuk or other services running on the Docker host.
 A minimal `docker-compose.yml` file that builds a new container image and runs the test inside the container look something like:
 
-```Yaml
+```yaml
 version: "3"
 services:
   docker_compose_test:

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -10,7 +10,7 @@ dotnet add package Testcontainers.ModuleName
 
 All modules follow the same design and come pre-configured with best practices. Usually, you do not need to worry about configuring them yourself. To create and start a container, all you need is:
 
-```chsarp
+```csharp
 var moduleNameContainer = new ModuleNameBuilder().Build();
 
 await moduleNameContainer.StartAsync()

--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -2,6 +2,25 @@
 
 Modules are great examples of Testcontainers' capabilities. To write tests against real dependencies, you can either choose one of the pre-configurations listed below or create your own implementation.
 
+Modules are standalone dependencies that can be installed from [NuGet.org](https://www.nuget.org/profiles/Testcontainers). To use a module in your test project, you need to add it as a dependency first:
+
+```console
+dotnet add package Testcontainers.ModuleName
+```
+
+All modules follow the same design and come pre-configured with best practices. Usually, you do not need to worry about configuring them yourself. To create and start a container, all you need is:
+
+```chsarp
+var moduleNameContainer = new ModuleNameBuilder().Build();
+
+await moduleNameContainer.StartAsync()
+  .ConfigureAwait(false);
+```
+
+!!! note
+
+    We will be add module-specific documentations soon.
+
 | Module        | Image                                                   | NuGet                                                                | Source                                                                                                          |
 |---------------|---------------------------------------------------------|----------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | Couchbase     | `couchbase:community-7.0.2`                             | [NuGet](https://www.nuget.org/packages/Testcontainers.Couchbase)     | [Source](https://github.com/testcontainers/testcontainers-dotnet/tree/develop/src/Testcontainers.Couchbase)     |

--- a/docs/modules/postgres.md
+++ b/docs/modules/postgres.md
@@ -1,6 +1,6 @@
 # PostgreSQL
 
-Here is an example of a pre-configured PostgreSQL container. In the example, Testcontainers starts a PostgreSQL database in a [xUnit.net][xunit] test and executes a SQL query against it.
+Here is an example of a pre-configured PostgreSQL module. In the example, Testcontainers starts a PostgreSQL database in a [xUnit.net][xunit] test and executes a SQL query against it.
 
 ```csharp
 public sealed class PostgreSqlContainerTest : IAsyncLifetime

--- a/examples/WeatherForecast/src/WeatherForecast/Program.cs
+++ b/examples/WeatherForecast/src/WeatherForecast/Program.cs
@@ -18,7 +18,7 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
 
 if (string.IsNullOrWhiteSpace(connectionString))
 {
-  // No database connection string is available. Start and seed a database using Testcontainers for .NET first.
+  // The application configuration does not include a database connection string, use Testcontainers for .NET to create, start and seed the dependent database.
   builder.Services.AddSingleton<DatabaseContainer>();
   builder.Services.AddHostedService(services => services.GetRequiredService<DatabaseContainer>());
   builder.Services.AddDbContext<WeatherDataContext>((services, options) =>
@@ -29,6 +29,7 @@ if (string.IsNullOrWhiteSpace(connectionString))
 }
 else
 {
+  // The application configuration includes a database connection string, use it to establish a connection and seed the database.
   builder.Services.AddDbContext<WeatherDataContext>((_, options) => options.UseSqlServer(connectionString));
 }
 

--- a/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecastTest.cs
+++ b/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecastTest.cs
@@ -40,6 +40,8 @@ public sealed class WeatherForecastTest : IAsyncLifetime
 
     public Api(WeatherForecastTest weatherForecastTest)
     {
+      // Instead of using environment variables to bootstrap our application configuration, we can implement a custom WebApplicationFactory<TEntryPoint>
+      // that overrides the ConfigureWebHost(IWebHostBuilder) method to add a WeatherDataContext to the service collection.
       Environment.SetEnvironmentVariable("ASPNETCORE_URLS", "https://+");
       Environment.SetEnvironmentVariable("ASPNETCORE_Kestrel__Certificates__Default__Path", "certificate.crt");
       Environment.SetEnvironmentVariable("ASPNETCORE_Kestrel__Certificates__Default__Password", "password");

--- a/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecastContainer.cs
+++ b/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecastContainer.cs
@@ -33,7 +33,7 @@ public sealed class WeatherForecastContainer : HttpClient, IAsyncLifetime
   {
     const string weatherForecastStorage = "weatherForecastStorage";
 
-    const string connectionString = $"server={weatherForecastStorage};user id=sa;password={SqlEdgeBuilder.DefaultPassword};database={SqlEdgeBuilder.DefaultDatabase}";
+    const string connectionString = $"server={weatherForecastStorage};user id={SqlEdgeBuilder.DefaultUsername};password={SqlEdgeBuilder.DefaultPassword};database={SqlEdgeBuilder.DefaultDatabase}";
 
     _weatherForecastNetwork = new NetworkBuilder()
       .Build();


### PR DESCRIPTION
## What does this PR do?

Updates the ASP.NET Core Blazor out-off-process example.

## Why is it important?

Since the latest major release (3.0.0) the `MsSqlTestcontainerConfiguration` type does no longer exists. The ASP.NET Core Blazor examples relies on a simpler implementation.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
