### PR TITLE
docs: Fix typo in Testcontainers properties file path

### DIFF
--- a/docs/custom_configuration/index.md
+++ b/docs/custom_configuration/index.md
@@ -1,6 +1,6 @@
 # Custom Configuration
 
-Testcontainers supports various configurations to set up your test environment. It automatically discovers the Docker environment and applies the configuration. You can set or override the default values either with the Testcontainers [properties file][properties-file-format] (`~/testcontainers.properties`) or with environment variables. The following configurations are available:
+Testcontainers supports various configurations to set up your test environment. It automatically discovers the Docker environment and applies the configuration. You can set or override the default values either with the Testcontainers [properties file][properties-file-format] (`~/.testcontainers.properties`) or with environment variables. The following configurations are available:
 
 | Properties File             | Environment Variable                       | Description                                                                                                               | Default                     |
 |-----------------------------|--------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|-----------------------------|


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in the Testcontainers properties file path.

## Why is it important?

Refer to the correct file path.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #933

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
