### PR TITLE
Share container lifetime implementation across all container tests

### DIFF
--- a/tests/Testcontainers.Azurite.Tests/AzuriteContainerTest.cs
+++ b/tests/Testcontainers.Azurite.Tests/AzuriteContainerTest.cs
@@ -1,19 +1,7 @@
 namespace Testcontainers.Azurite;
 
-public abstract class AzuriteContainerTest : IAsyncLifetime
+public abstract class AzuriteContainerTest : ContainerTest<AzuriteBuilder, AzuriteContainer>
 {
-    private readonly AzuriteContainer _azuriteContainer = new AzuriteBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _azuriteContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _azuriteContainer.DisposeAsync().AsTask();
-    }
-
     private static bool HasError<TResponseEntity>(NullableResponse<TResponseEntity> response)
     {
         using (var rawResponse = response.GetRawResponse())
@@ -29,7 +17,7 @@ public abstract class AzuriteContainerTest : IAsyncLifetime
         public async Task EstablishesConnection()
         {
             // Give
-            var client = new BlobServiceClient(_azuriteContainer.GetConnectionString());
+            var client = new BlobServiceClient(Container.GetConnectionString());
 
             // When
             var properties = await client.GetPropertiesAsync()
@@ -47,7 +35,7 @@ public abstract class AzuriteContainerTest : IAsyncLifetime
         public async Task EstablishesConnection()
         {
             // Give
-            var client = new QueueServiceClient(_azuriteContainer.GetConnectionString());
+            var client = new QueueServiceClient(Container.GetConnectionString());
 
             // When
             var properties = await client.GetPropertiesAsync()
@@ -65,7 +53,7 @@ public abstract class AzuriteContainerTest : IAsyncLifetime
         public async Task EstablishesConnection()
         {
             // Give
-            var client = new TableServiceClient(_azuriteContainer.GetConnectionString());
+            var client = new TableServiceClient(Container.GetConnectionString());
 
             // When
             var properties = await client.GetPropertiesAsync()

--- a/tests/Testcontainers.Commons/ContainerTest.cs
+++ b/tests/Testcontainers.Commons/ContainerTest.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using Xunit;
+
+namespace DotNet.Testcontainers.Commons
+{
+    public abstract class ContainerTest<TBuilderEntity, TContainerEntity> : IAsyncLifetime
+        where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity>, new()
+        where TContainerEntity : IContainer
+    {
+        protected ContainerTest() : this(null)
+        {
+        }
+
+        protected ContainerTest(Action<TBuilderEntity> configure)
+        {
+            var builder = new TBuilderEntity();
+            configure?.Invoke(builder);
+            Container = builder.Build();
+        }
+
+        protected TContainerEntity Container { get; }
+
+        public async Task InitializeAsync()
+        {
+            await Container.StartAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await Container.DisposeAsync();
+        }
+    }
+}

--- a/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
+++ b/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
@@ -3,6 +3,7 @@
         <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <IsTestProject>false</IsTestProject>
         <SignAssembly>true</SignAssembly>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>

--- a/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
+++ b/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2022.3.1"/>
+        <PackageReference Include="xunit" Version="2.4.2"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/tests/Testcontainers.CosmosDb.Tests/CosmosDbContainerTest.cs
+++ b/tests/Testcontainers.CosmosDb.Tests/CosmosDbContainerTest.cs
@@ -1,31 +1,19 @@
 namespace Testcontainers.CosmosDb;
 
-public sealed class CosmosDbContainerTest : IAsyncLifetime
+public sealed class CosmosDbContainerTest : ContainerTest<CosmosDbBuilder, CosmosDbContainer>
 {
-    private readonly CosmosDbContainer _cosmosDbContainer = new CosmosDbBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _cosmosDbContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _cosmosDbContainer.DisposeAsync().AsTask();
-    }
-
     [Fact(Skip = "The Cosmos DB Linux Emulator Docker image does not run on Microsoft's CI environment (GitHub, Azure DevOps).")] // https://github.com/Azure/azure-cosmos-db-emulator-docker/issues/45.
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task AccountPropertiesIdReturnsLocalhost()
     {
         // Given
-        using var httpClient = _cosmosDbContainer.HttpClient;
+        using var httpClient = Container.HttpClient;
 
         var cosmosClientOptions = new CosmosClientOptions();
         cosmosClientOptions.ConnectionMode = ConnectionMode.Gateway;
         cosmosClientOptions.HttpClientFactory = () => httpClient;
 
-        using var cosmosClient = new CosmosClient(_cosmosDbContainer.GetConnectionString(), cosmosClientOptions);
+        using var cosmosClient = new CosmosClient(Container.GetConnectionString(), cosmosClientOptions);
 
         // When
         var accountProperties = await cosmosClient.ReadAccountAsync()

--- a/tests/Testcontainers.CouchDb.Tests/CouchDbContainerTest.cs
+++ b/tests/Testcontainers.CouchDb.Tests/CouchDbContainerTest.cs
@@ -1,25 +1,13 @@
 namespace Testcontainers.CouchDb;
 
-public sealed class CouchDbContainerTest : IAsyncLifetime
+public sealed class CouchDbContainerTest : ContainerTest<CouchDbBuilder, CouchDbContainer>
 {
-    private readonly CouchDbContainer _couchDbContainer = new CouchDbBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _couchDbContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _couchDbContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task PutDatabaseReturnsHttpStatusCodeCreated()
     {
         // Given
-        using var client = new MyCouchClient(_couchDbContainer.GetConnectionString(), "db");
+        using var client = new MyCouchClient(Container.GetConnectionString(), "db");
 
         // When
         var database = await client.Database.PutAsync()

--- a/tests/Testcontainers.Couchbase.Tests/CouchDbContainerTest.cs
+++ b/tests/Testcontainers.Couchbase.Tests/CouchDbContainerTest.cs
@@ -1,26 +1,14 @@
 namespace Testcontainers.Couchbase;
 
-public sealed class CouchbaseContainerTest : IAsyncLifetime
+public sealed class CouchbaseContainerTest : ContainerTest<CouchbaseBuilder, CouchbaseContainer>
 {
-    private readonly CouchbaseContainer _couchbaseContainer = new CouchbaseBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _couchbaseContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _couchbaseContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task GetBucketReturnsDefaultBucket()
     {
         // Given
         var clusterOptions = new ClusterOptions();
-        clusterOptions.ConnectionString = _couchbaseContainer.GetConnectionString();
+        clusterOptions.ConnectionString = Container.GetConnectionString();
         clusterOptions.UserName = CouchbaseBuilder.DefaultUsername;
         clusterOptions.Password = CouchbaseBuilder.DefaultPassword;
 
@@ -31,7 +19,7 @@ public sealed class CouchbaseContainerTest : IAsyncLifetime
         var ping = await cluster.PingAsync()
             .ConfigureAwait(false);
 
-        var bucket = await cluster.BucketAsync(_couchbaseContainer.Buckets.Single().Name)
+        var bucket = await cluster.BucketAsync(Container.Buckets.Single().Name)
             .ConfigureAwait(false);
 
         // Then

--- a/tests/Testcontainers.DynamoDb.Tests/DynamoDbContainerTest.cs
+++ b/tests/Testcontainers.DynamoDb.Tests/DynamoDbContainerTest.cs
@@ -1,23 +1,11 @@
 namespace Testcontainers.DynamoDb;
 
-public sealed class DynamoDbContainerTest : IAsyncLifetime
+public sealed class DynamoDbContainerTest : ContainerTest<DynamoDbBuilder, DynamoDbContainer>
 {
-    private readonly DynamoDbContainer _dynamoDbContainer = new DynamoDbBuilder().Build();
-
     static DynamoDbContainerTest()
     {
         Environment.SetEnvironmentVariable("AWS_ACCESS_KEY_ID", CommonCredentials.AwsAccessKey);
         Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", CommonCredentials.AwsSecretKey);
-    }
-
-    public Task InitializeAsync()
-    {
-        return _dynamoDbContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _dynamoDbContainer.DisposeAsync().AsTask();
     }
 
     [Fact]
@@ -26,7 +14,7 @@ public sealed class DynamoDbContainerTest : IAsyncLifetime
     {
         // Given
         var config = new AmazonDynamoDBConfig();
-        config.ServiceURL = _dynamoDbContainer.GetConnectionString();
+        config.ServiceURL = Container.GetConnectionString();
 
         using var client = new AmazonDynamoDBClient(config);
 
@@ -48,7 +36,7 @@ public sealed class DynamoDbContainerTest : IAsyncLifetime
         var tableName = Guid.NewGuid().ToString("D");
 
         var config = new AmazonDynamoDBConfig();
-        config.ServiceURL = _dynamoDbContainer.GetConnectionString();
+        config.ServiceURL = Container.GetConnectionString();
 
         using var client = new AmazonDynamoDBClient(config);
 

--- a/tests/Testcontainers.Elasticsearch.Tests/ElasticsearchContainerTest.cs
+++ b/tests/Testcontainers.Elasticsearch.Tests/ElasticsearchContainerTest.cs
@@ -1,25 +1,13 @@
 namespace Testcontainers.Elasticsearch;
 
-public sealed class ElasticsearchContainerTest : IAsyncLifetime
+public sealed class ElasticsearchContainerTest : ContainerTest<ElasticsearchBuilder, ElasticsearchContainer>
 {
-    private readonly ElasticsearchContainer _elasticsearchContainer = new ElasticsearchBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _elasticsearchContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _elasticsearchContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void PingReturnsValidResponse()
     {
         // Given
-        var clientSettings = new ElasticsearchClientSettings(new Uri(_elasticsearchContainer.GetConnectionString()));
+        var clientSettings = new ElasticsearchClientSettings(new Uri(Container.GetConnectionString()));
         clientSettings.ServerCertificateValidationCallback(CertificateValidations.AllowAll);
 
         var client = new ElasticsearchClient(clientSettings);

--- a/tests/Testcontainers.EventStoreDb.Tests/EventStoreDbContainerTest.cs
+++ b/tests/Testcontainers.EventStoreDb.Tests/EventStoreDbContainerTest.cs
@@ -1,19 +1,7 @@
 namespace Testcontainers.EventStoreDb;
 
-public sealed class EventStoreDbContainerTest : IAsyncLifetime
+public sealed class EventStoreDbContainerTest : ContainerTest<EventStoreDbBuilder, EventStoreDbContainer>
 {
-    private readonly EventStoreDbContainer _eventStoreDbContainer = new EventStoreDbBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _eventStoreDbContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _eventStoreDbContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task ReadStreamReturnsEvent()
@@ -23,7 +11,7 @@ public sealed class EventStoreDbContainerTest : IAsyncLifetime
 
         const string streamName = "some-stream";
 
-        var settings = EventStoreClientSettings.Create(_eventStoreDbContainer.GetConnectionString());
+        var settings = EventStoreClientSettings.Create(Container.GetConnectionString());
 
         using var client = new EventStoreClient(settings);
 

--- a/tests/Testcontainers.K3s.Tests/K3sContainerTest.cs
+++ b/tests/Testcontainers.K3s.Tests/K3sContainerTest.cs
@@ -1,19 +1,7 @@
 namespace Testcontainers.K3s;
 
-public sealed class K3sContainerTest : IAsyncLifetime
+public sealed class K3sContainerTest : ContainerTest<K3sBuilder, K3sContainer>
 {
-    private readonly K3sContainer _k3sConainter = new K3sBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _k3sConainter.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _k3sConainter.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task CreateNamespaceReturnsHttpStatusCodeCreated()
@@ -21,7 +9,7 @@ public sealed class K3sContainerTest : IAsyncLifetime
         // Given
         using var kubeconfigStream = new MemoryStream();
 
-        var kubeconfig = await _k3sConainter.GetKubeconfigAsync()
+        var kubeconfig = await Container.GetKubeconfigAsync()
             .ConfigureAwait(false);
 
         await kubeconfigStream.WriteAsync(Encoding.Default.GetBytes(kubeconfig))

--- a/tests/Testcontainers.Kafka.Tests/KafkaContainerTest.cs
+++ b/tests/Testcontainers.Kafka.Tests/KafkaContainerTest.cs
@@ -1,19 +1,7 @@
 namespace Testcontainers.Kafka;
 
-public sealed class KafkaContainerTest : IAsyncLifetime
+public sealed class KafkaContainerTest : ContainerTest<KafkaBuilder, KafkaContainer>
 {
-    private readonly KafkaContainer _kafkaContainer = new KafkaBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _kafkaContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _kafkaContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task ConsumerReturnsProducerMessage()
@@ -21,7 +9,7 @@ public sealed class KafkaContainerTest : IAsyncLifetime
         // Given
         const string topic = "sample";
 
-        var bootstrapServer = _kafkaContainer.GetBootstrapAddress();
+        var bootstrapServer = Container.GetBootstrapAddress();
 
         var producerConfig = new ProducerConfig();
         producerConfig.BootstrapServers = bootstrapServer;

--- a/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
+++ b/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
@@ -1,25 +1,13 @@
 namespace Testcontainers.Keycloak.Tests;
 
-public sealed class KeycloakContainerTest : IAsyncLifetime
+public sealed class KeycloakContainerTest : ContainerTest<KeycloakBuilder, KeycloakContainer>
 {
-    private readonly KeycloakContainer _keycloakContainer = new KeycloakBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _keycloakContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _keycloakContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     public async Task GetOpenIdEndpointReturnsHttpStatusCodeOk()
     {
         // Given
         using var httpClient = new HttpClient();
-        httpClient.BaseAddress = new Uri(_keycloakContainer.GetBaseAddress());
+        httpClient.BaseAddress = new Uri(Container.GetBaseAddress());
 
         // When
         using var response = await httpClient.GetAsync("/realms/master/.well-known/openid-configuration")
@@ -33,7 +21,7 @@ public sealed class KeycloakContainerTest : IAsyncLifetime
     public async Task MasterRealmIsEnabled()
     {
         // Given
-        var keycloakClient = new KeycloakClient(_keycloakContainer.GetBaseAddress(), KeycloakBuilder.DefaultUsername, KeycloakBuilder.DefaultPassword);
+        var keycloakClient = new KeycloakClient(Container.GetBaseAddress(), KeycloakBuilder.DefaultUsername, KeycloakBuilder.DefaultPassword);
 
         // When
         var masterRealm = await keycloakClient.GetRealmAsync("master")

--- a/tests/Testcontainers.Keycloak.Tests/Usings.cs
+++ b/tests/Testcontainers.Keycloak.Tests/Usings.cs
@@ -2,5 +2,6 @@ global using System;
 global using System.Net;
 global using System.Net.Http;
 global using System.Threading.Tasks;
+global using DotNet.Testcontainers.Commons;
 global using Keycloak.Net;
 global using Xunit;

--- a/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTests.cs
+++ b/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTests.cs
@@ -1,10 +1,8 @@
 namespace Testcontainers.LocalStack;
 
-public abstract class LocalStackContainerTest : IAsyncLifetime
+public abstract class LocalStackContainerTest : ContainerTest<LocalStackBuilder, LocalStackContainer>
 {
     private const string AwsService = "Service";
-
-    private readonly LocalStackContainer _localStackContainer;
 
     static LocalStackContainerTest()
     {
@@ -12,19 +10,8 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
         Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", CommonCredentials.AwsSecretKey);
     }
 
-    private LocalStackContainerTest(LocalStackContainer localStackContainer)
+    protected LocalStackContainerTest(Action<LocalStackBuilder> configure = null) : base(configure)
     {
-        _localStackContainer = localStackContainer;
-    }
-
-    public Task InitializeAsync()
-    {
-        return _localStackContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _localStackContainer.DisposeAsync().AsTask();
     }
 
     [Fact]
@@ -34,7 +21,7 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
     {
         // Given
         var config = new AmazonCloudWatchLogsConfig();
-        config.ServiceURL = _localStackContainer.GetConnectionString();
+        config.ServiceURL = Container.GetConnectionString();
 
         using var client = new AmazonCloudWatchLogsClient(config);
 
@@ -59,7 +46,7 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
         var tableName = Guid.NewGuid().ToString("D");
 
         var config = new AmazonDynamoDBConfig();
-        config.ServiceURL = _localStackContainer.GetConnectionString();
+        config.ServiceURL = Container.GetConnectionString();
 
         using var client = new AmazonDynamoDBClient(config);
 
@@ -98,7 +85,7 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
     {
         // Given
         var config = new AmazonS3Config();
-        config.ServiceURL = _localStackContainer.GetConnectionString();
+        config.ServiceURL = Container.GetConnectionString();
 
         using var client = new AmazonS3Client(config);
 
@@ -117,7 +104,7 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
     {
         // Given
         var config = new AmazonSimpleNotificationServiceConfig();
-        config.ServiceURL = _localStackContainer.GetConnectionString();
+        config.ServiceURL = Container.GetConnectionString();
 
         using var client = new AmazonSimpleNotificationServiceClient(config);
 
@@ -136,7 +123,7 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
     {
         // Given
         var config = new AmazonSQSConfig();
-        config.ServiceURL = _localStackContainer.GetConnectionString();
+        config.ServiceURL = Container.GetConnectionString();
 
         using var client = new AmazonSQSClient(config);
 
@@ -151,17 +138,13 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
     [UsedImplicitly]
     public sealed class LocalStackDefaultConfiguration : LocalStackContainerTest
     {
-        public LocalStackDefaultConfiguration()
-            : base(new LocalStackBuilder().Build())
-        {
-        }
     }
 
     [UsedImplicitly]
     public sealed class LocalStackV1Configuration : LocalStackContainerTest
     {
         public LocalStackV1Configuration()
-            : base(new LocalStackBuilder().WithImage("localstack/localstack:1.4").Build())
+            : base(builder => builder.WithImage("localstack/localstack:1.4"))
         {
         }
     }

--- a/tests/Testcontainers.MariaDb.Tests/MariaDbContainerTest.cs
+++ b/tests/Testcontainers.MariaDb.Tests/MariaDbContainerTest.cs
@@ -1,22 +1,9 @@
 namespace Testcontainers.MariaDb;
 
-public abstract class MariaDbContainerTest : IAsyncLifetime
+public abstract class MariaDbContainerTest : ContainerTest<MariaDbBuilder, MariaDbContainer>
 {
-    private readonly MariaDbContainer _mariaDbContainer;
-
-    protected MariaDbContainerTest(MariaDbContainer mariaDbContainer)
+    protected MariaDbContainerTest(Action<MariaDbBuilder> configure = null) : base(configure)
     {
-        _mariaDbContainer = mariaDbContainer;
-    }
-
-    public Task InitializeAsync()
-    {
-        return _mariaDbContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _mariaDbContainer.DisposeAsync().AsTask();
     }
 
     [Fact]
@@ -24,7 +11,7 @@ public abstract class MariaDbContainerTest : IAsyncLifetime
     public void ConnectionStateReturnsOpen()
     {
         // Given
-        using DbConnection connection = new MySqlConnection(_mariaDbContainer.GetConnectionString());
+        using DbConnection connection = new MySqlConnection(Container.GetConnectionString());
 
         // When
         connection.Open();
@@ -41,7 +28,7 @@ public abstract class MariaDbContainerTest : IAsyncLifetime
         const string scriptContent = "SELECT 1;";
 
         // When
-        var execResult = await _mariaDbContainer.ExecScriptAsync(scriptContent)
+        var execResult = await Container.ExecScriptAsync(scriptContent)
             .ConfigureAwait(false);
 
         // When
@@ -51,17 +38,13 @@ public abstract class MariaDbContainerTest : IAsyncLifetime
     [UsedImplicitly]
     public sealed class MariaDbUserConfiguration : MariaDbContainerTest
     {
-        public MariaDbUserConfiguration()
-            : base(new MariaDbBuilder().Build())
-        {
-        }
     }
 
     [UsedImplicitly]
     public sealed class MariaDbRootConfiguration : MariaDbContainerTest
     {
         public MariaDbRootConfiguration()
-            : base(new MariaDbBuilder().WithUsername("root").Build())
+            : base(builder => builder.WithUsername("root"))
         {
         }
     }

--- a/tests/Testcontainers.MariaDb.Tests/Usings.cs
+++ b/tests/Testcontainers.MariaDb.Tests/Usings.cs
@@ -1,3 +1,4 @@
+global using System;
 global using System.Data;
 global using System.Data.Common;
 global using System.Threading.Tasks;

--- a/tests/Testcontainers.Minio.Tests/MinioContainerTest.cs
+++ b/tests/Testcontainers.Minio.Tests/MinioContainerTest.cs
@@ -1,28 +1,16 @@
 namespace Testcontainers.Minio;
 
-public sealed class MinioContainerTest : IAsyncLifetime
+public sealed class MinioContainerTest : ContainerTest<MinioBuilder, MinioContainer>
 {
-    private readonly MinioContainer _minioContainer = new MinioBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _minioContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _minioContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task ListBucketsReturnsHttpStatusCodeOk()
     {
         // Given
         var config = new AmazonS3Config();
-        config.ServiceURL = _minioContainer.GetConnectionString();
+        config.ServiceURL = Container.GetConnectionString();
 
-        using var client = new AmazonS3Client(_minioContainer.GetAccessKey(), _minioContainer.GetSecretKey(), config);
+        using var client = new AmazonS3Client(Container.GetAccessKey(), Container.GetSecretKey(), config);
 
         // When
         var buckets = await client.ListBucketsAsync()
@@ -40,9 +28,9 @@ public sealed class MinioContainerTest : IAsyncLifetime
         using var inputStream = new MemoryStream(new byte[byte.MaxValue]);
 
         var config = new AmazonS3Config();
-        config.ServiceURL = _minioContainer.GetConnectionString();
+        config.ServiceURL = Container.GetConnectionString();
 
-        using var client = new AmazonS3Client(_minioContainer.GetAccessKey(), _minioContainer.GetSecretKey(), config);
+        using var client = new AmazonS3Client(Container.GetAccessKey(), Container.GetSecretKey(), config);
 
         var objectRequest = new PutObjectRequest();
         objectRequest.BucketName = Guid.NewGuid().ToString("D");

--- a/tests/Testcontainers.MongoDb.Tests/Usings.cs
+++ b/tests/Testcontainers.MongoDb.Tests/Usings.cs
@@ -1,3 +1,4 @@
+global using System;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
 global using JetBrains.Annotations;

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -1,25 +1,13 @@
 namespace Testcontainers.MsSql;
 
-public sealed class MsSqlContainerTest : IAsyncLifetime
+public sealed class MsSqlContainerTest : ContainerTest<MsSqlBuilder, MsSqlContainer>
 {
-    private readonly MsSqlContainer _msSqlContainer = new MsSqlBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _msSqlContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _msSqlContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void ConnectionStateReturnsOpen()
     {
         // Given
-        using DbConnection connection = new SqlConnection(_msSqlContainer.GetConnectionString());
+        using DbConnection connection = new SqlConnection(Container.GetConnectionString());
 
         // When
         connection.Open();
@@ -36,7 +24,7 @@ public sealed class MsSqlContainerTest : IAsyncLifetime
         const string scriptContent = "SELECT 1;";
 
         // When
-        var execResult = await _msSqlContainer.ExecScriptAsync(scriptContent)
+        var execResult = await Container.ExecScriptAsync(scriptContent)
             .ConfigureAwait(false);
 
         // When

--- a/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
+++ b/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
@@ -1,22 +1,9 @@
 namespace Testcontainers.MySql;
 
-public abstract class MySqlContainerTest : IAsyncLifetime
+public abstract class MySqlContainerTest : ContainerTest<MySqlBuilder, MySqlContainer>
 {
-    private readonly MySqlContainer _mySqlContainer;
-
-    protected MySqlContainerTest(MySqlContainer mySqlContainer)
+    protected MySqlContainerTest(Action<MySqlBuilder> configure = null) : base(configure)
     {
-        _mySqlContainer = mySqlContainer;
-    }
-
-    public Task InitializeAsync()
-    {
-        return _mySqlContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _mySqlContainer.DisposeAsync().AsTask();
     }
 
     [Fact]
@@ -24,7 +11,7 @@ public abstract class MySqlContainerTest : IAsyncLifetime
     public void ConnectionStateReturnsOpen()
     {
         // Given
-        using DbConnection connection = new MySqlConnection(_mySqlContainer.GetConnectionString());
+        using DbConnection connection = new MySqlConnection(Container.GetConnectionString());
 
         // When
         connection.Open();
@@ -41,7 +28,7 @@ public abstract class MySqlContainerTest : IAsyncLifetime
         const string scriptContent = "SELECT 1;";
 
         // When
-        var execResult = await _mySqlContainer.ExecScriptAsync(scriptContent)
+        var execResult = await Container.ExecScriptAsync(scriptContent)
             .ConfigureAwait(false);
 
         // When
@@ -51,17 +38,13 @@ public abstract class MySqlContainerTest : IAsyncLifetime
     [UsedImplicitly]
     public sealed class MySqlUserConfiguration : MySqlContainerTest
     {
-        public MySqlUserConfiguration()
-            : base(new MySqlBuilder().Build())
-        {
-        }
     }
 
     [UsedImplicitly]
     public sealed class MySqlRootConfiguration : MySqlContainerTest
     {
         public MySqlRootConfiguration()
-            : base(new MySqlBuilder().WithUsername("root").Build())
+            : base(builder => builder.WithUsername("root"))
         {
         }
     }

--- a/tests/Testcontainers.MySql.Tests/Usings.cs
+++ b/tests/Testcontainers.MySql.Tests/Usings.cs
@@ -1,3 +1,4 @@
+global using System;
 global using System.Data;
 global using System.Data.Common;
 global using System.Threading.Tasks;

--- a/tests/Testcontainers.Neo4j.Tests/Neo4jContainerTest.cs
+++ b/tests/Testcontainers.Neo4j.Tests/Neo4jContainerTest.cs
@@ -1,19 +1,7 @@
 namespace Testcontainers.Neo4j;
 
-public sealed class Neo4jContainerTest : IAsyncLifetime
+public sealed class Neo4jContainerTest : ContainerTest<Neo4jBuilder, Neo4jContainer>
 {
-    private readonly Neo4jContainer _neo4jContainer = new Neo4jBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _neo4jContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _neo4jContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void SessionReturnsDatabase()
@@ -21,7 +9,7 @@ public sealed class Neo4jContainerTest : IAsyncLifetime
         // Given
         const string database = "neo4j";
 
-        using var driver = GraphDatabase.Driver(_neo4jContainer.GetConnectionString());
+        using var driver = GraphDatabase.Driver(Container.GetConnectionString());
 
         // When
         using var session = driver.AsyncSession(sessionConfigBuilder => sessionConfigBuilder.WithDatabase("neo4j"));

--- a/tests/Testcontainers.Oracle.Tests/OracleContainerTest.cs
+++ b/tests/Testcontainers.Oracle.Tests/OracleContainerTest.cs
@@ -1,25 +1,13 @@
 namespace Testcontainers.Oracle;
 
-public sealed class OracleContainerTest : IAsyncLifetime
+public sealed class OracleContainerTest : ContainerTest<OracleBuilder, OracleContainer>
 {
-    private readonly OracleContainer _oracleContainer = new OracleBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _oracleContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _oracleContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void ConnectionStateReturnsOpen()
     {
         // Given
-        using DbConnection connection = new OracleConnection(_oracleContainer.GetConnectionString());
+        using DbConnection connection = new OracleConnection(Container.GetConnectionString());
 
         // When
         connection.Open();
@@ -36,7 +24,7 @@ public sealed class OracleContainerTest : IAsyncLifetime
         const string scriptContent = "SELECT 1 FROM DUAL;";
 
         // When
-        var execResult = await _oracleContainer.ExecScriptAsync(scriptContent)
+        var execResult = await Container.ExecScriptAsync(scriptContent)
             .ConfigureAwait(false);
 
         // When

--- a/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
+++ b/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
@@ -1,25 +1,13 @@
 namespace Testcontainers.PostgreSql;
 
-public sealed class PostgreSqlContainerTest : IAsyncLifetime
+public sealed class PostgreSqlContainerTest : ContainerTest<PostgreSqlBuilder, PostgreSqlContainer>
 {
-    private readonly PostgreSqlContainer _postgreSqlContainer = new PostgreSqlBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _postgreSqlContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _postgreSqlContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void ConnectionStateReturnsOpen()
     {
         // Given
-        using DbConnection connection = new NpgsqlConnection(_postgreSqlContainer.GetConnectionString());
+        using DbConnection connection = new NpgsqlConnection(Container.GetConnectionString());
 
         // When
         connection.Open();
@@ -36,7 +24,7 @@ public sealed class PostgreSqlContainerTest : IAsyncLifetime
         const string scriptContent = "SELECT 1;";
 
         // When
-        var execResult = await _postgreSqlContainer.ExecScriptAsync(scriptContent)
+        var execResult = await Container.ExecScriptAsync(scriptContent)
             .ConfigureAwait(false);
 
         // When

--- a/tests/Testcontainers.RabbitMq.Tests/RabbitMqContainerTest.cs
+++ b/tests/Testcontainers.RabbitMq.Tests/RabbitMqContainerTest.cs
@@ -1,26 +1,14 @@
 namespace Testcontainers.RabbitMq;
 
-public sealed class RabbitMqContainerTest : IAsyncLifetime
+public sealed class RabbitMqContainerTest : ContainerTest<RabbitMqBuilder, RabbitMqContainer>
 {
-    private readonly RabbitMqContainer _rabbitMqContainer = new RabbitMqBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _rabbitMqContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _rabbitMqContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void IsOpenReturnsTrue()
     {
         // Given
         var connectionFactory = new ConnectionFactory();
-        connectionFactory.Uri = new Uri(_rabbitMqContainer.GetConnectionString());
+        connectionFactory.Uri = new Uri(Container.GetConnectionString());
 
         // When
         using var connection = connectionFactory.CreateConnection();

--- a/tests/Testcontainers.RavenDb.Tests/RavenDbContainerTest.cs
+++ b/tests/Testcontainers.RavenDb.Tests/RavenDbContainerTest.cs
@@ -1,26 +1,14 @@
 namespace Testcontainers.RavenDb;
 
-public sealed class RavenDbContainerTest : IAsyncLifetime
+public sealed class RavenDbContainerTest : ContainerTest<RavenDbBuilder, RavenDbContainer>
 {
-    private readonly RavenDbContainer _ravenDbContainer = new RavenDbBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _ravenDbContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _ravenDbContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void GetBuildNumberOperationReturnsBuildNumber()
     {
         // Given
         using var documentStore = new DocumentStore();
-        documentStore.Urls = new[] { _ravenDbContainer.GetConnectionString() };
+        documentStore.Urls = new[] { Container.GetConnectionString() };
         documentStore.Initialize();
 
         // When

--- a/tests/Testcontainers.Redis.Tests/RedisContainerTest.cs
+++ b/tests/Testcontainers.Redis.Tests/RedisContainerTest.cs
@@ -1,24 +1,12 @@
 namespace Testcontainers.Redis;
 
-public sealed class RedisContainerTest : IAsyncLifetime
+public sealed class RedisContainerTest : ContainerTest<RedisBuilder, RedisContainer>
 {
-    private readonly RedisContainer _redisContainer = new RedisBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _redisContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _redisContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void ConnectionStateReturnsOpen()
     {
-        using var connection = ConnectionMultiplexer.Connect(_redisContainer.GetConnectionString());
+        using var connection = ConnectionMultiplexer.Connect(Container.GetConnectionString());
         Assert.True(connection.IsConnected);
     }
 
@@ -30,7 +18,7 @@ public sealed class RedisContainerTest : IAsyncLifetime
         const string scriptContent = "return 'Hello, scripting!'";
 
         // When
-        var execResult = await _redisContainer.ExecScriptAsync(scriptContent)
+        var execResult = await Container.ExecScriptAsync(scriptContent)
             .ConfigureAwait(false);
 
         // When

--- a/tests/Testcontainers.Redpanda.Tests/RedpandaContainerTest.cs
+++ b/tests/Testcontainers.Redpanda.Tests/RedpandaContainerTest.cs
@@ -1,19 +1,7 @@
 namespace Testcontainers.Redpanda;
 
-public sealed class RedpandaContainerTest : IAsyncLifetime
+public sealed class RedpandaContainerTest : ContainerTest<RedpandaBuilder, RedpandaContainer>
 {
-    private readonly RedpandaContainer _redpandaContainer = new RedpandaBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _redpandaContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _redpandaContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task ConsumerReturnsProducerMessage()
@@ -21,7 +9,7 @@ public sealed class RedpandaContainerTest : IAsyncLifetime
         // Given
         const string topic = "sample";
 
-        var bootstrapServer = _redpandaContainer.GetBootstrapAddress();
+        var bootstrapServer = Container.GetBootstrapAddress();
 
         var producerConfig = new ProducerConfig();
         producerConfig.BootstrapServers = bootstrapServer;

--- a/tests/Testcontainers.SqlEdge.Tests/SqlEdgeContainerTest.cs
+++ b/tests/Testcontainers.SqlEdge.Tests/SqlEdgeContainerTest.cs
@@ -1,25 +1,13 @@
 namespace Testcontainers.SqlEdge;
 
-public sealed class SqlEdgeContainerTest : IAsyncLifetime
+public sealed class SqlEdgeContainerTest : ContainerTest<SqlEdgeBuilder, SqlEdgeContainer>
 {
-    private readonly SqlEdgeContainer _sqlEdgeContainer = new SqlEdgeBuilder().Build();
-
-    public Task InitializeAsync()
-    {
-        return _sqlEdgeContainer.StartAsync();
-    }
-
-    public Task DisposeAsync()
-    {
-        return _sqlEdgeContainer.DisposeAsync().AsTask();
-    }
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void ConnectionStateReturnsOpen()
     {
         // Given
-        using DbConnection connection = new SqlConnection(_sqlEdgeContainer.GetConnectionString());
+        using DbConnection connection = new SqlConnection(Container.GetConnectionString());
 
         // When
         connection.Open();


### PR DESCRIPTION
## What does this PR do?

This PR makes all container test classes inherit from a new abstract `ContainerTest<TBuilderEntity, TContainerEntity>` class that takes care of implementing the `IAsyncLifetime` interface for starting and disposing the container. This reduces boilerplate code in all test projects.

## Why is it important?

This removes code duplication, thus reducing maintenance. Also, adding a timeout when starting a container during the tests could now be performed at a single place (`ContainerTest.cs`) instead of at 24 different places.

## Related issues

PR #908 is somehow related in that it simplifies the maintenance of the tests but both PRs can be merged independently.
