### PR TITLE
chore: Set WithResourceMapping(string, string) obsolete and explain the new behavior

### DIFF
--- a/src/Testcontainers.WebDriver/WebDriverBuilder.cs
+++ b/src/Testcontainers.WebDriver/WebDriverBuilder.cs
@@ -64,7 +64,7 @@ public sealed class WebDriverBuilder : ContainerBuilder<WebDriverBuilder, WebDri
     /// <returns>A configured instance of <see cref="WebDriverBuilder" />.</returns>
     public WebDriverBuilder WithConfigurationFromTomlFile(string configTomlFilePath)
     {
-        return WithResourceMapping(File.ReadAllBytes(configTomlFilePath), "/opt/bin/config.toml");
+        return WithResourceMapping(new FileInfo(configTomlFilePath), new FileInfo("/opt/bin/config.toml"));
     }
 
     /// <summary>

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -195,32 +195,33 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
+    [Obsolete("The next release will change how this member behaves. The target argument, which used to be a file path, will be a directory path where the file will be copied to, similar to WithResourceMapping(DirectoryInfo, string) and WithResourceMapping(FileInfo, string).\nTo retain the old behavior, use WithResourceMapping(FileInfo, FileInfo) instead.")]
     public TBuilderEntity WithResourceMapping(string source, string target, UnixFileModes fileMode = Unix.FileMode644)
     {
-      return WithResourceMapping(new FileResourceMapping(source, target, fileMode));
+      return WithResourceMapping(new FileInfo(source), new FileInfo(target), fileMode);
     }
 
     /// <inheritdoc />
     public TBuilderEntity WithResourceMapping(DirectoryInfo source, string target, UnixFileModes fileMode = Unix.FileMode644)
     {
-      return WithResourceMapping(source.FullName, target, fileMode);
+      return WithResourceMapping(new FileResourceMapping(source.FullName, target, fileMode));
     }
 
     /// <inheritdoc />
     public TBuilderEntity WithResourceMapping(FileInfo source, string target, UnixFileModes fileMode = Unix.FileMode644)
     {
-      return WithResourceMapping(source.FullName, target, fileMode);
+      return WithResourceMapping(new FileResourceMapping(source.FullName, target, fileMode));
     }
 
     /// <inheritdoc />
     public TBuilderEntity WithResourceMapping(FileInfo source, FileInfo target, UnixFileModes fileMode = Unix.FileMode644)
     {
-      using (var fileStream = File.Open(source.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+      using (var fileStream = source.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
       {
         using (var streamReader = new BinaryReader(fileStream))
         {
           var resourceContent = streamReader.ReadBytes((int)streamReader.BaseStream.Length);
-          return WithResourceMapping(new BinaryResourceMapping(resourceContent, target.ToString(), fileMode));
+          return WithResourceMapping(resourceContent, target.ToString(), fileMode);
         }
       }
     }
@@ -327,6 +328,7 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
+    [Obsolete("It is no longer necessary to assign an output consumer to read the container's log messages.\nUse IContainer.GetLogsAsync(DateTime, DateTime, bool, CancellationToken) instead.")]
     public TBuilderEntity WithOutputConsumer(IOutputConsumer outputConsumer)
     {
       return Clone(new ContainerConfiguration(outputConsumer: outputConsumer));

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -406,7 +406,6 @@ namespace DotNet.Testcontainers.Builders
     /// <param name="outputConsumer">The output consumer.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
-    [Obsolete("It is no longer necessary to assign an output consumer to read the container's log messages.\nUse IContainer.GetLogsAsync(DateTime, DateTime, bool, CancellationToken) instead.")]
     TBuilderEntity WithOutputConsumer(IOutputConsumer outputConsumer);
 
     /// <summary>

--- a/src/Testcontainers/Containers/TarOutputMemoryStream.cs
+++ b/src/Testcontainers/Containers/TarOutputMemoryStream.cs
@@ -56,8 +56,8 @@ namespace DotNet.Testcontainers.Containers
         .ConfigureAwait(false);
 
 #if NETSTANDARD2_1_OR_GREATER
-        await WriteAsync(fileContent, ct)
-          .ConfigureAwait(false);
+      await WriteAsync(fileContent, ct)
+        .ConfigureAwait(false);
 #else
       await WriteAsync(fileContent, 0, fileContent.Length, ct)
         .ConfigureAwait(false);

--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -10,7 +10,7 @@ public abstract class TarOutputMemoryStreamTest
 
     protected TarOutputMemoryStreamTest()
     {
-        using var fileStream = _testFile.Create();
+        using var fileStream = _testFile.Open(FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
         fileStream.WriteByte(13);
     }
 

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/CopyResourceMappingContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/CopyResourceMappingContainerTest.cs
@@ -27,7 +27,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     {
       var resourceContent = Encoding.Default.GetBytes(ResourceMappingContent);
 
-      using var fileStream = _sourceFilePath.Create();
+      using var fileStream = _sourceFilePath.Open(FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
       fileStream.Write(resourceContent);
 
       _bytesTargetFilePath = string.Join("/", string.Empty, "tmp", Guid.NewGuid(), _sourceFilePath.Name);

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/CopyResourceMappingContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/CopyResourceMappingContainerTest.cs
@@ -15,7 +15,7 @@ namespace DotNet.Testcontainers.Tests.Unit
   {
     private const string ResourceMappingContent = "👋";
 
-    private readonly FileInfo _sourceFilePath = new FileInfo(Path.Combine(TestSession.TempDirectoryPath, Path.GetRandomFileName()));
+    private readonly FileInfo _testFile = new FileInfo(Path.Combine(TestSession.TempDirectoryPath, Path.GetRandomFileName()));
 
     private readonly string _bytesTargetFilePath;
 
@@ -27,17 +27,17 @@ namespace DotNet.Testcontainers.Tests.Unit
     {
       var resourceContent = Encoding.Default.GetBytes(ResourceMappingContent);
 
-      using var fileStream = _sourceFilePath.Open(FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
+      using var fileStream = _testFile.Open(FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
       fileStream.Write(resourceContent);
 
-      _bytesTargetFilePath = string.Join("/", string.Empty, "tmp", Guid.NewGuid(), _sourceFilePath.Name);
+      _bytesTargetFilePath = string.Join("/", string.Empty, "tmp", Guid.NewGuid(), _testFile.Name);
 
       _fileTargetFilePath = string.Join("/", string.Empty, "tmp", Guid.NewGuid());
 
       _container = new ContainerBuilder()
         .WithImage(CommonImages.Alpine)
         .WithResourceMapping(resourceContent, _bytesTargetFilePath)
-        .WithResourceMapping(_sourceFilePath, _fileTargetFilePath)
+        .WithResourceMapping(_testFile, _fileTargetFilePath)
         .Build();
     }
 
@@ -53,7 +53,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     public void Dispose()
     {
-      _sourceFilePath.Delete();
+      _testFile.Delete();
     }
 
     [Fact]
@@ -62,7 +62,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       // Given
       IList<string> targetFilePaths = new List<string>();
       targetFilePaths.Add(_bytesTargetFilePath);
-      targetFilePaths.Add(string.Join("/", _fileTargetFilePath, _sourceFilePath.Name));
+      targetFilePaths.Add(string.Join("/", _fileTargetFilePath, _testFile.Name));
 
       // When
       var resourceContents = await Task.WhenAll(targetFilePaths.Select(containerFilePath => _container.ReadFileAsync(containerFilePath)))


### PR DESCRIPTION
## What does this PR do?

The pull request sets the `WithResourceMapping(string, string)` member obsolete. In the next release, the behavior of the member will change. The target argument, which used to be a file path, will be a directory path where the file will be copied to. Then the member will accept either a directory or file path as source argument.

    WithResourceMapping("appsettings.json", "/tmp/appsettings.json")

will be

    WithResourceMapping("appsettings.json", "/tmp/")

## Why is it important?

In order to match the `IContainer.CopyAsync` APIs, it is better to ensure a consistent behavior when copying files to the container.

One aspect we should take into account is modifying the API that the target argument aligns with the corresponding source argument. If the source target argument refers to a file, then the target argument should also be treated as a file too.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
