### PR TITLE
chore: Update Ryuk image from version 0.3.4 to 0.4.0

### DIFF
--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -33,7 +33,7 @@ namespace DotNet.Testcontainers.Containers
     /// </summary>
     private const int RetryTimeoutInSeconds = 2;
 
-    private static readonly IImage RyukImage = new DockerImage("registry.testcontainers.com/testcontainers/ryuk:0.4.0");
+    private static readonly IImage RyukImage = new DockerImage("testcontainers/ryuk:0.4.0");
 
     private static readonly SemaphoreSlim DefaultLock = new SemaphoreSlim(1, 1);
 

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -33,7 +33,7 @@ namespace DotNet.Testcontainers.Containers
     /// </summary>
     private const int RetryTimeoutInSeconds = 2;
 
-    private static readonly IImage RyukImage = new DockerImage("testcontainers/ryuk:0.3.4");
+    private static readonly IImage RyukImage = new DockerImage("registry.testcontainers.com/testcontainers/ryuk:0.4.0");
 
     private static readonly SemaphoreSlim DefaultLock = new SemaphoreSlim(1, 1);
 

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -3,7 +3,7 @@ namespace DotNet.Testcontainers.Commons;
 [PublicAPI]
 public static class CommonImages
 {
-    public static readonly IImage Ryuk = new DockerImage("testcontainers/ryuk:0.3.4");
+    public static readonly IImage Ryuk = new DockerImage("registry.testcontainers.com/testcontainers/ryuk:0.4.0");
 
     public static readonly IImage Alpine = new DockerImage("alpine:3.17");
 

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -3,7 +3,7 @@ namespace DotNet.Testcontainers.Commons;
 [PublicAPI]
 public static class CommonImages
 {
-    public static readonly IImage Ryuk = new DockerImage("registry.testcontainers.com/testcontainers/ryuk:0.4.0");
+    public static readonly IImage Ryuk = new DockerImage("testcontainers/ryuk:0.4.0");
 
     public static readonly IImage Alpine = new DockerImage("alpine:3.17");
 


### PR DESCRIPTION
## What does this PR do?

Updates the Resource Reaper Docker image Ryuk to its latest version 0.4.0.

## Why is it important?

With the recent Docker announcement, we start to host our OSS images in addition to Docker Hub in our own registry.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
