### PR TITLE
feat: Add UsingHttpMessageHandler(HttpMessageHandler) to HttpWaitStrategy

### DIFF
--- a/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
@@ -36,6 +36,8 @@ namespace DotNet.Testcontainers.Configurations
 
     private ushort? _portNumber;
 
+    private HttpClientHandler _httpClientHandler;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="HttpWaitStrategy" /> class.
     /// </summary>
@@ -64,7 +66,7 @@ namespace DotNet.Testcontainers.Configurations
         return false;
       }
 
-      using (var httpClient = new HttpClient())
+      using (var httpClient = _httpClientHandler == null ? new HttpClient() : new HttpClient(_httpClientHandler))
       {
         using (var httpRequestMessage = new HttpRequestMessage(_httpMethod, new UriBuilder(_schemeName, host, port, _pathValue).Uri))
         {
@@ -192,6 +194,17 @@ namespace DotNet.Testcontainers.Configurations
     public HttpWaitStrategy UsingTls(bool tlsEnabled = true)
     {
       _schemeName = tlsEnabled ? Uri.UriSchemeHttps : Uri.UriSchemeHttp;
+      return this;
+    }
+
+    /// <summary>
+    /// Defines a custom <see cref="HttpClientHandler"/> to pass to the internal <see cref="HttpClient"/>.
+    /// </summary>
+    /// <param name="handler">The handler to pass to the <see cref="HttpClient"/> when it is created.</param>
+    /// <returns>A configured instance of <see cref="HttpWaitStrategy" />.</returns>
+    public HttpWaitStrategy UsingHttpClientHandler(HttpClientHandler handler)
+    {
+      _httpClientHandler = handler;
       return this;
     }
 

--- a/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
@@ -36,7 +36,7 @@ namespace DotNet.Testcontainers.Configurations
 
     private ushort? _portNumber;
 
-    private HttpClientHandler _httpClientHandler;
+    private HttpMessageHandler _httpMessageHandler;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HttpWaitStrategy" /> class.
@@ -66,7 +66,7 @@ namespace DotNet.Testcontainers.Configurations
         return false;
       }
 
-      using (var httpClient = new HttpClient(_httpClientHandler ?? new HttpClientHandler()))
+      using (var httpClient = new HttpClient(_httpMessageHandler ?? new HttpClientHandler()))
       {
         using (var httpRequestMessage = new HttpRequestMessage(_httpMethod, new UriBuilder(_schemeName, host, port, _pathValue).Uri))
         {
@@ -198,13 +198,13 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <summary>
-    /// Defines a custom <see cref="HttpClientHandler"/> which should be used by the internal <see cref="HttpClient"/>.
+    /// Defines a custom <see cref="HttpMessageHandler"/> which should be used by the internal <see cref="HttpClient"/>.
     /// </summary>
     /// <param name="handler">The handler to pass to the <see cref="HttpClient"/> when it is created.</param>
     /// <returns>A configured instance of <see cref="HttpWaitStrategy" />.</returns>
-    public HttpWaitStrategy UsingHttpClientHandler(HttpClientHandler handler)
+    public HttpWaitStrategy UsingHttpMessageHandler(HttpMessageHandler handler)
     {
-      _httpClientHandler = handler;
+      _httpMessageHandler = handler;
       return this;
     }
 

--- a/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
@@ -198,7 +198,7 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <summary>
-    /// Defines a custom <see cref="HttpClientHandler"/> to pass to the internal <see cref="HttpClient"/>.
+    /// Defines a custom <see cref="HttpClientHandler"/> which should be used by the internal <see cref="HttpClient"/>.
     /// </summary>
     /// <param name="handler">The handler to pass to the <see cref="HttpClient"/> when it is created.</param>
     /// <returns>A configured instance of <see cref="HttpWaitStrategy" />.</returns>

--- a/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
@@ -66,7 +66,7 @@ namespace DotNet.Testcontainers.Configurations
         return false;
       }
 
-      using (var httpClient = _httpClientHandler == null ? new HttpClient() : new HttpClient(_httpClientHandler))
+      using (var httpClient = new HttpClient(_httpClientHandler ?? new HttpClientHandler()))
       {
         using (var httpRequestMessage = new HttpRequestMessage(_httpMethod, new UriBuilder(_schemeName, host, port, _pathValue).Uri))
         {

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
@@ -90,7 +90,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var cookieContainer = new CookieContainer();
       cookieContainer.Add(new Cookie("Key1", "Value1", "/", _container.Hostname));
 
-      var httpWaitStrategy = new HttpWaitStrategy().UsingHttpClientHandler(new HttpClientHandler
+      var httpWaitStrategy = new HttpWaitStrategy().UsingHttpMessageHandler(new HttpClientHandler
       {
         CookieContainer = cookieContainer
       });


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability to pass a custom HttpClientHandler to the HttpWaitStrategy.

## Why is it important?

One reason for passing a custom HttpClientHandler would be the ability to tell the health checks to ignore or deviate from local proxy settings (often useful if tests are being executed on a build agent which sits behind a proxy, where the settings for that proxy get in the way of communicating with the container).
