### PR TITLE
feat: Always use Docker's assigned random host port (Ryuk)

### DIFF
--- a/docs/examples/dind.md
+++ b/docs/examples/dind.md
@@ -1,6 +1,16 @@
-# Compose
+# Running inside another container
 
 ## Docker Desktop
+
+### Sibling containers
+
+If you choose to run your tests in a Docker Wormhole configuration, which involves using sibling containers, it is necessary to mount Docker's raw socket `/var/run/docker.sock.raw`. You find more information and an explanation of the bug in this [comment](https://github.com/docker/for-mac/issues/5588#issuecomment-934600089).
+
+```console
+docker run -v /var/run/docker.sock.raw:/var/run/docker.sock $IMAGE dotnet test
+```
+
+### Compose
 
 To use Docker's Compose tool to build and run a Testcontainers environment in a Docker Desktop Wormhole configuration,
 it is necessary to override Testcontainers' Docker host resolution and set the environment variable `TESTCONTAINERS_HOST_OVERRIDE` to `host.docker.internal`.

--- a/docs/examples/dind.md
+++ b/docs/examples/dind.md
@@ -4,7 +4,7 @@
 
 ### Sibling containers
 
-If you choose to run your tests in a Docker Wormhole configuration, which involves using sibling containers, it is necessary to mount Docker's raw socket `/var/run/docker.sock.raw`. You find more information and an explanation of the bug in this [comment](https://github.com/docker/for-mac/issues/5588#issuecomment-934600089).
+If you choose to run your tests in a Docker Wormhole configuration, which involves using sibling containers, it is necessary to mount Docker's raw socket `/var/run/docker.sock.raw`. You find more information and an explanation of the Docker bug in this [comment](https://github.com/docker/for-mac/issues/5588#issuecomment-934600089).
 
 ```console
 docker run -v /var/run/docker.sock.raw:/var/run/docker.sock $IMAGE dotnet test

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ nav:
   - api/wait_strategies.md
   - api/best_practices.md
   - Examples:
-    - examples/compose.md
+    - examples/dind.md
     - examples/aspnet.md
   - Modules:
     - modules/index.md

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -182,6 +182,9 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc cref="IContainerBuilder{TBuilderEntity, TContainerEntity}" />
     public TBuilderEntity WithPortBinding(string hostPort, string containerPort)
     {
+      // Remove this together with TestcontainersSettings.ResourceReaperPublicHostPort.
+      hostPort = "0".Equals(hostPort, StringComparison.OrdinalIgnoreCase) ? string.Empty : hostPort;
+
       var portBindings = new Dictionary<string, string> { { containerPort, hostPort } };
       return Clone(new ContainerConfiguration(portBindings: portBindings)).WithExposedPort(containerPort);
     }

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -140,6 +140,7 @@ namespace DotNet.Testcontainers.Configurations
     /// - https://github.com/docker/for-win/issues/11584.
     /// </remarks>
     [NotNull]
+    [Obsolete("The Resource Reaper will use Docker's assigned random host port. This property is no longer supported. For DinD configurations see: https://dotnet.testcontainers.org/examples/dind/.")]
     public static Func<IDockerEndpointAuthenticationConfiguration, ushort> ResourceReaperPublicHostPort { get; set; }
       = _ => 0;
 

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -61,7 +61,7 @@ namespace DotNet.Testcontainers.Containers
         .WithPrivileged(requiresPrivilegedMode)
         .WithAutoRemove(true)
         .WithCleanUp(false)
-        .WithPortBinding(RyukPort, true)
+        .WithPortBinding(TestcontainersSettings.ResourceReaperPublicHostPort.Invoke(dockerEndpointAuthConfig), RyukPort)
         .WithMount(dockerSocket)
         .Build();
 

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -61,8 +61,7 @@ namespace DotNet.Testcontainers.Containers
         .WithPrivileged(requiresPrivilegedMode)
         .WithAutoRemove(true)
         .WithCleanUp(false)
-        .WithExposedPort(RyukPort)
-        .WithPortBinding(TestcontainersSettings.ResourceReaperPublicHostPort.Invoke(dockerEndpointAuthConfig), RyukPort)
+        .WithPortBinding(RyukPort, true)
         .WithMount(dockerSocket)
         .Build();
 


### PR DESCRIPTION
## What does this PR do?

This PR extends the .NET documentation and explains that the Docker Wormhole configurations should use Docker's raw socket due to a bug in Docker Desktop. Furthermore, it sets the `ResourceReaperPublicHostPort` delegate obsolete. The Resource Reaper no longer uses the API to configure the assigned host port.

## Why is it important?

The PR provides more information about the Docker Wormhole configuration and use the same port assignment everywhere. The Resource Reaper was the only exception that uses the `0` assignments instead of `string.Empty`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #847
- Relates https://github.com/docker/for-mac/issues/5588#issuecomment-934600089

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->