### PR TITLE
fix: Do not create a Port Forwarding Container instance if auto-discovery does not detect Docker host

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>$(AssemblyName)</PackageId>
-    <Version>3.1.1</Version>
+    <Version>3.2.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Product>Testcontainers</Product>

--- a/src/Testcontainers/Containers/PortForwarding.cs
+++ b/src/Testcontainers/Containers/PortForwarding.cs
@@ -98,8 +98,13 @@ namespace DotNet.Testcontainers.Containers
       /// <inheritdoc />
       public override PortForwardingContainer Build()
       {
-        Validate();
-        return new PortForwardingContainer(DockerResourceConfiguration, TestcontainersSettings.Logger);
+        // The port forwarding container only works in conjunction with the Docker host
+        // auto-discovery. It does not support configuring individual Docker hosts. If
+        // Testcontainers cannot detect a Docker host configuration, do not create an
+        // instance of the port forwarding container. To improve the user experience, it
+        // is preferable to stop supporting `WithDockerEndpoint(string)` and instead rely
+        // on the environment variables or the properties file custom configurations.
+        return DockerResourceConfiguration.DockerEndpointAuthConfig == null ? null : new PortForwardingContainer(DockerResourceConfiguration, TestcontainersSettings.Logger);
       }
 
       /// <inheritdoc />


### PR DESCRIPTION
## What does this PR do?

The PR prevents Testcontainers from creating a Port Forwarding Container instance if auto-discovery does not detect a Docker host.

## Why is it important?

If users choose to configure their Docker host environment individually using the container builder method `WithDockerEndpoint`, Testcontainers will throw an exception

    Cannot detect the Docker endpoint. [...]

if auto-discovery fails to find a Docker host environment. The port forwarding container depends on auto-discovery and cannot be customized for individual Docker host configurations since it is implemented as a singleton.

To enhance the user experience, we should consider removing feature `WithDockerEndpoint`. By relying on auto-discovery, we can better support a wide range of features in Testcontainers and simplify test configurations.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
