### PR TITLE
chore: Update Docker.DotNet from version 3.125.13 to 3.125.15

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -2,8 +2,8 @@
 <Project>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0" />
-    <PackageReference Update="Docker.DotNet" Version="3.125.13" />
-    <PackageReference Update="Docker.DotNet.X509" Version="3.125.13" />
+    <PackageReference Update="Docker.DotNet" Version="3.125.15" />
+    <PackageReference Update="Docker.DotNet.X509" Version="3.125.15" />
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />


### PR DESCRIPTION
## What does this PR do?

Bumps the version of Docker.DotNet.

## Why is it important?

Docker.DotNet version 3.125.15 addresses a `SocketException` issue that prevented Podman users from using Testcontainers for .NET for certain test configurations:

    System.Net.Http.HttpRequestException : Error while copying content to a stream

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #876

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
