### PR TITLE
feat: Automatically detect Docker Desktop for Linux rootless socket

### DIFF
--- a/src/Testcontainers/Builders/RootlessUnixEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/RootlessUnixEndpointAuthenticationProvider.cs
@@ -17,7 +17,7 @@ namespace DotNet.Testcontainers.Builders
     /// Initializes a new instance of the <see cref="RootlessUnixEndpointAuthenticationProvider" /> class.
     /// </summary>
     public RootlessUnixEndpointAuthenticationProvider()
-      : this(GetSocketPathFromEnv(), GetSocketPathFromHomeDir(), GetSocketPathFromRunDir())
+      : this(GetSocketPathFromEnv(), GetSocketPathFromHomeDesktopDir(), GetSocketPathFromHomeRunDir(), GetSocketPathFromRunDir())
     {
     }
 
@@ -52,7 +52,12 @@ namespace DotNet.Testcontainers.Builders
       return string.Join("/", xdgRuntimeDir, "docker.sock");
     }
 
-    private static string GetSocketPathFromHomeDir()
+    private static string GetSocketPathFromHomeDesktopDir()
+    {
+      return string.Join("/", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".docker", "desktop", "docker.sock");
+    }
+
+    private static string GetSocketPathFromHomeRunDir()
     {
       return string.Join("/", Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".docker", "run", "docker.sock");
     }


### PR DESCRIPTION
## What does this PR do?

Adds the `~/.docker/desktop/docker.sock` path to the rootless Docker socket detection.

## Why is it important?

Docker Desktop for Linux uses the mentioned path above. To automatically detect Docker Desktop for Linux environments it is necessary to consider the path as well.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
