### PR TITLE
chore: Update Redpanda image

### DIFF
--- a/src/Testcontainers.Redpanda/RedpandaBuilder.cs
+++ b/src/Testcontainers.Redpanda/RedpandaBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.Redpanda;
 [PublicAPI]
 public sealed class RedpandaBuilder : ContainerBuilder<RedpandaBuilder, RedpandaContainer, RedpandaConfiguration>
 {
-    public const string RedpandaImage = "docker.redpanda.com/vectorized/redpanda:v22.2.1";
+    public const string RedpandaImage = "docker.redpanda.com/redpandadata/redpanda:v22.2.1";
 
     public const ushort RedpandaPort = 9092;
 


### PR DESCRIPTION
Currently, `RedpandaContainer` uses `docker.redpanda.com/vectorized/redpanda`
but must use `docker.redpanda.com/redpandadata/redpanda` instead.
