### PR TITLE
chore: Update Ryuk image from version 0.4.0 to 0.5.1

### DIFF
--- a/docs/api/resource-reaper.md
+++ b/docs/api/resource-reaper.md
@@ -1,10 +1,12 @@
 # Resource Reaper
 
-Testcontainers automatically assigns a Resource Reaper session id to each Docker resource. After the tests are finished — whether they are successful or not — [Ryuk][moby-ryuk] will take care of the remaining Docker resources and removes them. You can change the Resource Reaper session and group Docker resources together. Right now, only Linux containers are supported.
+Testcontainers automatically assigns a Resource Reaper session id to each Docker resource. After the tests are finished — whether they are successful or not — [Moby Ryuk](https://github.com/testcontainers/moby-ryuk) will take care of the remaining Docker resources and removes them. You can change the Resource Reaper session and group Docker resources together. Right now, only Linux containers are supported.
 
 !!!tip
 
     Whenever possible, do **not** disable the Resource Reaper. It keeps your machine and CI/CD environment clean. If at all, consider disabling the Resource Reaper only for environments that have a mechanism to cleanup Docker resources, e.g. ephemeral CI nodes.
+
+Moby Ryuk derives its name from the anime character [Ryuk](https://en.wikipedia.org/wiki/Ryuk_(Death_Note)) and is a fitting choice due to the intriguing narrative of the anime Death Note.
 
 <!-- ## Examples
 
@@ -25,5 +27,3 @@ await new ContainerBuilder()
 !!!warning
 
     Testcontainers for .NET assigns a default session id. You do not have to override the Resource Reaper session id usually. -->
-
-[moby-ryuk]: https://github.com/testcontainers/moby-ryuk

--- a/docs/cicd/index.md
+++ b/docs/cicd/index.md
@@ -4,7 +4,7 @@ To use Testcontainers in your CI/CD environment, you only require Docker install
 
 ## Azure Pipelines
 
-[Microsoft-hosted agents](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops) come with Docker pre-installed, there is no need for any additional configuration. It is important to note that Windows agents use the Docker Windows engine and cannot run Linux containers. If you are using Windows agents, ensure that the image you are using matches the agent's architecture and operating system version [^1)^](https://docs.docker.com/build/building/multi-platform/) [^2)^](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
+[Microsoft-hosted agents](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops) come with Docker pre-installed, there is no need for any additional configuration. It is important to note that Windows agents use the Docker Windows engine and cannot run Linux containers. If you are using Windows agents, ensure that the image you are using matches the agent's architecture and operating system version [1)](https://docs.docker.com/build/building/multi-platform/) [2)](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
 
 ## GitHub Actions
 

--- a/docs/cicd/index.md
+++ b/docs/cicd/index.md
@@ -4,7 +4,7 @@ To use Testcontainers in your CI/CD environment, you only require Docker install
 
 ## Azure Pipelines
 
-[Microsoft-hosted agents](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops) come with Docker pre-installed, there is no need for any additional configuration. It is important to note that Windows agents use the Docker Windows engine and cannot run Linux containers. If you are using Windows agents, ensure that the image you are using matches the agent's architecture and operating system version [1)](https://docs.docker.com/build/building/multi-platform/) [2)](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
+[Microsoft-hosted agents](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops) come with Docker pre-installed, there is no need for any additional configuration. It is important to note that Windows agents use the Docker Windows engine and cannot run Linux containers. If you are using Windows agents, ensure that the image you are using matches the agent's architecture and operating system version [1)](https://docs.docker.com/build/building/multi-platform/), [2)](https://learn.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility).
 
 ## GitHub Actions
 

--- a/docs/custom_configuration/index.md
+++ b/docs/custom_configuration/index.md
@@ -14,7 +14,7 @@ Testcontainers supports various configurations to set up your test environment. 
 | `docker.socket.override`    | `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`    | The file path to the Docker daemon socket that is used by Ryuk (resource reaper).                                         | `/var/run/docker.sock`      |
 | `ryuk.disabled`             | `TESTCONTAINERS_RYUK_DISABLED`             | Disables Ryuk (resource reaper).                                                                                          | `false`                     |
 | `ryuk.container.privileged` | `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED` | Runs Ryuk (resource reaper) in privileged mode.                                                                           | `false`                     |
-| `ryuk.container.image`      | `TESTCONTAINERS_RYUK_CONTAINER_IMAGE`      | The Ryuk (resource reaper) Docker image.                                                                                  | `testcontainers/ryuk:0.3.4` |
+| `ryuk.container.image`      | `TESTCONTAINERS_RYUK_CONTAINER_IMAGE`      | The Ryuk (resource reaper) Docker image.                                                                                  | `testcontainers/ryuk:0.5.1` |
 | `hub.image.name.prefix`     | `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX`     | The name to use for substituting the Docker Hub registry part of the image name.                                          | -                           |
 
 ## Configure remote container runtime

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,10 +24,11 @@ await container.StartAsync()
 var httpClient = new HttpClient();
 
 // Construct the request URI by specifying the scheme, hostname, assigned random host port, and the endpoint "uuid".
-var requestUri = new UriBuilder(Uri.UriSchemeHttp, container.Hostname, container.GetMappedPublicPort(8080), "uuid").ToString();
+var requestUri = new UriBuilder(Uri.UriSchemeHttp, container.Hostname, container.GetMappedPublicPort(8080), "uuid").Uri;
 
 // Send an HTTP GET request to the specified URI and retrieve the response as a string.
-var guid = await httpClient.GetStringAsync(requestUri).ConfigureAwait(false);
+var guid = await httpClient.GetStringAsync(requestUri)
+  .ConfigureAwait(false);
 
 // Ensure that the retrieved UUID is a valid GUID.
 Debug.Assert(Guid.TryParse(guid, out _));

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -33,7 +33,7 @@ namespace DotNet.Testcontainers.Containers
     /// </summary>
     private const int RetryTimeoutInSeconds = 2;
 
-    private static readonly IImage RyukImage = new DockerImage("testcontainers/ryuk:0.4.0");
+    private static readonly IImage RyukImage = new DockerImage("testcontainers/ryuk:0.5.1");
 
     private static readonly SemaphoreSlim DefaultLock = new SemaphoreSlim(1, 1);
 

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -3,7 +3,7 @@ namespace DotNet.Testcontainers.Commons;
 [PublicAPI]
 public static class CommonImages
 {
-    public static readonly IImage Ryuk = new DockerImage("testcontainers/ryuk:0.4.0");
+    public static readonly IImage Ryuk = new DockerImage("testcontainers/ryuk:0.5.1");
 
     public static readonly IImage Alpine = new DockerImage("alpine:3.17");
 


### PR DESCRIPTION
## What does this PR do?

Updates Moby Ryuk to version 0.5.1.

## Why is it important?

The latest Moby Ryuk version contains a fix for a breaking API change (in Moby).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
