### PR TITLE
chore: Set ContinuousIntegrationBuild and EmbedUntrackedSources MSBuild propery

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -135,8 +135,8 @@ Task("Create-NuGet-Packages")
     SymbolPackageFormat = "snupkg",
     OutputDirectory = param.Paths.Directories.NuGetDirectoryPath,
     ArgumentCustomization = args => args
-      .Append($"/p:ContinuousIntegrationBuild=true")
-      .Append($"/p:EmbedUntrackedSources=true")
+      .Append("/p:ContinuousIntegrationBuild=true")
+      .Append("/p:EmbedUntrackedSources=true")
       .Append($"/p:Version={param.Version}")
   });
 });

--- a/build.cake
+++ b/build.cake
@@ -132,9 +132,11 @@ Task("Create-NuGet-Packages")
     NoRestore = true,
     NoBuild = true,
     IncludeSymbols = true,
+    SymbolPackageFormat = "snupkg",
     OutputDirectory = param.Paths.Directories.NuGetDirectoryPath,
     ArgumentCustomization = args => args
-      .Append("/p:SymbolPackageFormat=snupkg")
+      .Append($"/p:ContinuousIntegrationBuild=true")
+      .Append($"/p:EmbedUntrackedSources=true")
       .Append($"/p:Version={param.Version}")
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds the MSBuild flags `ContinuousIntegrationBuild` and `EmbedUntrackedSources`.

## Why is it important?

To fulfill the NuGet information [health](https://nuget.info/packages/Testcontainers/3.2.0) check.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
