### PR TITLE
feat: Add default session-id label to Docker resources

### DIFF
--- a/src/Testcontainers/Clients/DefaultLabels.cs
+++ b/src/Testcontainers/Clients/DefaultLabels.cs
@@ -17,6 +17,7 @@ namespace DotNet.Testcontainers.Clients
         { TestcontainersClient.TestcontainersLabel, bool.TrueString.ToLowerInvariant() },
         { TestcontainersClient.TestcontainersLangLabel, "dotnet" },
         { TestcontainersClient.TestcontainersVersionLabel, typeof(DefaultLabels).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion },
+        { TestcontainersClient.TestcontainersSessionIdLabel, ResourceReaper.DefaultSessionId.ToString("D") },
         { ResourceReaper.ResourceReaperSessionLabel, ResourceReaper.DefaultSessionId.ToString("D") },
       })
     {

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -24,6 +24,8 @@ namespace DotNet.Testcontainers.Clients
 
     public const string TestcontainersVersionLabel = TestcontainersLabel + ".version";
 
+    public const string TestcontainersSessionIdLabel = TestcontainersLabel + ".session-id";
+
     private readonly string _osRootDirectory = Path.GetPathRoot(Directory.GetCurrentDirectory());
 
     private readonly IDockerContainerOperations _containers;


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

By default, Docker resources are labeled with the `session-id`.

## Why is it important?

Align with other TC language implementations.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
