### PR TITLE
docs: Add information about running Testcontainers in specific CI environments

### DIFF
--- a/docs/api/create_docker_image.md
+++ b/docs/api/create_docker_image.md
@@ -7,11 +7,12 @@ Testcontainers for .NET uses the builder design pattern to configure, create and
 Builds and tags a new container image. The Dockerfile is located inside the solution (`.sln`) directory.
 
 ```csharp
-await new ImageFromDockerfileBuilder()
+var futureImage = new ImageFromDockerfileBuilder()
   .WithDockerfileDirectory(CommonDirectoryPath.GetSolutionDirectory(), string.Empty)
   .WithDockerfile("Dockerfile")
-  .Build()
-  .CreateAsync()
+  .Build();
+
+await futureImage.CreateAsync()
   .ConfigureAwait(false);
 ```
 
@@ -42,8 +43,7 @@ Testcontainers offers convenient features to detect common directories in .NET p
 ```csharp
 _ = new ImageFromDockerfileBuilder()
   .WithDockerfileDirectory(CommonDirectoryPath.GetSolutionDirectory(), string.Empty)
-  .WithDockerfile("Dockerfile")
-  .Build();
+  .WithDockerfile("Dockerfile");
 ```
 
 As the tarball's content is based on `/Users/testcontainers/WeatherForecast/`, all paths inside the Dockerfile must be relative to this path. For example, Docker's `COPY` instruction copies all files inside the `WeatherForecast/` directory to the image.

--- a/docs/cicd/index.md
+++ b/docs/cicd/index.md
@@ -1,0 +1,22 @@
+# Continuous Integration
+
+To use Testcontainers in your CI/CD environment, you only require Docker installed. A local installation of Docker is not mandatory; you can also use a remote Docker installation.
+
+## Azure Pipelines
+
+[Microsoft-hosted agents](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops) come with Docker pre-installed, there is no need for any additional configuration. It is important to note that Windows agents use the Docker Windows engine and cannot run Linux containers. If you are using Windows agents, ensure that the image you are using matches the agent's architecture and operating system version [^1)^](https://docs.docker.com/build/building/multi-platform/) [^2)^](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
+
+## GitHub Actions
+
+GitHub-hosted runners have the same configuration as Microsoft-hosted agents. The configuration is similar to what is described in the section Azure Pipelines.
+
+## GitLab CI/CD
+
+To configure the Docker service in GitLab CI ([Docker-in-Docker](https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-in-docker)), you need to define the service in your `.gitlab-ci.yml` file and expose the Docker host address `docker:2375` by setting the `DOCKER_HOST` environment variable.
+
+```yml
+services:
+  - docker:dind
+variables:
+  DOCKER_HOST: tcp://docker:2375
+```

--- a/docs/cicd/index.md
+++ b/docs/cicd/index.md
@@ -14,7 +14,7 @@ GitHub-hosted runners have the same configuration as Microsoft-hosted agents. Th
 
 To configure the Docker service in GitLab CI ([Docker-in-Docker](https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-in-docker)), you need to define the service in your `.gitlab-ci.yml` file and expose the Docker host address `docker:2375` by setting the `DOCKER_HOST` environment variable.
 
-```yml
+```yml title=".gitlab-ci.yml file"
 services:
   - docker:dind
 variables:

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,33 +2,6 @@
 
 ![Testcontainers Banner](banner.png)
 
-<p style="text-align:center">
-  <strong>Not using .NET? Here are other supported languages!</strong>
-</p>
-<div class="card-grid">
-  <a class="card-grid-item" href="https://www.testcontainers.org">
-    <img src="language-logos/java.svg" />Java
-  </a>
-  <a class="card-grid-item" href="https://golang.testcontainers.org">
-    <img src="language-logos/go.svg" />Go
-  </a>
-  <a class="card-grid-item">
-    <img src="language-logos/dotnet.svg" />.NET
-  </a>
-  <a class="card-grid-item" href="https://node.testcontainers.org">
-    <img src="language-logos/nodejs.svg" />Node.js
-  </a>
-  <a class="card-grid-item" href="https://testcontainers-python.readthedocs.io/en/latest/">
-    <img src="language-logos/python.svg" />Python
-  </a>
-  <a class="card-grid-item" href="https://docs.rs/testcontainers/latest/testcontainers/">
-    <img src="language-logos/rust.svg" />Rust
-  </a>
-  <a class="card-grid-item" href="https://github.com/testcontainers/testcontainers-hs/">
-    <img src="language-logos/haskell.svg"/>Haskell
-  </a>
-</div>
-
 ```console title="Install the NuGet dependency"
 dotnet add package Testcontainers
 ```
@@ -60,11 +33,40 @@ var guid = await httpClient.GetStringAsync(requestUri).ConfigureAwait(false);
 Debug.Assert(Guid.TryParse(guid, out _));
 ```
 
+<p style="text-align:center">
+  <strong>Not using .NET? Here are other supported languages!</strong>
+</p>
+<div class="card-grid">
+  <a class="card-grid-item" href="https://www.testcontainers.org">
+    <img src="language-logos/java.svg" />Java
+  </a>
+  <a class="card-grid-item" href="https://golang.testcontainers.org">
+    <img src="language-logos/go.svg" />Go
+  </a>
+  <a class="card-grid-item">
+    <img src="language-logos/dotnet.svg" />.NET
+  </a>
+  <a class="card-grid-item" href="https://node.testcontainers.org">
+    <img src="language-logos/nodejs.svg" />Node.js
+  </a>
+  <a class="card-grid-item" href="https://testcontainers-python.readthedocs.io/en/latest/">
+    <img src="language-logos/python.svg" />Python
+  </a>
+  <a class="card-grid-item" href="https://docs.rs/testcontainers/latest/testcontainers/">
+    <img src="language-logos/rust.svg" />Rust
+  </a>
+  <a class="card-grid-item" href="https://github.com/testcontainers/testcontainers-hs/">
+    <img src="language-logos/haskell.svg"/>Haskell
+  </a>
+</div>
+
 ## About
 
 Testcontainers for .NET is a library to support tests with throwaway instances of Docker containers for all compatible .NET Standard versions. The library is built on top of the .NET Docker remote API and provides a lightweight implementation to support your test environment in all circumstances.
 
 Choose from existing pre-configured modules and start containers within a second, to support and run your tests. Or create your own container images with Dockerfiles and run your containers and tests immediately afterward.
+
+For more detailed instructions and guidance, please refer to the Testcontainers' [Getting Started](https://testcontainers.com/guides/introducing-testcontainers/) guide. If you are specifically interested in using Testcontainers for .NET, you find a dedicated follow-up guide [here](https://testcontainers.com/guides/getting-started-with-testcontainers-for-dotnet/). These resources will provide you with comprehensive information to help you get started and make the most out of Testcontainers.
 
 ## Supported operating systems
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,37 @@
   </a>
 </div>
 
+```console title="Install the NuGet dependency"
+dotnet add package Testcontainers
+```
+
+```csharp title="Run the Hello World container"
+// Create a new instance of a container.
+var container = new ContainerBuilder()
+  // Set the image for the container to "testcontainers/helloworld:1.1.0".
+  .WithImage("testcontainers/helloworld:1.1.0")
+  // Bind port 8080 of the container to a random port on the host.
+  .WithPortBinding(8080, true)
+  // Build the container configuration.
+  .Build();
+
+// Start the container.
+await container.StartAsync()
+  .ConfigureAwait(false);
+
+// Create a new instance of HttpClient to send HTTP requests.
+var httpClient = new HttpClient();
+
+// Construct the request URI by specifying the scheme, hostname, assigned random host port, and the endpoint "uuid".
+var requestUri = new UriBuilder(Uri.UriSchemeHttp, container.Hostname, container.GetMappedPublicPort(8080), "uuid").ToString();
+
+// Send an HTTP GET request to the specified URI and retrieve the response as a string.
+var guid = await httpClient.GetStringAsync(requestUri).ConfigureAwait(false);
+
+// Ensure that the retrieved UUID is a valid GUID.
+Debug.Assert(Guid.TryParse(guid, out _));
+```
+
 ## About
 
 Testcontainers for .NET is a library to support tests with throwaway instances of Docker containers for all compatible .NET Standard versions. The library is built on top of the .NET Docker remote API and provides a lightweight implementation to support your test environment in all circumstances.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ markdown_extensions:
   - pymdownx.superfences
 nav:
   - index.md
+  - cicd/index.md
   - custom_configuration/index.md
   - api/create_docker_image.md
   - api/create_docker_container.md


### PR DESCRIPTION
## What does this PR do?

The pull request updates the documentation, adding information on running Testcontainers in specific CI environments. It also includes a getting started example on the start page to assist .NET developers.

## Why is it important?

Enhance the developer experience when starting with Testcontainers.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
