### PR TITLE
feat: Detect rootless Docker endpoint configurations

### DIFF
--- a/src/Testcontainers/Builders/EnvironmentEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/EnvironmentEndpointAuthenticationProvider.cs
@@ -3,8 +3,10 @@ namespace DotNet.Testcontainers.Builders
   using System;
   using System.Linq;
   using DotNet.Testcontainers.Configurations;
+  using JetBrains.Annotations;
 
   /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
+  [PublicAPI]
   internal sealed class EnvironmentEndpointAuthenticationProvider : DockerEndpointAuthenticationProvider
   {
     private readonly Uri _dockerEngine;

--- a/src/Testcontainers/Builders/MTlsEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/MTlsEndpointAuthenticationProvider.cs
@@ -6,6 +6,7 @@ namespace DotNet.Testcontainers.Builders
   using System.Security.Cryptography.X509Certificates;
   using Docker.DotNet.X509;
   using DotNet.Testcontainers.Configurations;
+  using JetBrains.Annotations;
   using Org.BouncyCastle.Crypto;
   using Org.BouncyCastle.OpenSsl;
   using Org.BouncyCastle.Pkcs;
@@ -13,6 +14,7 @@ namespace DotNet.Testcontainers.Builders
   using Org.BouncyCastle.X509;
 
   /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
+  [PublicAPI]
   internal sealed class MTlsEndpointAuthenticationProvider : TlsEndpointAuthenticationProvider
   {
     private static readonly X509CertificateParser CertificateParser = new X509CertificateParser();

--- a/src/Testcontainers/Builders/NpipeEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/NpipeEndpointAuthenticationProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Builders
+namespace DotNet.Testcontainers.Builders
 {
   using System;
   using System.Runtime.InteropServices;
@@ -6,18 +6,14 @@
   using JetBrains.Annotations;
 
   /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
+  [PublicAPI]
   internal sealed class NpipeEndpointAuthenticationProvider : DockerEndpointAuthenticationProvider
   {
-#pragma warning disable S1075
-
     /// <summary>
     /// Gets the named pipe Docker Engine endpoint.
     /// </summary>
-    [PublicAPI]
     public static Uri DockerEngine { get; }
       = new Uri("npipe://./pipe/docker_engine");
-
-#pragma warning restore S1075
 
     /// <inheritdoc />
     public override bool IsApplicable()

--- a/src/Testcontainers/Builders/RootlessUnixEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/RootlessUnixEndpointAuthenticationProvider.cs
@@ -59,7 +59,7 @@ namespace DotNet.Testcontainers.Builders
 
     private static string GetSocketPathFromRunDir()
     {
-      var uid = 0;
+      ushort uid = 0;
 
       if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
       {

--- a/src/Testcontainers/Builders/RootlessUnixEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/RootlessUnixEndpointAuthenticationProvider.cs
@@ -1,0 +1,118 @@
+namespace DotNet.Testcontainers.Builders
+{
+  using System;
+  using System.IO;
+  using System.Linq;
+  using System.Runtime.InteropServices;
+  using DotNet.Testcontainers.Configurations;
+  using JetBrains.Annotations;
+
+  /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
+  [PublicAPI]
+  internal sealed class RootlessUnixEndpointAuthenticationProvider : DockerEndpointAuthenticationProvider
+  {
+    private readonly Uri _dockerEngine;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RootlessUnixEndpointAuthenticationProvider" /> class.
+    /// </summary>
+    public RootlessUnixEndpointAuthenticationProvider()
+      : this(GetSocketPathFromEnv(), GetSocketPathFromHomeDir(), GetSocketPathFromRunDir())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RootlessUnixEndpointAuthenticationProvider" /> class.
+    /// </summary>
+    /// <param name="socketPaths">A list of socket paths.</param>
+    public RootlessUnixEndpointAuthenticationProvider(params string[] socketPaths)
+    {
+      _dockerEngine = socketPaths
+        .Where(File.Exists)
+        .Select(socketPath => new UriBuilder("unix", socketPath))
+        .Select(uriBuilder => uriBuilder.Uri)
+        .FirstOrDefault();
+    }
+
+    /// <inheritdoc />
+    public override bool IsApplicable()
+    {
+      return _dockerEngine != null;
+    }
+
+    /// <inheritdoc />
+    public override IDockerEndpointAuthenticationConfiguration GetAuthConfig()
+    {
+      return new DockerEndpointAuthenticationConfiguration(_dockerEngine);
+    }
+
+    private static string GetSocketPathFromEnv()
+    {
+      var xdgRuntimeDir = Environment.GetEnvironmentVariable("XDG_RUNTIME_DIR");
+      return string.Join("/", xdgRuntimeDir, "docker.sock");
+    }
+
+    private static string GetSocketPathFromHomeDir()
+    {
+      return string.Join("/", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".docker", "run", "docker.sock");
+    }
+
+    private static string GetSocketPathFromRunDir()
+    {
+      var uid = 0;
+
+      if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+      {
+        uid = new Darwin().GetUid();
+      }
+
+      if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+      {
+        uid = new Linux().GetUid();
+      }
+
+      return string.Join("/", string.Empty, "user", uid, "docker.sock");
+    }
+
+    /// <summary>
+    /// A user identity.
+    /// </summary>
+    [PublicAPI]
+    private interface IUserIdentity
+    {
+      /// <summary>
+      /// Gets the real user ID of the calling process.
+      /// </summary>
+      /// <returns>The real user ID of the calling process.</returns>
+      ushort GetUid();
+    }
+
+    /// <inheritdoc cref="IUserIdentity" />
+    [PublicAPI]
+    private sealed class Darwin : IUserIdentity
+    {
+      [DllImport("libSystem")]
+      private static extern ushort getuid();
+
+      /// <inheritdoc />
+      public ushort GetUid()
+      {
+        return getuid();
+      }
+    }
+
+    /// <inheritdoc cref="IUserIdentity" />
+    [PublicAPI]
+    private sealed class Linux : IUserIdentity
+    {
+      [DllImport("libc")]
+      private static extern ushort getuid();
+
+      /// <inheritdoc />
+      public ushort GetUid()
+      {
+        return getuid();
+      }
+    }
+  }
+}

--- a/src/Testcontainers/Builders/TlsEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/TlsEndpointAuthenticationProvider.cs
@@ -7,8 +7,10 @@ namespace DotNet.Testcontainers.Builders
   using System.Net.Security;
   using System.Security.Cryptography.X509Certificates;
   using DotNet.Testcontainers.Configurations;
+  using JetBrains.Annotations;
 
   /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
+  [PublicAPI]
   internal class TlsEndpointAuthenticationProvider : DockerEndpointAuthenticationProvider
   {
     protected const string CaCertificateFileName = "ca.pem";

--- a/src/Testcontainers/Builders/UnixEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/UnixEndpointAuthenticationProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Builders
+namespace DotNet.Testcontainers.Builders
 {
   using System;
   using System.Runtime.InteropServices;
@@ -6,14 +6,14 @@
   using JetBrains.Annotations;
 
   /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
+  [PublicAPI]
   internal sealed class UnixEndpointAuthenticationProvider : DockerEndpointAuthenticationProvider
   {
     /// <summary>
     /// Gets the Unix socket Docker Engine endpoint.
     /// </summary>
-    [NotNull]
     public static Uri DockerEngine { get; }
-      = new Uri("unix:/var/run/docker.sock");
+      = new Uri("unix:///var/run/docker.sock");
 
     /// <inheritdoc />
     public override bool IsApplicable()

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -29,6 +29,7 @@ namespace DotNet.Testcontainers.Configurations
           new EnvironmentEndpointAuthenticationProvider(),
           new NpipeEndpointAuthenticationProvider(),
           new UnixEndpointAuthenticationProvider(),
+          new RootlessUnixEndpointAuthenticationProvider(),
         }
         .Where(authProvider => authProvider.IsApplicable())
         .Where(authProvider => authProvider.IsAvailable())

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -2,6 +2,7 @@ namespace DotNet.Testcontainers.Containers
 {
   using System;
   using System.IO;
+  using System.Linq;
   using System.Net.Sockets;
   using System.Text;
   using System.Threading;
@@ -238,6 +239,7 @@ namespace DotNet.Testcontainers.Containers
       {
         await resourceReaper.DisposeAsync()
           .ConfigureAwait(false);
+
         throw;
       }
 
@@ -416,44 +418,6 @@ namespace DotNet.Testcontainers.Containers
       }
     }
 
-    private sealed class NamedPipeSocketMount : IMount
-    {
-      private const string DockerSocketFilePath = "\\\\.\\pipe\\docker_engine";
-
-      static NamedPipeSocketMount()
-      {
-      }
-
-      private NamedPipeSocketMount()
-      {
-      }
-
-      public static IMount Instance { get; }
-        = new NamedPipeSocketMount();
-
-      public MountType Type
-        => MountType.NamedPipe;
-
-      public AccessMode AccessMode
-        => AccessMode.ReadWrite;
-
-      public string Source
-        => TestcontainersSettings.DockerSocketOverride ?? DockerSocketFilePath;
-
-      public string Target
-        => DockerSocketFilePath;
-
-      public Task CreateAsync(CancellationToken ct = default)
-      {
-        return Task.CompletedTask;
-      }
-
-      public Task DeleteAsync(CancellationToken ct = default)
-      {
-        return Task.CompletedTask;
-      }
-    }
-
     private sealed class UnixSocketMount : IMount
     {
       private const string DockerSocketFilePath = "/var/run/docker.sock";
@@ -476,7 +440,7 @@ namespace DotNet.Testcontainers.Containers
         => AccessMode.ReadOnly;
 
       public string Source
-        => TestcontainersSettings.DockerSocketOverride ?? DockerSocketFilePath;
+        => TestcontainersSettings.DockerSocketOverride ?? GetSocketPath();
 
       public string Target
         => DockerSocketFilePath;
@@ -489,6 +453,12 @@ namespace DotNet.Testcontainers.Containers
       public Task DeleteAsync(CancellationToken ct = default)
       {
         return Task.CompletedTask;
+      }
+
+      private static string GetSocketPath()
+      {
+        var dockerEndpoints = new[] { TestcontainersSettings.OS.DockerEndpointAuthConfig.Endpoint, UnixEndpointAuthenticationProvider.DockerEngine };
+        return dockerEndpoints.First(dockerEndpoint => "unix".Equals(dockerEndpoint.Scheme, StringComparison.OrdinalIgnoreCase)).AbsolutePath;
       }
     }
   }

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
@@ -77,7 +77,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         Add(new object[] { new TlsEndpointAuthenticationProvider(DockerTlsHostConfiguration).GetAuthConfig(), new Uri(DockerTlsHost) });
         Add(new object[] { new EnvironmentEndpointAuthenticationProvider(DockerHostConfiguration).GetAuthConfig(), new Uri(DockerHost) });
         Add(new object[] { new NpipeEndpointAuthenticationProvider().GetAuthConfig(), new Uri("npipe://./pipe/docker_engine") });
-        Add(new object[] { new UnixEndpointAuthenticationProvider().GetAuthConfig(), new Uri("unix:/var/run/docker.sock") });
+        Add(new object[] { new UnixEndpointAuthenticationProvider().GetAuthConfig(), new Uri("unix:///var/run/docker.sock") });
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Adds another Docker endpoint authentication provider to detect rootless Docker configurations.

## Why is it important?

We are seeing an increasing number of setups that use rootless Docker endpoint configurations. In order to prevent developers from having to configure Testcontainers repeatedly to detect these configurations, we have added another provider that can automatically detect this configurations.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
