### PR TITLE
fix: Ensure site_url is set in the MkDocs config to prevent <loc>None</loc> in sitemap generation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Testcontainers for .NET
+site_url: https://dotnet.testcontainers.org
 repo_name: testcontainers-dotnet
 repo_url: https://github.com/testcontainers/testcontainers-dotnet
 edit_uri: edit/develop/docs/


### PR DESCRIPTION
## What does this do
Fix a bug with the documentation generating a sitemap with `<loc>None</loc>` seamingly caused by not having `site_url` set in the mkdocs config.

e.g. 
```xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>None</loc>
    <lastmod>2023-06-15</lastmod>
    <changefreq>daily</changefreq>
  </url>
  ...
</urlset>
```

## Why this is important
Search engines and other tools use the sitemap. Presenting correct information is important for discoverability of the documentation.