### PR TITLE
fix: Use the actual Docker endpoint to extract the socket path for the Resource Reaper

### DIFF
--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -23,8 +23,8 @@ namespace DotNet.Testcontainers.Configurations
     private static readonly ManualResetEventSlim ManualResetEvent = new ManualResetEventSlim(false);
 
     [CanBeNull]
-    private static readonly IDockerEndpointAuthenticationProvider DockerEndpointAuthProvider =
-      new IDockerEndpointAuthenticationProvider[]
+    private static readonly IDockerEndpointAuthenticationProvider DockerEndpointAuthProvider
+      = new IDockerEndpointAuthenticationProvider[]
         {
           new TestcontainersEndpointAuthenticationProvider(),
           new MTlsEndpointAuthenticationProvider(),
@@ -39,8 +39,8 @@ namespace DotNet.Testcontainers.Configurations
         .FirstOrDefault(authProvider => authProvider.IsAvailable());
 
     [CanBeNull]
-    private static readonly IDockerEndpointAuthenticationConfiguration DockerEndpointAuthConfig =
-      DockerEndpointAuthProvider?.GetAuthConfig();
+    private static readonly IDockerEndpointAuthenticationConfiguration DockerEndpointAuthConfig
+      = DockerEndpointAuthProvider?.GetAuthConfig();
 
     static TestcontainersSettings()
     {


### PR DESCRIPTION
## What does this PR do?

Instead of relying on the automatically discovered Docker endpoint to retrieve the Docker socket, the pull request utilizes the actual Docker endpoint. If the auto-discovery mechanism fails to detect a Docker endpoint and the user manually configures the Docker endpoint using the builder API, Testcontainers will encounter a null reference exception during runtime.

## Why is it important?

The fix is significant because it allows the support of test environments where the auto-discovery mechanism cannot detect a Docker endpoint (although this is not recommended).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #929

## How to test this PR

@paule96 Would it be possible for you to test the fix and see if it resolves the issue? It is a bit challenging to set up a test in CI due to the required remote Docker endpoint, etc.

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
