### PR TITLE
fix: Replace CLI command to detect open ports in Linux containers

### DIFF
--- a/src/Testcontainers/Configurations/WaitStrategies/UntilUnixPortIsAvailable.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilUnixPortIsAvailable.cs
@@ -3,7 +3,7 @@ namespace DotNet.Testcontainers.Configurations
   internal class UntilUnixPortIsAvailable : UntilUnixCommandIsCompleted
   {
     public UntilUnixPortIsAvailable(int port)
-      : base($"true && (cat /proc/net/tcp{{,6}} | awk '{{print $2}}' | grep -i :{port} || nc -vz -w 1 localhost {port} || /bin/bash -c '</dev/tcp/localhost/{port}')")
+      : base(string.Format("true && (grep -i ':0*{0:X}' /proc/net/tcp* || nc -vz -w 1 localhost {0:D} || /bin/bash -c '</dev/tcp/localhost/{0:D}')", port))
     {
     }
   }


### PR DESCRIPTION
## What does this PR do?

The CLI command for detecting open ports in Linux containers has been replaced. The new command is aligned with the TC for Java configuration.

## Why is it important?

The old command was not successful in certain configurations.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
