### PR TITLE
fix: Add Docker Desktop (for Linux / macOS) authentication provider

### DIFF
--- a/src/Testcontainers/Builders/DockerDesktopEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/DockerDesktopEndpointAuthenticationProvider.cs
@@ -1,0 +1,100 @@
+﻿namespace DotNet.Testcontainers.Builders
+{
+  using System;
+  using System.Runtime.InteropServices;
+  using System.Text.Json;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Images;
+  using JetBrains.Annotations;
+
+  /// <inheritdoc cref="IDockerRegistryAuthenticationProvider" />
+  [PublicAPI]
+  internal sealed class DockerDesktopEndpointAuthenticationProvider : RootlessUnixEndpointAuthenticationProvider, ICustomConfiguration
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockerDesktopEndpointAuthenticationProvider" /> class.
+    /// </summary>
+    public DockerDesktopEndpointAuthenticationProvider()
+      : base(GetSocketPathFromHomeDesktopDir(), GetSocketPathFromHomeRunDir())
+    {
+    }
+
+    /// <inheritdoc />
+    public override bool IsApplicable()
+    {
+      return !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && DockerEngine != null;
+    }
+
+    /// <inheritdoc />
+    public string GetDockerConfig()
+    {
+      return null;
+    }
+
+    /// <inheritdoc />
+    public Uri GetDockerHost()
+    {
+      return null;
+    }
+
+    /// <inheritdoc />
+    public string GetDockerHostOverride()
+    {
+      return null;
+    }
+
+    /// <inheritdoc />
+    public string GetDockerSocketOverride()
+    {
+      return "/var/run/docker.sock";
+    }
+
+    /// <inheritdoc />
+    public JsonDocument GetDockerAuthConfig()
+    {
+      return null;
+    }
+
+    /// <inheritdoc />
+    public string GetDockerCertPath()
+    {
+      return null;
+    }
+
+    /// <inheritdoc />
+    public bool GetDockerTls()
+    {
+      return false;
+    }
+
+    /// <inheritdoc />
+    public bool GetDockerTlsVerify()
+    {
+      return false;
+    }
+
+    /// <inheritdoc />
+    public bool GetRyukDisabled()
+    {
+      return false;
+    }
+
+    /// <inheritdoc />
+    public bool GetRyukContainerPrivileged()
+    {
+      return false;
+    }
+
+    /// <inheritdoc />
+    public IImage GetRyukContainerImage()
+    {
+      return null;
+    }
+
+    /// <inheritdoc />
+    public string GetHubImageNamePrefix()
+    {
+      return null;
+    }
+  }
+}

--- a/src/Testcontainers/Builders/DockerDesktopEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/DockerDesktopEndpointAuthenticationProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Builders
+namespace DotNet.Testcontainers.Builders
 {
   using System;
   using System.Runtime.InteropServices;
@@ -46,6 +46,11 @@
     /// <inheritdoc />
     public string GetDockerSocketOverride()
     {
+      // Docker Desktop for Linux and macOS executes containers within a virtual
+      // machine. It is important to note that the socket path inside the VM differs
+      // from the socket path on the test host. In order to properly mount the
+      // appropriate socket to the Resource Reaper, we need to override it specifically
+      // for Docker Desktop.
       return "/var/run/docker.sock";
     }
 

--- a/src/Testcontainers/Builders/TestcontainersEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/TestcontainersEndpointAuthenticationProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Builders
+namespace DotNet.Testcontainers.Builders
 {
   using System;
   using System.Text.Json;
@@ -26,9 +26,8 @@
     /// Initializes a new instance of the <see cref="TestcontainersEndpointAuthenticationProvider" /> class.
     /// </summary>
     public TestcontainersEndpointAuthenticationProvider()
+      : this(new TestcontainersConfiguration())
     {
-      _customConfiguration = new TestcontainersConfiguration();
-      _dockerEngine = GetDockerHost();
     }
 
     /// <summary>
@@ -36,9 +35,14 @@
     /// </summary>
     /// <param name="lines">A list of Java properties file lines.</param>
     public TestcontainersEndpointAuthenticationProvider(params string[] lines)
+      : this(new TestcontainersConfiguration(lines))
     {
-      _customConfiguration = new TestcontainersConfiguration(lines);
-      _dockerEngine = GetDockerHost();
+    }
+
+    private TestcontainersEndpointAuthenticationProvider(ICustomConfiguration customConfiguration)
+    {
+      _customConfiguration = customConfiguration;
+      _dockerEngine = customConfiguration.GetDockerHost();
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/TestcontainersEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/TestcontainersEndpointAuthenticationProvider.cs
@@ -16,28 +16,28 @@
   /// Testcontainers Cloud if it is running.
   /// </summary>
   [PublicAPI]
-  internal sealed class TestcontainersHostEndpointAuthenticationProvider : DockerEndpointAuthenticationProvider, ICustomConfiguration
+  internal sealed class TestcontainersEndpointAuthenticationProvider : DockerEndpointAuthenticationProvider, ICustomConfiguration
   {
     private readonly ICustomConfiguration _customConfiguration;
 
     private readonly Uri _dockerEngine;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="TestcontainersHostEndpointAuthenticationProvider" /> class.
+    /// Initializes a new instance of the <see cref="TestcontainersEndpointAuthenticationProvider" /> class.
     /// </summary>
-    public TestcontainersHostEndpointAuthenticationProvider()
+    public TestcontainersEndpointAuthenticationProvider()
     {
-      _customConfiguration = new TestcontainersHostConfiguration();
+      _customConfiguration = new TestcontainersConfiguration();
       _dockerEngine = GetDockerHost();
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="TestcontainersHostEndpointAuthenticationProvider" /> class.
+    /// Initializes a new instance of the <see cref="TestcontainersEndpointAuthenticationProvider" /> class.
     /// </summary>
     /// <param name="lines">A list of Java properties file lines.</param>
-    public TestcontainersHostEndpointAuthenticationProvider(params string[] lines)
+    public TestcontainersEndpointAuthenticationProvider(params string[] lines)
     {
-      _customConfiguration = new TestcontainersHostConfiguration(lines);
+      _customConfiguration = new TestcontainersConfiguration(lines);
       _dockerEngine = GetDockerHost();
     }
 
@@ -125,13 +125,13 @@
       return _customConfiguration.GetHubImageNamePrefix();
     }
 
-    private sealed class TestcontainersHostConfiguration : PropertiesFileConfiguration
+    private sealed class TestcontainersConfiguration : PropertiesFileConfiguration
     {
-      public TestcontainersHostConfiguration()
+      public TestcontainersConfiguration()
       {
       }
 
-      public TestcontainersHostConfiguration(params string[] lines)
+      public TestcontainersConfiguration(params string[] lines)
         : base(lines)
       {
       }

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -25,12 +25,13 @@ namespace DotNet.Testcontainers.Configurations
     private static readonly IDockerEndpointAuthenticationProvider DockerEndpointAuthProvider =
       new IDockerEndpointAuthenticationProvider[]
         {
-          new TestcontainersHostEndpointAuthenticationProvider(),
+          new TestcontainersEndpointAuthenticationProvider(),
           new MTlsEndpointAuthenticationProvider(),
           new TlsEndpointAuthenticationProvider(),
           new EnvironmentEndpointAuthenticationProvider(),
           new NpipeEndpointAuthenticationProvider(),
           new UnixEndpointAuthenticationProvider(),
+          new DockerDesktopEndpointAuthenticationProvider(),
           new RootlessUnixEndpointAuthenticationProvider(),
         }
         .Where(authProvider => authProvider.IsApplicable())

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -223,7 +223,7 @@ namespace DotNet.Testcontainers.Containers
     {
       ThrowIfResourceNotFound();
 
-      if (_container.NetworkSettings.Ports.TryGetValue($"{containerPort}/tcp", out var portBindings) && ushort.TryParse(portBindings.First().HostPort, out var publicPort))
+      if (_container.NetworkSettings.Ports.TryGetValue($"{containerPort}/tcp", out var portBindings) && ushort.TryParse(portBindings.ElementAt(0).HostPort, out var publicPort))
       {
         return publicPort;
       }

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
@@ -51,14 +51,14 @@ namespace DotNet.Testcontainers.Tests.Unit
       [Fact]
       public void GetDockerHostOverrideReturnsNull()
       {
-        ICustomConfiguration customConfiguration = new TestcontainersHostEndpointAuthenticationProvider("host.override=host.docker.internal");
+        ICustomConfiguration customConfiguration = new TestcontainersEndpointAuthenticationProvider("host.override=host.docker.internal");
         Assert.Null(customConfiguration.GetDockerHostOverride());
       }
 
       [Fact]
       public void GetDockerSocketOverrideReturnsNull()
       {
-        ICustomConfiguration customConfiguration = new TestcontainersHostEndpointAuthenticationProvider("docker.socket.override=/var/run/docker.sock");
+        ICustomConfiguration customConfiguration = new TestcontainersEndpointAuthenticationProvider("docker.socket.override=/var/run/docker.sock");
         Assert.Null(customConfiguration.GetDockerSocketOverride());
       }
     }
@@ -84,8 +84,8 @@ namespace DotNet.Testcontainers.Tests.Unit
         Add(new object[] { new EnvironmentEndpointAuthenticationProvider(defaultConfiguration, DockerHostConfiguration), true });
         Add(new object[] { new NpipeEndpointAuthenticationProvider(), RuntimeInformation.IsOSPlatform(OSPlatform.Windows) });
         Add(new object[] { new UnixEndpointAuthenticationProvider(), !RuntimeInformation.IsOSPlatform(OSPlatform.Windows) });
-        Add(new object[] { new TestcontainersHostEndpointAuthenticationProvider(string.Empty), false });
-        Add(new object[] { new TestcontainersHostEndpointAuthenticationProvider("tc.host=" + DockerHost), true });
+        Add(new object[] { new TestcontainersEndpointAuthenticationProvider(string.Empty), false });
+        Add(new object[] { new TestcontainersEndpointAuthenticationProvider("tc.host=" + DockerHost), true });
       }
     }
 
@@ -97,7 +97,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         Add(new object[] { new EnvironmentEndpointAuthenticationProvider(DockerHostConfiguration).GetAuthConfig(), new Uri(DockerHost) });
         Add(new object[] { new NpipeEndpointAuthenticationProvider().GetAuthConfig(), new Uri("npipe://./pipe/docker_engine") });
         Add(new object[] { new UnixEndpointAuthenticationProvider().GetAuthConfig(), new Uri("unix:///var/run/docker.sock") });
-        Add(new object[] { new TestcontainersHostEndpointAuthenticationProvider("tc.host=" + DockerHost).GetAuthConfig(), new Uri(DockerHost) });
+        Add(new object[] { new TestcontainersEndpointAuthenticationProvider("tc.host=" + DockerHost).GetAuthConfig(), new Uri(DockerHost) });
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Adds a new Docker endpoint authentication provider specifically for Docker Desktop for Linux and macOS. 

## Why is it important?

Docker Desktop (for Linux / macOS) no longer create the Docker daemon socket at the default location `/var/run/docker.sock`. Instead, the socket is created in the user's home directory (e.g. `$HOME/.docker/run/docker.sock`). Due to Docker Desktop running inside a virtual machine, we are unable to obtain the socket path required for mounting into moby-ryuk from the host. In case of Docker Desktop, the path inside the VM is still `/var/run/docker.sock`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #890

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
