### PR TITLE
fix: Log Docker image build progress messages

### DIFF
--- a/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
+++ b/src/Testcontainers/BackwardCompatibility/BackwardsCompatibility.cs
@@ -1,5 +1,4 @@
-﻿#pragma warning disable SA1402
-#pragma warning disable SA1403
+﻿#pragma warning disable SA1402, SA1403
 
 namespace DotNet.Testcontainers
 {
@@ -99,5 +98,4 @@ namespace DotNet.Testcontainers
   }
 }
 
-#pragma warning restore SA1402
-#pragma warning restore SA1403
+#pragma warning restore SA1402, SA1403

--- a/src/Testcontainers/Clients/TraceProgress.cs
+++ b/src/Testcontainers/Clients/TraceProgress.cs
@@ -17,6 +17,16 @@ namespace DotNet.Testcontainers.Clients
     {
 #pragma warning disable CA1848, CA2254
 
+      if (!string.IsNullOrWhiteSpace(value.Status))
+      {
+        this.logger.LogTrace(value.Status);
+      }
+
+      if (!string.IsNullOrWhiteSpace(value.Stream))
+      {
+        this.logger.LogTrace(value.Stream);
+      }
+
       if (!string.IsNullOrWhiteSpace(value.ProgressMessage))
       {
         this.logger.LogTrace(value.ProgressMessage);

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -2,15 +2,14 @@ namespace DotNet.Testcontainers
 {
   using System;
   using System.Collections.Generic;
-  using System.Diagnostics.CodeAnalysis;
   using System.Text.RegularExpressions;
   using DotNet.Testcontainers.Images;
   using Microsoft.Extensions.Logging;
 
-  [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1309", MessageId = "Field names should not begin with underscore", Justification = "Do not apply rule for delegate fields.")]
-  [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Do not apply rule for delegate fields.")]
   internal static class Logging
   {
+#pragma warning disable InconsistentNaming, SA1309
+
     private static readonly Action<ILogger, Regex, Exception> _IgnorePatternAdded
       = LoggerMessage.Define<Regex>(LogLevel.Information, default, "Pattern {IgnorePattern} added to the regex cache");
 
@@ -79,6 +78,8 @@ namespace DotNet.Testcontainers
 
     private static readonly Action<ILogger, string, Exception> _DockerRegistryCredentialFound
       = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker registry credential {DockerRegistry} found");
+
+#pragma warning restore InconsistentNaming, SA1309
 
     public static void IgnorePatternAdded(this ILogger logger, Regex ignorePattern)
     {


### PR DESCRIPTION
## What does this PR do?

Logs Docker image build progress messages.

## Why is it important?

It fixes a regression. TC for .NET already logged those properties in previous versions. @michal-korniak thanks for bringing this to our attention

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #500
- Closes #836

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
