### PR TITLE
fix: Remove trailing slash from rootless Docker socket path

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>$(AssemblyName)</PackageId>
-    <Version>3.1.0</Version>
+    <Version>3.1.1</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Product>Testcontainers</Product>

--- a/src/Testcontainers/Builders/RootlessUnixEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/RootlessUnixEndpointAuthenticationProvider.cs
@@ -29,8 +29,7 @@ namespace DotNet.Testcontainers.Builders
     {
       _dockerEngine = socketPaths
         .Where(File.Exists)
-        .Select(socketPath => new UriBuilder("unix", socketPath))
-        .Select(uriBuilder => uriBuilder.Uri)
+        .Select(socketPath => new Uri("unix://" + socketPath))
         .FirstOrDefault();
     }
 


### PR DESCRIPTION
## What does this PR do?

The pull request removes a trailing slash that prevents Testcontainers for .NET to auto-detect rootless Docker environment.

## Why is it important?

It looks like the [UriBuilder](https://learn.microsoft.com/de-de/dotnet/api/system.uribuilder) appends a trailing slash to the Docker daemon socket path which breaks the auto discovery.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
