### PR TITLE
Testcontainers.MsSql: WithDatabase to public

### DIFF
--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -62,20 +62,6 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             .WithEnvironment("SQLCMDDBNAME", database);
     }
 
-    /// <summary>
-    /// Sets the MsSql username.
-    /// </summary>
-    /// <remarks>
-    /// The Docker image does not allow to configure the username.
-    /// </remarks>
-    /// <param name="username">The MsSql username.</param>
-    /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
-    public MsSqlBuilder WithUsername(string username)
-    {
-        return Merge(DockerResourceConfiguration, new MsSqlConfiguration(username: username))
-            .WithEnvironment("SQLCMDUSER", username);
-    }
-
     /// <inheritdoc />
     public override MsSqlContainer Build()
     {
@@ -122,6 +108,20 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     protected override MsSqlBuilder Merge(MsSqlConfiguration oldValue, MsSqlConfiguration newValue)
     {
         return new MsSqlBuilder(new MsSqlConfiguration(oldValue, newValue));
+    }
+
+    /// <summary>
+    /// Sets the MsSql username.
+    /// </summary>
+    /// <remarks>
+    /// The Docker image does not allow to configure the username.
+    /// </remarks>
+    /// <param name="username">The MsSql username.</param>
+    /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
+    private MsSqlBuilder WithUsername(string username)
+    {
+        return Merge(DockerResourceConfiguration, new MsSqlConfiguration(username: username))
+            .WithEnvironment("SQLCMDUSER", username);
     }
 
     /// <inheritdoc cref="IWaitUntil" />

--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -131,7 +131,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// </remarks>
     private sealed class WaitUntil : IWaitUntil
     {
-        private readonly string[] _command = { "/opt/mssql-tools/bin/sqlcmd", "-Q", "SELECT 1;" };
+        private readonly string[] _command = { "/opt/mssql-tools/bin/sqlcmd", "-d", "master", "-Q", "SELECT 1;" };
 
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)

--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -48,6 +48,34 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             .WithEnvironment("SQLCMDPASSWORD", password);
     }
 
+    /// <summary>
+    /// Sets the MsSql database.
+    /// </summary>
+    /// <remarks>
+    /// The Docker image does not allow to configure the database.
+    /// </remarks>
+    /// <param name="database">The MsSql database.</param>
+    /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
+    public MsSqlBuilder WithDatabase(string database)
+    {
+        return Merge(DockerResourceConfiguration, new MsSqlConfiguration(database: database))
+            .WithEnvironment("SQLCMDDBNAME", database);
+    }
+
+    /// <summary>
+    /// Sets the MsSql username.
+    /// </summary>
+    /// <remarks>
+    /// The Docker image does not allow to configure the username.
+    /// </remarks>
+    /// <param name="username">The MsSql username.</param>
+    /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
+    public MsSqlBuilder WithUsername(string username)
+    {
+        return Merge(DockerResourceConfiguration, new MsSqlConfiguration(username: username))
+            .WithEnvironment("SQLCMDUSER", username);
+    }
+
     /// <inheritdoc />
     public override MsSqlContainer Build()
     {
@@ -94,34 +122,6 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     protected override MsSqlBuilder Merge(MsSqlConfiguration oldValue, MsSqlConfiguration newValue)
     {
         return new MsSqlBuilder(new MsSqlConfiguration(oldValue, newValue));
-    }
-
-    /// <summary>
-    /// Sets the MsSql database.
-    /// </summary>
-    /// <remarks>
-    /// The Docker image does not allow to configure the database.
-    /// </remarks>
-    /// <param name="database">The MsSql database.</param>
-    /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
-    private MsSqlBuilder WithDatabase(string database)
-    {
-        return Merge(DockerResourceConfiguration, new MsSqlConfiguration(database: database))
-            .WithEnvironment("SQLCMDDBNAME", database);
-    }
-
-    /// <summary>
-    /// Sets the MsSql username.
-    /// </summary>
-    /// <remarks>
-    /// The Docker image does not allow to configure the username.
-    /// </remarks>
-    /// <param name="username">The MsSql username.</param>
-    /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
-    private MsSqlBuilder WithUsername(string username)
-    {
-        return Merge(DockerResourceConfiguration, new MsSqlConfiguration(username: username))
-            .WithEnvironment("SQLCMDUSER", username);
     }
 
     /// <inheritdoc cref="IWaitUntil" />


### PR DESCRIPTION
## What does this PR do?

Changed visibility of `WithDatabase` from `private` to `public` for the `MsSqlBuilder`.
Also updated `WaitUntil` to always target the `master` database.

## Why is it important?

With the methods being private there is no way to use the builder to set a database.
This was easily accomplishable in v2 via `new MsSqlTestcontainerConfiguration { Password = "123", Database = "MyDb" }`

In case of testing with ORMs (like EF Core) it can be beneficial to be able to specify a non-existing database in the connection string so that migrations can create the database.

## Alternative

Calling `WithDatabase` will now succeed. However, calling `ExecScriptAsync` will fail, **unless** the database was created beforehand in some capacity.

An alternative that could work as well is to update the `GetConnectionString()` to accept an optional parameter for the database like `GetConnectionString(string? database = null)` to then return a connection string targeting either the given `database` (if not null) or simply the database according to configuration (always master).