### PR TITLE
feat: Support coping directories using WithResourceMapping(string, string)

### DIFF
--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -29,7 +29,7 @@ _ = new ContainerBuilder()
   .WithEnvironment("ASPNETCORE_URLS", "https://+")
   .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Path", "/app/certificate.crt")
   .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Password", "password")
-  .WithResourceMapping("certificate.crt", "/app/certificate.crt");
+  .WithResourceMapping("certificate.crt", "/app/");
 ```
 
 `WithBindMount(string, string)` is another option to provide access to directories or files. It mounts a host directory or file into the container. Note, this does not follow our best practices. Host paths differ between environments and may not be available on every system or Docker setup, e.g. CI.

--- a/src/Testcontainers.WebDriver/WebDriverBuilder.cs
+++ b/src/Testcontainers.WebDriver/WebDriverBuilder.cs
@@ -64,7 +64,7 @@ public sealed class WebDriverBuilder : ContainerBuilder<WebDriverBuilder, WebDri
     /// <returns>A configured instance of <see cref="WebDriverBuilder" />.</returns>
     public WebDriverBuilder WithConfigurationFromTomlFile(string configTomlFilePath)
     {
-        return WithResourceMapping(configTomlFilePath, "/opt/bin/config.toml");
+        return WithResourceMapping(File.ReadAllBytes(configTomlFilePath), "/opt/bin/config.toml");
     }
 
     /// <summary>

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -213,6 +213,19 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
+    public TBuilderEntity WithResourceMapping(FileInfo source, FileInfo target, UnixFileModes fileMode = Unix.FileMode644)
+    {
+      using (var fileStream = File.Open(source.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+      {
+        using (var streamReader = new BinaryReader(fileStream))
+        {
+          var resourceContent = streamReader.ReadBytes((int)streamReader.BaseStream.Length);
+          return WithResourceMapping(new BinaryResourceMapping(resourceContent, target.ToString(), fileMode));
+        }
+      }
+    }
+
+    /// <inheritdoc />
     public TBuilderEntity WithMount(IMount mount)
     {
       var mounts = new[] { mount };

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -189,21 +189,27 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    public TBuilderEntity WithResourceMapping(byte[] resourceContent, string target)
+    public TBuilderEntity WithResourceMapping(byte[] resourceContent, string filePath, UnixFileModes fileMode = Unix.FileMode644)
     {
-      return WithResourceMapping(new BinaryResourceMapping(resourceContent, target));
+      return WithResourceMapping(new BinaryResourceMapping(resourceContent, filePath, fileMode));
     }
 
     /// <inheritdoc />
-    public TBuilderEntity WithResourceMapping(string source, string target)
+    public TBuilderEntity WithResourceMapping(string source, string target, UnixFileModes fileMode = Unix.FileMode644)
     {
-      return WithResourceMapping(new FileResourceMapping(source, target));
+      return WithResourceMapping(new FileResourceMapping(source, target, fileMode));
     }
 
     /// <inheritdoc />
-    public TBuilderEntity WithResourceMapping(FileSystemInfo source, string target)
+    public TBuilderEntity WithResourceMapping(DirectoryInfo source, string target, UnixFileModes fileMode = Unix.FileMode644)
     {
-      return WithResourceMapping(source.FullName, target);
+      return WithResourceMapping(source.FullName, target, fileMode);
+    }
+
+    /// <inheritdoc />
+    public TBuilderEntity WithResourceMapping(FileInfo source, string target, UnixFileModes fileMode = Unix.FileMode644)
+    {
+      return WithResourceMapping(source.FullName, target, fileMode);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -3,6 +3,7 @@ namespace DotNet.Testcontainers.Builders
   using System;
   using System.Collections.Generic;
   using System.Globalization;
+  using System.IO;
   using System.Linq;
   using System.Threading;
   using System.Threading.Tasks;
@@ -181,22 +182,28 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    public TBuilderEntity WithResourceMapping(string source, string destination)
-    {
-      return WithResourceMapping(new FileResourceMapping(source, destination));
-    }
-
-    /// <inheritdoc />
-    public TBuilderEntity WithResourceMapping(byte[] resourceContent, string destination)
-    {
-      return WithResourceMapping(new BinaryResourceMapping(resourceContent, destination));
-    }
-
-    /// <inheritdoc />
     public TBuilderEntity WithResourceMapping(IResourceMapping resourceMapping)
     {
       var resourceMappings = new Dictionary<string, IResourceMapping> { { resourceMapping.Target, resourceMapping } };
       return Clone(new ContainerConfiguration(resourceMappings: resourceMappings));
+    }
+
+    /// <inheritdoc />
+    public TBuilderEntity WithResourceMapping(byte[] resourceContent, string target)
+    {
+      return WithResourceMapping(new BinaryResourceMapping(resourceContent, target));
+    }
+
+    /// <inheritdoc />
+    public TBuilderEntity WithResourceMapping(string source, string target)
+    {
+      return WithResourceMapping(new FileResourceMapping(source, target));
+    }
+
+    /// <inheritdoc />
+    public TBuilderEntity WithResourceMapping(FileSystemInfo source, string target)
+    {
+      return WithResourceMapping(source.FullName, target);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -2,6 +2,7 @@ namespace DotNet.Testcontainers.Builders
 {
   using System;
   using System.Collections.Generic;
+  using System.IO;
   using System.Threading;
   using System.Threading.Tasks;
   using Docker.DotNet.Models;
@@ -200,29 +201,38 @@ namespace DotNet.Testcontainers.Builders
     TBuilderEntity WithPortBinding(string hostPort, string containerPort);
 
     /// <summary>
-    /// Copies the source file to the created container before it starts.
-    /// </summary>
-    /// <param name="source">An absolute path or a name value within the host machine.</param>
-    /// <param name="destination">An absolute path as destination in the container.</param>
-    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
-    [PublicAPI]
-    TBuilderEntity WithResourceMapping(string source, string destination);
-
-    /// <summary>
-    /// Copies the byte array content to the created container before it starts.
-    /// </summary>
-    /// <param name="resourceContent">The byte array content of the resource mapping.</param>
-    /// <param name="destination">An absolute path as destination in the container.</param>
-    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
-    [PublicAPI]
-    TBuilderEntity WithResourceMapping(byte[] resourceContent, string destination);
-
-    /// <summary>
     /// Copies the byte array content of the resource mapping to the created container before it starts.
     /// </summary>
     /// <param name="resourceMapping">The resource mapping.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     TBuilderEntity WithResourceMapping(IResourceMapping resourceMapping);
+
+    /// <summary>
+    /// Copies the byte array content to the created container before it starts.
+    /// </summary>
+    /// <param name="resourceContent">The byte array content of the resource mapping.</param>
+    /// <param name="target">An absolute path as destination in the container.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
+    TBuilderEntity WithResourceMapping(byte[] resourceContent, string target);
+
+    /// <summary>
+    /// Copies a test host directory or file to the container before it starts.
+    /// </summary>
+    /// <param name="source">The source directory or file to be copied.</param>
+    /// <param name="target">The target directory path to copy the files to.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
+    TBuilderEntity WithResourceMapping(string source, string target);
+
+    /// <summary>
+    /// Copies a test host directory or file to the container before it starts.
+    /// </summary>
+    /// <param name="source">The source directory or file to be copied.</param>
+    /// <param name="target">The target directory path to copy the files to.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
+    TBuilderEntity WithResourceMapping(FileSystemInfo source, string target);
 
     /// <summary>
     /// Assigns the mount configuration to manage data in the container.

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -211,28 +211,41 @@ namespace DotNet.Testcontainers.Builders
     /// Copies the byte array content to the created container before it starts.
     /// </summary>
     /// <param name="resourceContent">The byte array content of the resource mapping.</param>
-    /// <param name="target">An absolute path as destination in the container.</param>
+    /// <param name="filePath">The target file path to copy the file to.</param>
+    /// <param name="fileMode">The POSIX file mode permission.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
-    TBuilderEntity WithResourceMapping(byte[] resourceContent, string target);
+    TBuilderEntity WithResourceMapping(byte[] resourceContent, string filePath, UnixFileModes fileMode = Unix.FileMode644);
 
     /// <summary>
     /// Copies a test host directory or file to the container before it starts.
     /// </summary>
     /// <param name="source">The source directory or file to be copied.</param>
     /// <param name="target">The target directory path to copy the files to.</param>
+    /// <param name="fileMode">The POSIX file mode permission.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
-    TBuilderEntity WithResourceMapping(string source, string target);
+    TBuilderEntity WithResourceMapping(string source, string target, UnixFileModes fileMode = Unix.FileMode644);
 
     /// <summary>
     /// Copies a test host directory or file to the container before it starts.
     /// </summary>
-    /// <param name="source">The source directory or file to be copied.</param>
+    /// <param name="source">The source directory to be copied.</param>
     /// <param name="target">The target directory path to copy the files to.</param>
+    /// <param name="fileMode">The POSIX file mode permission.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
-    TBuilderEntity WithResourceMapping(FileSystemInfo source, string target);
+    TBuilderEntity WithResourceMapping(DirectoryInfo source, string target, UnixFileModes fileMode = Unix.FileMode644);
+
+    /// <summary>
+    /// Copies a test host directory or file to the container before it starts.
+    /// </summary>
+    /// <param name="source">The source file to be copied.</param>
+    /// <param name="target">The target directory path to copy the file to.</param>
+    /// <param name="fileMode">The POSIX file mode permission.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
+    TBuilderEntity WithResourceMapping(FileInfo source, string target, UnixFileModes fileMode = Unix.FileMode644);
 
     /// <summary>
     /// Assigns the mount configuration to manage data in the container.

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -205,6 +205,7 @@ namespace DotNet.Testcontainers.Builders
     /// </summary>
     /// <param name="resourceMapping">The resource mapping.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
     TBuilderEntity WithResourceMapping(IResourceMapping resourceMapping);
 
     /// <summary>
@@ -246,6 +247,16 @@ namespace DotNet.Testcontainers.Builders
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithResourceMapping(FileInfo source, string target, UnixFileModes fileMode = Unix.FileMode644);
+
+    /// <summary>
+    /// Copies a test host file to the container before it starts.
+    /// </summary>
+    /// <param name="source">The source file to be copied.</param>
+    /// <param name="target">The target file path to copy the file to.</param>
+    /// <param name="fileMode">The POSIX file mode permission.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
+    TBuilderEntity WithResourceMapping(FileInfo source, FileInfo target, UnixFileModes fileMode = Unix.FileMode644);
 
     /// <summary>
     /// Assigns the mount configuration to manage data in the container.

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -165,6 +165,22 @@ namespace DotNet.Testcontainers.Clients
     /// <inheritdoc />
     public async Task CopyAsync(string id, IResourceMapping resourceMapping, CancellationToken ct = default)
     {
+      if (Directory.Exists(resourceMapping.Source))
+      {
+        await CopyAsync(id, new DirectoryInfo(resourceMapping.Source), resourceMapping.Target, resourceMapping.FileMode, ct)
+          .ConfigureAwait(false);
+
+        return;
+      }
+
+      if (File.Exists(resourceMapping.Source))
+      {
+        await CopyAsync(id, new FileInfo(resourceMapping.Source), resourceMapping.Target, resourceMapping.FileMode, ct)
+          .ConfigureAwait(false);
+
+        return;
+      }
+
       using (var tarOutputMemStream = new TarOutputMemoryStream())
       {
         await tarOutputMemStream.AddAsync(resourceMapping, ct)

--- a/src/Testcontainers/Configurations/Volumes/BinaryResourceMapping.cs
+++ b/src/Testcontainers/Configurations/Volumes/BinaryResourceMapping.cs
@@ -14,7 +14,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="resourceContent">The byte array content to map in the container.</param>
     /// <param name="containerPath">The absolute path of a file to map in the container.</param>
     /// <param name="fileMode">The POSIX file mode permission.</param>
-    public BinaryResourceMapping(byte[] resourceContent, string containerPath, UnixFileModes fileMode = Unix.FileMode644)
+    public BinaryResourceMapping(byte[] resourceContent, string containerPath, UnixFileModes fileMode)
       : base(string.Empty, containerPath, fileMode)
     {
       _resourceContent = resourceContent;

--- a/src/Testcontainers/Configurations/Volumes/FileResourceMapping.cs
+++ b/src/Testcontainers/Configurations/Volumes/FileResourceMapping.cs
@@ -13,7 +13,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="hostPath">The absolute path of a file to map on the host system.</param>
     /// <param name="containerPath">The absolute path of a file to map in the container.</param>
     /// <param name="fileMode">The POSIX file mode permission.</param>
-    public FileResourceMapping(string hostPath, string containerPath, UnixFileModes fileMode = Unix.FileMode644)
+    public FileResourceMapping(string hostPath, string containerPath, UnixFileModes fileMode)
     {
       Type = MountType.Bind;
       Source = hostPath;

--- a/src/Testcontainers/Configurations/Volumes/IResourceMapping.cs
+++ b/src/Testcontainers/Configurations/Volumes/IResourceMapping.cs
@@ -13,6 +13,9 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Gets the Unix file mode.
     /// </summary>
+    /// <remarks>
+    /// The <see cref="Unix" /> class provides access to common constant POSIX file mode permissions.
+    /// </remarks>
     UnixFileModes FileMode { get; }
 
     /// <summary>

--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -85,7 +85,9 @@ public abstract class TarOutputMemoryStreamTest
         public async Task TestFileExistsInContainer()
         {
             // Given
-            var targetFilePath = string.Join("/", string.Empty, "tmp", Guid.NewGuid(), _testFile.Name);
+            var targetFilePath1 = string.Join("/", string.Empty, "tmp", Guid.NewGuid(), _testFile.Name);
+
+            var targetFilePath2 = string.Join("/", string.Empty, "tmp", Guid.NewGuid(), _testFile.Name);
 
             var targetDirectoryPath1 = string.Join("/", string.Empty, "tmp", Guid.NewGuid());
 
@@ -96,7 +98,8 @@ public abstract class TarOutputMemoryStreamTest
             var targetDirectoryPath4 = string.Join("/", string.Empty, "tmp", Guid.NewGuid());
 
             IList<string> targetFilePaths = new List<string>();
-            targetFilePaths.Add(targetFilePath);
+            targetFilePaths.Add(targetFilePath1);
+            targetFilePaths.Add(targetFilePath2);
             targetFilePaths.Add(string.Join("/", targetDirectoryPath1, _testFile.Name));
             targetFilePaths.Add(string.Join("/", targetDirectoryPath2, _testFile.Name));
             targetFilePaths.Add(string.Join("/", targetDirectoryPath3, _testFile.Name));
@@ -105,6 +108,7 @@ public abstract class TarOutputMemoryStreamTest
             await using var container = new ContainerBuilder()
                 .WithImage(CommonImages.Alpine)
                 .WithEntrypoint(CommonCommands.SleepInfinity)
+                .WithResourceMapping(_testFile, new FileInfo(targetFilePath1))
                 .WithResourceMapping(_testFile, targetDirectoryPath1)
                 .WithResourceMapping(_testFile.Directory, targetDirectoryPath2)
                 .Build();
@@ -116,7 +120,7 @@ public abstract class TarOutputMemoryStreamTest
             await container.StartAsync()
                 .ConfigureAwait(false);
 
-            await container.CopyAsync(fileContent, targetFilePath)
+            await container.CopyAsync(fileContent, targetFilePath2)
                 .ConfigureAwait(false);
 
             await container.CopyAsync(_testFile, targetDirectoryPath3)


### PR DESCRIPTION
## What does this PR do?

The pull request includes a feature that enables copying of nested test host directories to the container directly from the container definition (`ContainerBuilder`).

## Why is it important?

This improvement simplifies the process for users to set up their test environment. It is a common to copy resources such as configuration files, etc., to containers right from the beginning.

⚠️ This pull request includes a change that cause compatibility issues. Unfortunately, we are unable to add a new member (container builder method) and mark the old one as obsolete. Both methods have the same signature. The `WithResourceMapping(string, string)` method's target no longer accepts an absolute file path; instead, it represents the directory where a file will be copied to. This modification was necessary to align with the general copy API.

Please use

    WithResourceMapping("appsettings.json", "/tmp/")

instead of

    WithResourceMapping("appsettings.json", "/tmp/appsettings.json")

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #811

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
