### PR TITLE
chore: Remove obsolete member CopyFileAsync

### DIFF
--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -136,19 +136,6 @@ namespace DotNet.Testcontainers.Clients
     Task CopyAsync(string id, FileInfo source, string target, UnixFileModes fileMode, CancellationToken ct = default);
 
     /// <summary>
-    /// Copies a file to the container.
-    /// </summary>
-    /// <param name="id">The container id.</param>
-    /// <param name="filePath">The path to the file in the container.</param>
-    /// <param name="fileContent">The content of the file as bytes.</param>
-    /// <param name="accessMode">The access mode for the file.</param>
-    /// <param name="userId">The owner of the file.</param>
-    /// <param name="groupId">The group of the file.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the file has been copied.</returns>
-    Task CopyFileAsync(string id, string filePath, byte[] fileContent, int accessMode, int userId, int groupId, CancellationToken ct = default);
-
-    /// <summary>
     /// Reads a file from the container.
     /// </summary>
     /// <param name="id">The container id.</param>

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -227,48 +227,6 @@ namespace DotNet.Testcontainers.Clients
     }
 
     /// <inheritdoc />
-    public async Task CopyFileAsync(string id, string filePath, byte[] fileContent, int accessMode, int userId, int groupId, CancellationToken ct = default)
-    {
-      var containerPath = Unix.Instance.NormalizePath(filePath);
-
-      using (var tarOutputMemStream = new MemoryStream())
-      {
-        using (var tarOutputStream = new TarOutputStream(tarOutputMemStream, Encoding.Default))
-        {
-          tarOutputStream.IsStreamOwner = false;
-
-          var header = new TarHeader();
-          header.Name = containerPath;
-          header.UserId = userId;
-          header.GroupId = groupId;
-          header.Mode = accessMode;
-          header.Size = fileContent.Length;
-
-          var entry = new TarEntry(header);
-
-          await tarOutputStream.PutNextEntryAsync(entry, ct)
-            .ConfigureAwait(false);
-
-#if NETSTANDARD2_1_OR_GREATER
-          await tarOutputStream.WriteAsync(fileContent, ct)
-            .ConfigureAwait(false);
-#else
-          await tarOutputStream.WriteAsync(fileContent, 0, fileContent.Length, ct)
-            .ConfigureAwait(false);
-#endif
-
-          await tarOutputStream.CloseEntryAsync(ct)
-            .ConfigureAwait(false);
-        }
-
-        tarOutputMemStream.Seek(0, SeekOrigin.Begin);
-
-        await Container.ExtractArchiveToContainerAsync(id, "/", tarOutputMemStream, ct)
-          .ConfigureAwait(false);
-      }
-    }
-
-    /// <inheritdoc />
     public async Task<byte[]> ReadFileAsync(string id, string filePath, CancellationToken ct = default)
     {
       Stream tarStream;

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -313,12 +313,6 @@ namespace DotNet.Testcontainers.Containers
     }
 
     /// <inheritdoc />
-    public Task CopyFileAsync(string filePath, byte[] fileContent, int accessMode = 384, int userId = 0, int groupId = 0, CancellationToken ct = default)
-    {
-      return _client.CopyFileAsync(Id, filePath, fileContent, accessMode, userId, groupId, ct);
-    }
-
-    /// <inheritdoc />
     public Task<byte[]> ReadFileAsync(string filePath, CancellationToken ct = default)
     {
       return _client.ReadFileAsync(Id, filePath, ct);

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -207,27 +207,6 @@ namespace DotNet.Testcontainers.Containers
     Task CopyAsync(FileInfo source, string target, UnixFileModes fileMode = Unix.FileMode644, CancellationToken ct = default);
 
     /// <summary>
-    /// Copies a file to the container.
-    /// </summary>
-    /// <param name="filePath">An absolute path as destination in the container.</param>
-    /// <param name="fileContent">The byte array content of the file.</param>
-    /// <param name="accessMode">The access mode for the file (default: 0600).</param>
-    /// <param name="userId">The owner of the file.</param>
-    /// <param name="groupId">The group of the file.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the file has been copied.</returns>
-    /// <remarks>
-    ///   <paramref name="accessMode" /> is a decimal value. Covert chmod (octal) to decimal.
-    ///   <ul>
-    ///     <li>777 octal 🠒 111_111_111 binary 🠒 511 decimal</li>
-    ///     <li>755 octal 🠒 111_101_101 binary 🠒 493 decimal</li>
-    ///     <li>644 octal 🠒 110_100_100 binary 🠒 420 decimal</li>
-    ///   </ul>
-    /// </remarks>
-    [Obsolete("Use CopyAsync(byte[], string, UnixFileMode, CancellationToken) or one of its overloads.")]
-    Task CopyFileAsync(string filePath, byte[] fileContent, int accessMode = 384, int userId = 0, int groupId = 0, CancellationToken ct = default);
-
-    /// <summary>
     /// Reads a file from the container.
     /// </summary>
     /// <param name="filePath">An absolute path or a name value within the container.</param>


### PR DESCRIPTION
## What does this PR do?

Removes the obsolete member `CopyFileAsync(string, byte[])`.

## Why is it important?

The `IContainer` supports now the `CopyAsync(byte[], string)` incl. several overloads to copy test host directories or files to a container.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
