### PR TITLE
feat: Add Docker image build policy

### DIFF
--- a/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
+++ b/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
@@ -1,5 +1,7 @@
 namespace DotNet.Testcontainers.Builders
 {
+  using System;
+  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Images;
   using JetBrains.Annotations;
 
@@ -50,6 +52,14 @@ namespace DotNet.Testcontainers.Builders
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithDockerfileDirectory(CommonDirectoryPath commonDirectoryPath, string dockerfileDirectory);
+
+    /// <summary>
+    /// Sets the image build policy.
+    /// </summary>
+    /// <param name="imageBuildPolicy">The image build policy.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
+    TBuilderEntity WithImageBuildPolicy(Func<ImagesListResponse, bool> imageBuildPolicy);
 
     /// <summary>
     /// Removes an existing image before building it again.

--- a/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
@@ -81,6 +81,12 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
+    public ImageFromDockerfileBuilder WithImageBuildPolicy(Func<ImagesListResponse, bool> imageBuildPolicy)
+    {
+      return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(imageBuildPolicy: imageBuildPolicy));
+    }
+
+    /// <inheritdoc />
     public ImageFromDockerfileBuilder WithDeleteIfExists(bool deleteIfExists)
     {
       return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(deleteIfExists: deleteIfExists));
@@ -103,7 +109,7 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc />
     protected sealed override ImageFromDockerfileBuilder Init()
     {
-      return base.Init().WithDockerfile("Dockerfile").WithDockerfileDirectory(Directory.GetCurrentDirectory()).WithName(new DockerImage("localhost/testcontainers", Guid.NewGuid().ToString("D"), string.Empty));
+      return base.Init().WithImageBuildPolicy(PullPolicy.Always).WithDockerfile("Dockerfile").WithDockerfileDirectory(Directory.GetCurrentDirectory()).WithName(new DockerImage("localhost/testcontainers", Guid.NewGuid().ToString("D"), string.Empty));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -314,9 +314,18 @@ namespace DotNet.Testcontainers.Clients
     }
 
     /// <inheritdoc />
-    public Task<string> BuildAsync(IImageFromDockerfileConfiguration configuration, CancellationToken ct = default)
+    public async Task<string> BuildAsync(IImageFromDockerfileConfiguration configuration, CancellationToken ct = default)
     {
-      return _images.BuildAsync(configuration, ct);
+      var cachedImage = await _images.ByNameAsync(configuration.Image.FullName, ct)
+        .ConfigureAwait(false);
+
+      if (configuration.ImageBuildPolicy(cachedImage))
+      {
+        _ = await _images.BuildAsync(configuration, ct)
+          .ConfigureAwait(false);
+      }
+
+      return configuration.Image.FullName;
     }
   }
 }

--- a/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
@@ -1,5 +1,6 @@
 namespace DotNet.Testcontainers.Configurations
 {
+  using System;
   using System.Collections.Generic;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Images;
@@ -30,6 +31,11 @@ namespace DotNet.Testcontainers.Configurations
     /// Gets the image.
     /// </summary>
     IImage Image { get; }
+
+    /// <summary>
+    /// Gets the image build policy.
+    /// </summary>
+    Func<ImagesListResponse, bool> ImageBuildPolicy { get; }
 
     /// <summary>
     /// Gets a list of build arguments.

--- a/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
@@ -1,5 +1,6 @@
 namespace DotNet.Testcontainers.Configurations
 {
+  using System;
   using System.Collections.Generic;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Builders;
@@ -16,18 +17,21 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="dockerfile">The Dockerfile.</param>
     /// <param name="dockerfileDirectory">The Dockerfile directory.</param>
     /// <param name="image">The image.</param>
+    /// <param name="imageBuildPolicy">The image build policy.</param>
     /// <param name="buildArguments">A list of build arguments.</param>
     /// <param name="deleteIfExists">A value indicating whether Testcontainers removes an existing image or not.</param>
     public ImageFromDockerfileConfiguration(
       string dockerfile = null,
       string dockerfileDirectory = null,
       IImage image = null,
+      Func<ImagesListResponse, bool> imageBuildPolicy = null,
       IReadOnlyDictionary<string, string> buildArguments = null,
       bool? deleteIfExists = null)
     {
       Dockerfile = dockerfile;
       DockerfileDirectory = dockerfileDirectory;
       Image = image;
+      ImageBuildPolicy = imageBuildPolicy;
       BuildArguments = buildArguments;
       DeleteIfExists = deleteIfExists;
     }
@@ -61,6 +65,7 @@ namespace DotNet.Testcontainers.Configurations
       Dockerfile = BuildConfiguration.Combine(oldValue.Dockerfile, newValue.Dockerfile);
       DockerfileDirectory = BuildConfiguration.Combine(oldValue.DockerfileDirectory, newValue.DockerfileDirectory);
       Image = BuildConfiguration.Combine(oldValue.Image, newValue.Image);
+      ImageBuildPolicy = BuildConfiguration.Combine(oldValue.ImageBuildPolicy, newValue.ImageBuildPolicy);
       BuildArguments = BuildConfiguration.Combine(oldValue.BuildArguments, newValue.BuildArguments);
       DeleteIfExists = (oldValue.DeleteIfExists.HasValue && oldValue.DeleteIfExists.Value) || (newValue.DeleteIfExists.HasValue && newValue.DeleteIfExists.Value);
     }
@@ -76,6 +81,9 @@ namespace DotNet.Testcontainers.Configurations
 
     /// <inheritdoc />
     public IImage Image { get; }
+
+    /// <inheritdoc />
+    public Func<ImagesListResponse, bool> ImageBuildPolicy { get; }
 
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string> BuildArguments { get; }

--- a/tests/Testcontainers.Tests/Assets/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/Dockerfile
@@ -1,3 +1,2 @@
-FROM alpine:latest
-
-LABEL maintainer="9199345+HofmeisterAn@users.noreply.github.com"
+FROM alpine:3.17
+LABEL "maintainer"="9199345+HofmeisterAn@users.noreply.github.com"

--- a/tests/Testcontainers.Tests/Assets/healthWaitStrategy/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/healthWaitStrategy/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine
-ARG RESOURCE_REAPER_SESSION_ID="00000000-0000-0000-0000-000000000000"
+FROM alpine:3.17
+LABEL "maintainer"="9199345+HofmeisterAn@users.noreply.github.com"
 HEALTHCHECK --interval=1s CMD test -e /healthcheck
 COPY docker-entrypoint.sh docker-entrypoint.sh
 RUN chmod +x docker-entrypoint.sh

--- a/tests/Testcontainers.Tests/Fixtures/Images/HealthCheckFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/HealthCheckFixture.cs
@@ -13,7 +13,6 @@ namespace DotNet.Testcontainers.Tests.Fixtures
   {
     private readonly IFutureDockerImage _image = new ImageFromDockerfileBuilder()
       .WithDockerfileDirectory(Path.Combine(Directory.GetCurrentDirectory(), "Assets", "healthWaitStrategy"))
-      .WithBuildArgument("RESOURCE_REAPER_SESSION_ID", ResourceReaper.DefaultSessionId.ToString("D"))
       .Build();
 
     public string Repository => _image.Repository;


### PR DESCRIPTION
## What does this PR do?

Adds a new property `ImageBuildPolicy` to the `IImageFromDockerfileConfiguration` interface. The new member `WithImageBuildPolicy(Func<ImagesListResponse, bool>)` allows to configure a predicate that determines whether an image should be built or not. For example, developers can use `WithImageBuildPolicy(PullPolicy.Missing)` to build the image only if it does not already exist. @WojciechNagorski your feedback would be appreciated.

I am uncertain if we should copy and rename the static `PullPolicy` class to `BuildPolicy`. It contains the same properties.

## Why is it important?

The image build policy makes it easier for developers to customize the image build behavior.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #853

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
