### PR TITLE
chore: Favor custom environment variable configurations over properties file

### DIFF
--- a/src/Testcontainers/Builders/DockerRegistryAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/DockerRegistryAuthenticationProvider.cs
@@ -70,13 +70,13 @@ namespace DotNet.Testcontainers.Builders
 
     private static string GetDefaultDockerConfigFilePath()
     {
-      var dockerConfigDirectoryPath = PropertiesFileConfiguration.Instance.GetDockerConfig() ?? EnvironmentConfiguration.Instance.GetDockerConfig() ?? UserProfileDockerConfigDirectoryPath;
+      var dockerConfigDirectoryPath = EnvironmentConfiguration.Instance.GetDockerConfig() ?? PropertiesFileConfiguration.Instance.GetDockerConfig() ?? UserProfileDockerConfigDirectoryPath;
       return Path.Combine(dockerConfigDirectoryPath, "config.json");
     }
 
     private static JsonDocument GetDefaultDockerAuthConfig()
     {
-      return PropertiesFileConfiguration.Instance.GetDockerAuthConfig() ?? EnvironmentConfiguration.Instance.GetDockerAuthConfig() ?? JsonDocument.Parse("{}");
+      return EnvironmentConfiguration.Instance.GetDockerAuthConfig() ?? PropertiesFileConfiguration.Instance.GetDockerAuthConfig() ?? JsonDocument.Parse("{}");
     }
 
     private IDockerRegistryAuthenticationConfiguration GetUncachedAuthConfig(string hostname)

--- a/src/Testcontainers/Builders/EnvironmentEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/EnvironmentEndpointAuthenticationProvider.cs
@@ -15,7 +15,7 @@ namespace DotNet.Testcontainers.Builders
     /// Initializes a new instance of the <see cref="EnvironmentEndpointAuthenticationProvider" /> class.
     /// </summary>
     public EnvironmentEndpointAuthenticationProvider()
-      : this(PropertiesFileConfiguration.Instance, EnvironmentConfiguration.Instance)
+      : this(EnvironmentConfiguration.Instance, PropertiesFileConfiguration.Instance)
     {
     }
 

--- a/src/Testcontainers/Builders/MTlsEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/MTlsEndpointAuthenticationProvider.cs
@@ -23,7 +23,7 @@ namespace DotNet.Testcontainers.Builders
     /// Initializes a new instance of the <see cref="MTlsEndpointAuthenticationProvider" /> class.
     /// </summary>
     public MTlsEndpointAuthenticationProvider()
-      : this(PropertiesFileConfiguration.Instance, EnvironmentConfiguration.Instance)
+      : this(EnvironmentConfiguration.Instance, PropertiesFileConfiguration.Instance)
     {
     }
 

--- a/src/Testcontainers/Builders/TlsEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/TlsEndpointAuthenticationProvider.cs
@@ -23,7 +23,7 @@ namespace DotNet.Testcontainers.Builders
     /// Initializes a new instance of the <see cref="TlsEndpointAuthenticationProvider" /> class.
     /// </summary>
     public TlsEndpointAuthenticationProvider()
-      : this(PropertiesFileConfiguration.Instance, EnvironmentConfiguration.Instance)
+      : this(EnvironmentConfiguration.Instance, PropertiesFileConfiguration.Instance)
     {
     }
 

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -108,7 +108,7 @@ namespace DotNet.Testcontainers.Configurations
     [CanBeNull]
     public static string DockerHostOverride { get; set; }
       = DockerEndpointAuthProvider is ICustomConfiguration config
-        ? config.GetDockerHostOverride() : PropertiesFileConfiguration.Instance.GetDockerHostOverride() ?? EnvironmentConfiguration.Instance.GetDockerHostOverride();
+        ? config.GetDockerHostOverride() : EnvironmentConfiguration.Instance.GetDockerHostOverride() ?? PropertiesFileConfiguration.Instance.GetDockerHostOverride();
 
     /// <summary>
     /// Gets or sets the Docker socket override value.
@@ -116,26 +116,26 @@ namespace DotNet.Testcontainers.Configurations
     [CanBeNull]
     public static string DockerSocketOverride { get; set; }
       = DockerEndpointAuthProvider is ICustomConfiguration config
-        ? config.GetDockerSocketOverride() : PropertiesFileConfiguration.Instance.GetDockerSocketOverride() ?? EnvironmentConfiguration.Instance.GetDockerSocketOverride();
+        ? config.GetDockerSocketOverride() : EnvironmentConfiguration.Instance.GetDockerSocketOverride() ?? PropertiesFileConfiguration.Instance.GetDockerSocketOverride();
 
     /// <summary>
     /// Gets or sets a value indicating whether the <see cref="ResourceReaper" /> is enabled or not.
     /// </summary>
     public static bool ResourceReaperEnabled { get; set; }
-      = !PropertiesFileConfiguration.Instance.GetRyukDisabled() && !EnvironmentConfiguration.Instance.GetRyukDisabled();
+      = !EnvironmentConfiguration.Instance.GetRyukDisabled() && !PropertiesFileConfiguration.Instance.GetRyukDisabled();
 
     /// <summary>
     /// Gets or sets a value indicating whether the <see cref="ResourceReaper" /> privileged mode is enabled or not.
     /// </summary>
     public static bool ResourceReaperPrivilegedModeEnabled { get; set; }
-      = PropertiesFileConfiguration.Instance.GetRyukContainerPrivileged() || EnvironmentConfiguration.Instance.GetRyukContainerPrivileged();
+      = EnvironmentConfiguration.Instance.GetRyukContainerPrivileged() || PropertiesFileConfiguration.Instance.GetRyukContainerPrivileged();
 
     /// <summary>
     /// Gets or sets the <see cref="ResourceReaper" /> image.
     /// </summary>
     [CanBeNull]
     public static IImage ResourceReaperImage { get; set; }
-      = PropertiesFileConfiguration.Instance.GetRyukContainerImage() ?? EnvironmentConfiguration.Instance.GetRyukContainerImage();
+      = EnvironmentConfiguration.Instance.GetRyukContainerImage() ?? PropertiesFileConfiguration.Instance.GetRyukContainerImage();
 
     /// <summary>
     /// Gets or sets the <see cref="ResourceReaper" /> public host port.
@@ -159,7 +159,7 @@ namespace DotNet.Testcontainers.Configurations
     /// </remarks>
     [CanBeNull]
     public static string HubImageNamePrefix { get; set; }
-      = PropertiesFileConfiguration.Instance.GetHubImageNamePrefix() ?? EnvironmentConfiguration.Instance.GetHubImageNamePrefix();
+      = EnvironmentConfiguration.Instance.GetHubImageNamePrefix() ?? PropertiesFileConfiguration.Instance.GetHubImageNamePrefix();
 
     /// <summary>
     /// Gets or sets the logger.


### PR DESCRIPTION
## What does this PR do?

The PR changes the order of `PropertiesFileConfiguration` and `EnvironmentConfiguration` (the environment variables take priority).

## Why is it important?

This enables users to have finer control over custom configurations by using environment variables.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
