### PR TITLE
Simplify test projects

### DIFF
--- a/Testcontainers.sln
+++ b/Testcontainers.sln
@@ -12,6 +12,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{673F23AE-7694-4BB9-ABD4-136D6C13634E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}"
+	ProjectSection(SolutionItems) = preProject
+		tests\Directory.Build.props = tests\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testcontainers.Azurite", "src\Testcontainers.Azurite\Testcontainers.Azurite.csproj", "{3F2E254F-C203-43FD-A078-DC3E2CBC0F9F}"
 EndProject

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,5 +3,14 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
+  <ItemGroup Condition="$(MSBuildProjectName) != 'Testcontainers.Commons'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1"/>
+    <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
+    <PackageReference Include="xunit" Version="2.4.2"/>
+    <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+  </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Azurite.Tests/Testcontainers.Azurite.Tests.csproj
+++ b/tests/Testcontainers.Azurite.Tests/Testcontainers.Azurite.Tests.csproj
@@ -1,20 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Azure.Data.Tables" Version="12.8.0"/>
         <PackageReference Include="Azure.Storage.Blobs" Version="12.15.1"/>
         <PackageReference Include="Azure.Storage.Queues" Version="12.13.1"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.Azurite/Testcontainers.Azurite.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
+++ b/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
         <SignAssembly>true</SignAssembly>
-        <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1"/>

--- a/tests/Testcontainers.CosmosDb.Tests/Testcontainers.CosmosDb.Tests.csproj
+++ b/tests/Testcontainers.CosmosDb.Tests/Testcontainers.CosmosDb.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.32.1"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.CosmosDb/Testcontainers.CosmosDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
+++ b/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="MyCouch" Version="7.6.0"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.CouchDb/Testcontainers.CouchDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
+++ b/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="CouchbaseNetClient" Version="3.4.3"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.Couchbase/Testcontainers.Couchbase.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
+++ b/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.42"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
+++ b/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.5"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
+++ b/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.K3s.Tests/Testcontainers.K3s.Tests.csproj
+++ b/tests/Testcontainers.K3s.Tests/Testcontainers.K3s.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="KubernetesClient" Version="10.1.4"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.K3s/Testcontainers.K3s.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
+++ b/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Confluent.Kafka" Version="2.0.2"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.Kafka/Testcontainers.Kafka.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
+++ b/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Keycloak.Net.Core" Version="1.0.20"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
+++ b/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
@@ -1,14 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="AWSSDK.CloudWatchLogs" Version="3.7.104.14"/>
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.42"/>
         <PackageReference Include="AWSSDK.S3" Version="3.7.103.3"/>
@@ -17,6 +11,5 @@
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.LocalStack/Testcontainers.LocalStack.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
+++ b/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="MySqlConnector" Version="2.2.5"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
+++ b/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="AWSSDK.S3" Version="3.7.103.3"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.Minio/Testcontainers.Minio.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
+++ b/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="MongoDB.Driver" Version="2.19.0"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.MongoDb/Testcontainers.MongoDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
+++ b/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.MsSql/Testcontainers.MsSql.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
+++ b/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="MySqlConnector" Version="2.2.5"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.MySql/Testcontainers.MySql.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
+++ b/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Neo4j.Driver" Version="5.5.0"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.Neo4j/Testcontainers.Neo4j.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
+++ b/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.90"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.Oracle/Testcontainers.Oracle.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
+++ b/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
@@ -1,16 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
-    </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
+++ b/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
@@ -1,16 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
-    </ItemGroup>
 </Project>

--- a/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
+++ b/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Npgsql" Version="6.0.9"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
+++ b/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="RabbitMQ.Client" Version="6.4.0"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.RabbitMq/Testcontainers.RabbitMq.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
+++ b/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="RavenDB.Client" Version="5.4.100"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.RavenDb/Testcontainers.RavenDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
+++ b/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="StackExchange.Redis" Version="2.6.90"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.Redis/Testcontainers.Redis.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
+++ b/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Confluent.Kafka" Version="2.0.2"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.Redpanda/Testcontainers.Redpanda.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
+++ b/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
@@ -1,18 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
-    <IsPublishable>false</IsPublishable>
-    <Configurations>Debug;Release</Configurations>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>DotNet.Testcontainers.ResourceReaper.Tests</RootNamespace>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj" />
   </ItemGroup>

--- a/tests/Testcontainers.SqlEdge.Tests/Testcontainers.SqlEdge.Tests.csproj
+++ b/tests/Testcontainers.SqlEdge.Tests/Testcontainers.SqlEdge.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.SqlEdge/Testcontainers.SqlEdge.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
+++ b/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
@@ -1,27 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
-<Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
-    <Configurations>Debug;Release</Configurations>
     <RootNamespace>DotNet.Testcontainers.Tests</RootNamespace>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="xunit.runner.visualstudio" />
-    <PackageReference Include="xunit" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Assets/**/*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <None Include="Assets/**/*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tests/Testcontainers.WebDriver.Tests/Testcontainers.WebDriver.Tests.csproj
+++ b/tests/Testcontainers.WebDriver.Tests/Testcontainers.WebDriver.Tests.csproj
@@ -1,18 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1"/>
-        <PackageReference Include="coverlet.collector" Version="3.2.0"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"/>
-        <PackageReference Include="xunit" Version="2.4.2"/>
         <PackageReference Include="Selenium.WebDriver" Version="4.8.1"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.WebDriver/Testcontainers.WebDriver.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## What does this PR do?

This PR extracts all the common properties across all test projects (except for `Testcontainers.Commons`) into the `Directory.Build.props` file.

## Why is it important?

This reduces duplication and makes it easier to maintain test projects.

## Related issues

None