### PR TITLE
chore: Add DebugLogLevelEnabled property to default logger implementation

### DIFF
--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -256,12 +256,6 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    public TBuilderEntity WithNetwork(string id, string name)
-    {
-      return WithNetwork(name);
-    }
-
-    /// <inheritdoc />
     public TBuilderEntity WithNetwork(string name)
     {
       var network = new FromExistingNetwork().WithName(name).Build();

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -102,13 +102,13 @@ namespace DotNet.Testcontainers.Clients
 
     public Task ExtractArchiveToContainerAsync(string id, string path, Stream tarStream, CancellationToken ct = default)
     {
-      _logger.ExtractArchiveToDockerContainer(id, path);
+      _logger.CopyArchiveToDockerContainer(id, path);
       return Docker.Containers.ExtractArchiveToContainerAsync(id, new ContainerPathStatParameters { Path = path, AllowOverwriteDirWithFile = false }, tarStream, ct);
     }
 
     public async Task<Stream> GetArchiveFromContainerAsync(string id, string path, CancellationToken ct = default)
     {
-      _logger.GetArchiveFromDockerContainer(id, path);
+      _logger.ReadArchiveFromDockerContainer(id, path);
 
       var tarResponse = await Docker.Containers.GetArchiveFromContainerAsync(id, new GetArchiveFromContainerParameters { Path = path }, false, ct)
         .ConfigureAwait(false);

--- a/src/Testcontainers/Clients/TraceProgress.cs
+++ b/src/Testcontainers/Clients/TraceProgress.cs
@@ -19,17 +19,17 @@ namespace DotNet.Testcontainers.Clients
 
       if (!string.IsNullOrWhiteSpace(value.Status))
       {
-        _logger.LogTrace(value.Status);
+        _logger.LogDebug(value.Status);
       }
 
       if (!string.IsNullOrWhiteSpace(value.Stream))
       {
-        _logger.LogTrace(value.Stream);
+        _logger.LogDebug(value.Stream);
       }
 
       if (!string.IsNullOrWhiteSpace(value.ProgressMessage))
       {
-        _logger.LogTrace(value.ProgressMessage);
+        _logger.LogDebug(value.ProgressMessage);
       }
 
       if (!string.IsNullOrWhiteSpace(value.ErrorMessage))

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -1,6 +1,7 @@
 namespace DotNet.Testcontainers.Configurations
 {
   using System;
+  using System.Collections.Generic;
   using System.Globalization;
   using System.Linq;
   using System.Runtime.InteropServices;
@@ -184,12 +185,16 @@ namespace DotNet.Testcontainers.Configurations
       => ManualResetEvent.WaitHandle;
 
     /// <inheritdoc cref="PortForwardingContainer.ExposeHostPortsAsync" />
-    public static async Task ExposeHostPortsAsync(params ushort[] ports)
+    public static Task ExposeHostPortsAsync(ushort port, CancellationToken ct = default)
+      => ExposeHostPortsAsync(new[] { port }, ct);
+
+    /// <inheritdoc cref="PortForwardingContainer.ExposeHostPortsAsync" />
+    public static async Task ExposeHostPortsAsync(IEnumerable<ushort> ports, CancellationToken ct = default)
     {
-      await PortForwardingContainer.Instance.StartAsync()
+      await PortForwardingContainer.Instance.StartAsync(ct)
         .ConfigureAwait(false);
 
-      await PortForwardingContainer.Instance.ExposeHostPortsAsync(ports)
+      await PortForwardingContainer.Instance.ExposeHostPortsAsync(ports, ct)
         .ConfigureAwait(false);
     }
   }

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -167,7 +167,7 @@ namespace DotNet.Testcontainers.Configurations
     /// </summary>
     [NotNull]
     public static ILogger Logger { get; set; }
-      = new Logger();
+      = ConsoleLogger.Instance;
 
     /// <summary>
     /// Gets or sets the host operating system.

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -450,8 +450,6 @@ namespace DotNet.Testcontainers.Containers
 
       Logger.CompleteReadinessCheck(_container.ID);
 
-      Started?.Invoke(this, EventArgs.Empty);
-
       if (TestcontainersStates.Exited.Equals(State))
       {
         var exitCode = await GetExitCodeAsync(ct)
@@ -464,7 +462,11 @@ namespace DotNet.Testcontainers.Containers
 
           Logger.LogError(stderr);
         }
+
+        return;
       }
+
+      Started?.Invoke(this, EventArgs.Empty);
     }
 
     /// <summary>

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -451,6 +451,20 @@ namespace DotNet.Testcontainers.Containers
       Logger.CompleteReadinessCheck(_container.ID);
 
       Started?.Invoke(this, EventArgs.Empty);
+
+      if (TestcontainersStates.Exited.Equals(State))
+      {
+        var exitCode = await GetExitCodeAsync(ct)
+          .ConfigureAwait(false);
+
+        if (exitCode > 0)
+        {
+          var (_, stderr) = await GetLogsAsync(timestampsEnabled: false, ct: ct)
+            .ConfigureAwait(false);
+
+          Logger.LogError(stderr);
+        }
+      }
     }
 
     /// <summary>

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -440,11 +440,15 @@ namespace DotNet.Testcontainers.Containers
       await _configuration.StartupCallback(this, ct)
         .ConfigureAwait(false);
 
+      Logger.StartReadinessCheck(_container.ID);
+
       foreach (var waitStrategy in _configuration.WaitStrategies)
       {
         await WaitStrategy.WaitUntilAsync(() => CheckWaitStrategyAsync(waitStrategy), TimeSpan.FromSeconds(1), Timeout.InfiniteTimeSpan, ct)
           .ConfigureAwait(false);
       }
+
+      Logger.CompleteReadinessCheck(_container.ID);
 
       Started?.Invoke(this, EventArgs.Empty);
     }

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -450,22 +450,6 @@ namespace DotNet.Testcontainers.Containers
 
       Logger.CompleteReadinessCheck(_container.ID);
 
-      if (TestcontainersStates.Exited.Equals(State))
-      {
-        var exitCode = await GetExitCodeAsync(ct)
-          .ConfigureAwait(false);
-
-        if (exitCode > 0)
-        {
-          var (_, stderr) = await GetLogsAsync(timestampsEnabled: false, ct: ct)
-            .ConfigureAwait(false);
-
-          Logger.LogError(stderr);
-        }
-
-        return;
-      }
-
       Started?.Invoke(this, EventArgs.Empty);
     }
 

--- a/src/Testcontainers/Containers/PortForwarding.cs
+++ b/src/Testcontainers/Containers/PortForwarding.cs
@@ -1,7 +1,9 @@
 namespace DotNet.Testcontainers.Containers
 {
+  using System.Collections.Generic;
   using System.Linq;
   using System.Net;
+  using System.Threading;
   using System.Threading.Tasks;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Builders;
@@ -41,8 +43,9 @@ namespace DotNet.Testcontainers.Containers
     /// Exposes the host ports using SSH port forwarding.
     /// </summary>
     /// <param name="ports">The host ports to forward.</param>
+    /// <param name="ct">Cancellation token.</param>
     /// <returns>A task that completes when the host ports are forwarded.</returns>
-    public Task ExposeHostPortsAsync(params ushort[] ports)
+    public Task ExposeHostPortsAsync(IEnumerable<ushort> ports, CancellationToken ct = default)
     {
       var sshClient = new SshClient(Hostname, GetMappedPublicPort(PortForwardingBuilder.SshdPort), _configuration.Username, _configuration.Password);
       sshClient.Connect();

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -25,6 +25,12 @@ namespace DotNet.Testcontainers
     private static readonly Action<ILogger, string, Exception> _DeleteDockerContainer
       = LoggerMessage.Define<string>(LogLevel.Information, default, "Delete Docker container {Id}");
 
+    private static readonly Action<ILogger, string, Exception> _StartReadinessCheck
+      = LoggerMessage.Define<string>(LogLevel.Information, default, "Wait for Docker container {Id} to complete readiness checks");
+
+    private static readonly Action<ILogger, string, Exception> _CompleteReadinessCheck
+      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker container {Id} is ready");
+
     private static readonly Action<ILogger, string, string, Exception> _ExtractArchiveToDockerContainer
       = LoggerMessage.Define<string, string>(LogLevel.Information, default, "Copy tar archive to \"{Path}\" at Docker container {Id}");
 
@@ -91,47 +97,57 @@ namespace DotNet.Testcontainers
 
     public static void DockerContainerCreated(this ILogger logger, string id)
     {
-      _DockerContainerCreated(logger, id, null);
+      _DockerContainerCreated(logger, TruncResourceId(id), null);
     }
 
     public static void StartDockerContainer(this ILogger logger, string id)
     {
-      _StartDockerContainer(logger, id, null);
+      _StartDockerContainer(logger, TruncResourceId(id), null);
     }
 
     public static void StopDockerContainer(this ILogger logger, string id)
     {
-      _StopDockerContainer(logger, id, null);
+      _StopDockerContainer(logger, TruncResourceId(id), null);
     }
 
     public static void DeleteDockerContainer(this ILogger logger, string id)
     {
-      _DeleteDockerContainer(logger, id, null);
+      _DeleteDockerContainer(logger, TruncResourceId(id), null);
+    }
+
+    public static void StartReadinessCheck(this ILogger logger, string id)
+    {
+      _StartReadinessCheck(logger, TruncResourceId(id), null);
+    }
+
+    public static void CompleteReadinessCheck(this ILogger logger, string id)
+    {
+      _CompleteReadinessCheck(logger, TruncResourceId(id), null);
     }
 
     public static void ExtractArchiveToDockerContainer(this ILogger logger, string id, string path)
     {
-      _ExtractArchiveToDockerContainer(logger, path, id, null);
+      _ExtractArchiveToDockerContainer(logger, path, TruncResourceId(id), null);
     }
 
     public static void GetArchiveFromDockerContainer(this ILogger logger, string id, string path)
     {
-      _GetArchiveFromDockerContainer(logger, path, id, null);
+      _GetArchiveFromDockerContainer(logger, path, TruncResourceId(id), null);
     }
 
     public static void AttachToDockerContainer(this ILogger logger, string id, Type type)
     {
-      _AttachToDockerContainer(logger, type, id, null);
+      _AttachToDockerContainer(logger, type, TruncResourceId(id), null);
     }
 
     public static void ConnectToDockerNetwork(this ILogger logger, string networkId, string containerId)
     {
-      _ConnectToDockerNetwork(logger, containerId, networkId, null);
+      _ConnectToDockerNetwork(logger, TruncResourceId(containerId), TruncResourceId(networkId), null);
     }
 
     public static void ExecuteCommandInDockerContainer(this ILogger logger, string id, IEnumerable<string> command)
     {
-      _ExecuteCommandInDockerContainer(logger, string.Join(" ", command), id, null);
+      _ExecuteCommandInDockerContainer(logger, string.Join(" ", command), TruncResourceId(id), null);
     }
 
     public static void DockerImageCreated(this ILogger logger, IImage image)
@@ -151,12 +167,12 @@ namespace DotNet.Testcontainers
 
     public static void DockerNetworkCreated(this ILogger logger, string id)
     {
-      _DockerNetworkCreated(logger, id, null);
+      _DockerNetworkCreated(logger, TruncResourceId(id), null);
     }
 
     public static void DeleteDockerNetwork(this ILogger logger, string id)
     {
-      _DeleteDockerNetwork(logger, id, null);
+      _DeleteDockerNetwork(logger, TruncResourceId(id), null);
     }
 
     public static void DockerVolumeCreated(this ILogger logger, string name)
@@ -204,6 +220,11 @@ namespace DotNet.Testcontainers
     public static void DockerRegistryCredentialFound(this ILogger logger, string dockerRegistry)
     {
       _DockerRegistryCredentialFound(logger, dockerRegistry, null);
+    }
+
+    private static string TruncResourceId(string id)
+    {
+      return id.Substring(0, Math.Min(12, id.Length));
     }
   }
 }

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -97,57 +97,57 @@ namespace DotNet.Testcontainers
 
     public static void DockerContainerCreated(this ILogger logger, string id)
     {
-      _DockerContainerCreated(logger, TruncResourceId(id), null);
+      _DockerContainerCreated(logger, TruncId(id), null);
     }
 
     public static void StartDockerContainer(this ILogger logger, string id)
     {
-      _StartDockerContainer(logger, TruncResourceId(id), null);
+      _StartDockerContainer(logger, TruncId(id), null);
     }
 
     public static void StopDockerContainer(this ILogger logger, string id)
     {
-      _StopDockerContainer(logger, TruncResourceId(id), null);
+      _StopDockerContainer(logger, TruncId(id), null);
     }
 
     public static void DeleteDockerContainer(this ILogger logger, string id)
     {
-      _DeleteDockerContainer(logger, TruncResourceId(id), null);
+      _DeleteDockerContainer(logger, TruncId(id), null);
     }
 
     public static void StartReadinessCheck(this ILogger logger, string id)
     {
-      _StartReadinessCheck(logger, TruncResourceId(id), null);
+      _StartReadinessCheck(logger, TruncId(id), null);
     }
 
     public static void CompleteReadinessCheck(this ILogger logger, string id)
     {
-      _CompleteReadinessCheck(logger, TruncResourceId(id), null);
+      _CompleteReadinessCheck(logger, TruncId(id), null);
     }
 
     public static void CopyArchiveToDockerContainer(this ILogger logger, string id, string path)
     {
-      _CopyArchiveToDockerContainer(logger, path, TruncResourceId(id), null);
+      _CopyArchiveToDockerContainer(logger, path, TruncId(id), null);
     }
 
     public static void ReadArchiveFromDockerContainer(this ILogger logger, string id, string path)
     {
-      _ReadArchiveFromDockerContainer(logger, path, TruncResourceId(id), null);
+      _ReadArchiveFromDockerContainer(logger, path, TruncId(id), null);
     }
 
     public static void AttachToDockerContainer(this ILogger logger, string id, Type type)
     {
-      _AttachToDockerContainer(logger, type, TruncResourceId(id), null);
+      _AttachToDockerContainer(logger, type, TruncId(id), null);
     }
 
     public static void ConnectToDockerNetwork(this ILogger logger, string networkId, string containerId)
     {
-      _ConnectToDockerNetwork(logger, TruncResourceId(containerId), TruncResourceId(networkId), null);
+      _ConnectToDockerNetwork(logger, TruncId(containerId), TruncId(networkId), null);
     }
 
     public static void ExecuteCommandInDockerContainer(this ILogger logger, string id, IEnumerable<string> command)
     {
-      _ExecuteCommandInDockerContainer(logger, string.Join(" ", command), TruncResourceId(id), null);
+      _ExecuteCommandInDockerContainer(logger, string.Join(" ", command), TruncId(id), null);
     }
 
     public static void DockerImageCreated(this ILogger logger, IImage image)
@@ -167,12 +167,12 @@ namespace DotNet.Testcontainers
 
     public static void DockerNetworkCreated(this ILogger logger, string id)
     {
-      _DockerNetworkCreated(logger, TruncResourceId(id), null);
+      _DockerNetworkCreated(logger, TruncId(id), null);
     }
 
     public static void DeleteDockerNetwork(this ILogger logger, string id)
     {
-      _DeleteDockerNetwork(logger, TruncResourceId(id), null);
+      _DeleteDockerNetwork(logger, TruncId(id), null);
     }
 
     public static void DockerVolumeCreated(this ILogger logger, string name)
@@ -222,7 +222,7 @@ namespace DotNet.Testcontainers
       _DockerRegistryCredentialFound(logger, dockerRegistry, null);
     }
 
-    private static string TruncResourceId(string id)
+    private static string TruncId(string id)
     {
       return id.Substring(0, Math.Min(12, id.Length));
     }

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -31,10 +31,10 @@ namespace DotNet.Testcontainers
     private static readonly Action<ILogger, string, Exception> _CompleteReadinessCheck
       = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker container {Id} ready");
 
-    private static readonly Action<ILogger, string, string, Exception> _ExtractArchiveToDockerContainer
-      = LoggerMessage.Define<string, string>(LogLevel.Information, default, "Copy tar archive to \"{Path}\" at Docker container {Id}");
+    private static readonly Action<ILogger, string, string, Exception> _CopyArchiveToDockerContainer
+      = LoggerMessage.Define<string, string>(LogLevel.Information, default, "Copy tar archive to \"{Path}\" to Docker container {Id}");
 
-    private static readonly Action<ILogger, string, string, Exception> _GetArchiveFromDockerContainer
+    private static readonly Action<ILogger, string, string, Exception> _ReadArchiveFromDockerContainer
       = LoggerMessage.Define<string, string>(LogLevel.Information, default, "Read \"{Path}\" from Docker container {Id}");
 
     private static readonly Action<ILogger, Type, string, Exception> _AttachToDockerContainer
@@ -125,14 +125,14 @@ namespace DotNet.Testcontainers
       _CompleteReadinessCheck(logger, TruncResourceId(id), null);
     }
 
-    public static void ExtractArchiveToDockerContainer(this ILogger logger, string id, string path)
+    public static void CopyArchiveToDockerContainer(this ILogger logger, string id, string path)
     {
-      _ExtractArchiveToDockerContainer(logger, path, TruncResourceId(id), null);
+      _CopyArchiveToDockerContainer(logger, path, TruncResourceId(id), null);
     }
 
-    public static void GetArchiveFromDockerContainer(this ILogger logger, string id, string path)
+    public static void ReadArchiveFromDockerContainer(this ILogger logger, string id, string path)
     {
-      _GetArchiveFromDockerContainer(logger, path, TruncResourceId(id), null);
+      _ReadArchiveFromDockerContainer(logger, path, TruncResourceId(id), null);
     }
 
     public static void AttachToDockerContainer(this ILogger logger, string id, Type type)

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -29,7 +29,7 @@ namespace DotNet.Testcontainers
       = LoggerMessage.Define<string>(LogLevel.Information, default, "Wait for Docker container {Id} to complete readiness checks");
 
     private static readonly Action<ILogger, string, Exception> _CompleteReadinessCheck
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker container {Id} is ready");
+      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker container {Id} ready");
 
     private static readonly Action<ILogger, string, string, Exception> _ExtractArchiveToDockerContainer
       = LoggerMessage.Define<string, string>(LogLevel.Information, default, "Copy tar archive to \"{Path}\" at Docker container {Id}");


### PR DESCRIPTION
## What does this PR do?

The pull request introduces a new member `DebugLogLevelEnabled`. This member allows developers to enable or disable (default) the debug log level for the default logger. By using this, developers can access the debug logs without the need to create or configure a new logger.

## Why is it important?

If developers only require access to the debug logs, it becomes simpler for them to obtain them.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
