### PR TITLE
chore: Refactor legacy TestcontainersContainerTest class

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>$(AssemblyName)</PackageId>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Product>Testcontainers</Product>


### PR DESCRIPTION
## What does this PR do?

The pull request slightly adjusts the legacy Testcontainers for .NET tests to support the container runtime environment Podman. Rootless Podman cannot expose privileged ports.

## Why is it important?

 To integrate Podman into our CI pipeline, it is necessary to fix the failing tests first.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #876

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
