### PR TITLE
chore: Update LocalStack image from version 1.4 to 2.0

### DIFF
--- a/src/Testcontainers.LocalStack/LocalStackBuilder.cs
+++ b/src/Testcontainers.LocalStack/LocalStackBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.LocalStack;
 [PublicAPI]
 public sealed class LocalStackBuilder : ContainerBuilder<LocalStackBuilder, LocalStackContainer, LocalStackConfiguration>
 {
-    public const string LocalStackImage = "localstack/localstack:1.4";
+    public const string LocalStackImage = "localstack/localstack:2.0";
 
     public const ushort LocalStackPort = 4566;
 

--- a/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTests.cs
+++ b/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTests.cs
@@ -1,15 +1,20 @@
 namespace Testcontainers.LocalStack;
 
-public sealed class LocalStackContainerTest : IAsyncLifetime
+public abstract class LocalStackContainerTest : IAsyncLifetime
 {
     private const string AwsService = "Service";
 
-    private readonly LocalStackContainer _localStackContainer = new LocalStackBuilder().Build();
+    private readonly LocalStackContainer _localStackContainer;
 
     static LocalStackContainerTest()
     {
         Environment.SetEnvironmentVariable("AWS_ACCESS_KEY_ID", CommonCredentials.AwsAccessKey);
         Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", CommonCredentials.AwsSecretKey);
+    }
+
+    private LocalStackContainerTest(LocalStackContainer localStackContainer)
+    {
+        _localStackContainer = localStackContainer;
     }
 
     public Task InitializeAsync()
@@ -141,5 +146,23 @@ public sealed class LocalStackContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(HttpStatusCode.OK, queueResponse.HttpStatusCode);
+    }
+
+    [UsedImplicitly]
+    public sealed class LocalStackDefaultConfiguration : LocalStackContainerTest
+    {
+        public LocalStackDefaultConfiguration()
+            : base(new LocalStackBuilder().Build())
+        {
+        }
+    }
+
+    [UsedImplicitly]
+    public sealed class LocalStackV1Configuration : LocalStackContainerTest
+    {
+        public LocalStackV1Configuration()
+            : base(new LocalStackBuilder().WithImage("localstack/localstack:1.4").Build())
+        {
+        }
     }
 }

--- a/tests/Testcontainers.LocalStack.Tests/Usings.cs
+++ b/tests/Testcontainers.LocalStack.Tests/Usings.cs
@@ -11,4 +11,5 @@ global using Amazon.S3;
 global using Amazon.SimpleNotificationService;
 global using Amazon.SQS;
 global using DotNet.Testcontainers.Commons;
+global using JetBrains.Annotations;
 global using Xunit;


### PR DESCRIPTION
## What does this PR do?

Updates the LocalStack image from version 1.4 to 2.0.

## Why is it important?

Keep the default LocalStack configuration up-to-date.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
