### PR TITLE
docs: Update Testcontainers for Java docs url

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Debug.Assert(Guid.TryParse(guid, out _));
   <strong>Not using .NET? Here are other supported languages!</strong>
 </p>
 <div class="card-grid">
-  <a class="card-grid-item" href="https://www.testcontainers.org">
+  <a class="card-grid-item" href="https://java.testcontainers.org">
     <img src="language-logos/java.svg" />Java
   </a>
   <a class="card-grid-item" href="https://golang.testcontainers.org">
@@ -98,5 +98,5 @@ Join our [Slack workspace][slack-workspace] | [Testcontainers OSS][testcontainer
 [windows-container-version-compatibility]: https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility
 [testcontainers-dotnet-contributors]: https://github.com/testcontainers/testcontainers-dotnet/graphs/contributors/
 [slack-workspace]: https://slack.testcontainers.org/
-[testcontainers-oss]: https://www.testcontainers.org/
+[testcontainers-oss]: https://java.testcontainers.org/
 [testcontainers-cloud]: https://www.testcontainers.cloud/

--- a/docs/index.md
+++ b/docs/index.md
@@ -98,5 +98,5 @@ Join our [Slack workspace][slack-workspace] | [Testcontainers OSS][testcontainer
 [windows-container-version-compatibility]: https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/version-compatibility
 [testcontainers-dotnet-contributors]: https://github.com/testcontainers/testcontainers-dotnet/graphs/contributors/
 [slack-workspace]: https://slack.testcontainers.org/
-[testcontainers-oss]: https://java.testcontainers.org/
+[testcontainers-oss]: https://www.testcontainers.org/
 [testcontainers-cloud]: https://www.testcontainers.cloud/


### PR DESCRIPTION
## What does this PR do?
This updates the domain of the Java docs in any links in the docs. 

## Why is it important?
The Java docs are migrating subdomain from `www` to `java`. 
