### PR TITLE
fix: Typo in Selenium

### DIFF
--- a/examples/WeatherForecast/README.md
+++ b/examples/WeatherForecast/README.md
@@ -9,4 +9,4 @@ cd ./testcontainers-dotnet/examples/WeatherForecast/
 dotnet test WeatherForecast.sln --configuration=Release
 ```
 
-_*) One unit test depends on Seleium and requires Chrome in version 106._
+_*) One unit test depends on Selenium and requires Chrome in version 106._


### PR DESCRIPTION
Fix typo: "Seleium" -> "Selenium"

## What does this PR do?

This PR fixes a typo in README.md.

## Why is it important?

It's best to not have typos in your README.md, because they can lead to confusing situations (e.g. a developer trying to search for the Seleium framework).

## Related issues

-

## How to test this PR

Verify that "Selenium" is spelled correctly.