### PR TITLE
fix: Refactor tests to support Podman container runtime

### DIFF
--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -442,7 +442,7 @@ namespace DotNet.Testcontainers.Containers
         _container = await _client.InspectContainerAsync(_container.ID, ct)
           .ConfigureAwait(false);
       }
-      catch (DockerContainerNotFoundException)
+      catch (DockerApiException)
       {
         _container = new ContainerInspectResponse();
       }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/AlpineFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/AlpineFixture.cs
@@ -13,10 +13,8 @@ namespace DotNet.Testcontainers.Tests.Fixtures
   {
     public IContainer Container { get; }
       = new ContainerBuilder()
-        .WithImage("alpine")
+        .WithImage(CommonImages.Alpine)
         .WithCommand(CommonCommands.SleepInfinity)
-        .WithCleanUp(false)
-        .WithAutoRemove(true)
         .WithStartupCallback((_, ct) => Task.Delay(TimeSpan.FromMinutes(1), ct))
         .Build();
 

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerCancellationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerCancellationTest.cs
@@ -21,14 +21,17 @@ namespace DotNet.Testcontainers.Tests.Unit
       [Fact]
       public async Task Start()
       {
-        using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15)))
-        {
-          var expectedExceptions = new[] { typeof(TaskCanceledException), typeof(OperationCanceledException), typeof(TimeoutException), typeof(IOException) };
+        // Given
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
-          // It depends which part in the StartAsync gets canceled. Catch base exception.
-          var exception = await Assert.ThrowsAnyAsync<SystemException>(() => _alpineFixture.Container.StartAsync(cts.Token));
-          Assert.Contains(exception.GetType(), expectedExceptions);
-        }
+        var expectedExceptions = new[] { typeof(TaskCanceledException), typeof(OperationCanceledException), typeof(TimeoutException), typeof(IOException) };
+
+        // When
+        var exception = await Assert.ThrowsAnyAsync<SystemException>(() => _alpineFixture.Container.StartAsync(cts.Token))
+          .ConfigureAwait(false);
+
+        // Then
+        Assert.Contains(exception.GetType(), expectedExceptions);
       }
     }
   }

--- a/tests/Testcontainers.Tests/Unit/Networks/TestcontainerNetworkBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Networks/TestcontainerNetworkBuilderTest.cs
@@ -17,7 +17,7 @@ namespace DotNet.Testcontainers.Tests.Unit
   {
     private static readonly string NetworkName = Guid.NewGuid().ToString("D");
 
-    private static readonly KeyValuePair<string, string> Option = new KeyValuePair<string, string>("com.docker.network.driver.mtu", "1350");
+    private static readonly KeyValuePair<string, string> Option = new KeyValuePair<string, string>("mtu", "1350");
 
     private static readonly KeyValuePair<string, string> Label = new KeyValuePair<string, string>(TestcontainersClient.TestcontainersLabel + ".network.test", Guid.NewGuid().ToString("D"));
 

--- a/tests/Testcontainers.Tests/Unit/Networks/TestcontainersNetworkTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Networks/TestcontainersNetworkTest.cs
@@ -11,44 +11,47 @@ namespace DotNet.Testcontainers.Tests.Unit
   {
     private const string AliasSuffix = "-alias";
 
-    private readonly IContainer _testcontainer1;
+    private readonly IContainer _container1;
 
-    private readonly IContainer _testcontainer2;
+    private readonly IContainer _container2;
 
     public TestcontainersNetworkTest(NetworkFixture networkFixture)
     {
-      var testcontainersBuilder = new ContainerBuilder()
-        .WithImage("alpine")
+      var containerBuilder = new ContainerBuilder()
+        .WithImage(CommonImages.Alpine)
         .WithEntrypoint(CommonCommands.SleepInfinity)
         .WithNetwork(networkFixture.Network.Name);
 
-      _testcontainer1 = testcontainersBuilder
-        .WithHostname(nameof(_testcontainer1))
-        .WithNetworkAliases(nameof(_testcontainer1) + AliasSuffix)
+      _container1 = containerBuilder
+        .WithNetworkAliases(nameof(_container1) + AliasSuffix)
         .Build();
 
-      _testcontainer2 = testcontainersBuilder
-        .WithHostname(nameof(_testcontainer2))
-        .WithNetworkAliases(nameof(_testcontainer2) + AliasSuffix)
+      _container2 = containerBuilder
+        .WithNetworkAliases(nameof(_container2) + AliasSuffix)
         .Build();
     }
 
     public Task InitializeAsync()
     {
-      return Task.WhenAll(_testcontainer1.StartAsync(), _testcontainer2.StartAsync());
+      return Task.WhenAll(_container1.StartAsync(), _container2.StartAsync());
     }
 
     public Task DisposeAsync()
     {
-      return Task.WhenAll(_testcontainer1.DisposeAsync().AsTask(), _testcontainer2.DisposeAsync().AsTask());
+      return Task.WhenAll(_container1.DisposeAsync().AsTask(), _container2.DisposeAsync().AsTask());
     }
 
-    [Theory]
-    [InlineData(nameof(_testcontainer2))]
-    [InlineData(nameof(_testcontainer2) + AliasSuffix)]
-    public async Task PingContainer(string destination)
+    [Fact]
+    public async Task PingContainer()
     {
-      var execResult = await _testcontainer1.ExecAsync(new[] { "ping", "-c", "4", destination });
+      // Given
+      const string destination = nameof(_container2) + AliasSuffix;
+
+      // When
+      var execResult = await _container1.ExecAsync(new[] { "ping", "-c", "1", destination })
+        .ConfigureAwait(false);
+
+      // Then
       Assert.Equal(0, execResult.ExitCode);
     }
   }


### PR DESCRIPTION
## What does this PR do?

The pull request adjusts some tests to support them on the Podman container runtime.

## Why is it important?

Continue to support other container runtimes than Docker.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #876

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
