### PR TITLE
fix: Copy files to container without removing first character from filename

### DIFF
--- a/src/Testcontainers/Containers/TarOutputMemoryStream.cs
+++ b/src/Testcontainers/Containers/TarOutputMemoryStream.cs
@@ -108,7 +108,7 @@ namespace DotNet.Testcontainers.Containers
     {
       using (var stream = new FileStream(file.FullName, FileMode.Open, FileAccess.Read))
       {
-        var targetFilePath = Unix.Instance.NormalizePath(Path.Combine(_targetDirectoryPath, file.FullName.Substring(directory.FullName.Length + 1)));
+        var targetFilePath = Unix.Instance.NormalizePath(Path.Combine(_targetDirectoryPath, file.FullName.Substring(directory.FullName.TrimEnd(Path.DirectorySeparatorChar).Length + 1)));
 
         var tarEntry = new TarEntry(new TarHeader());
         tarEntry.TarHeader.Name = targetFilePath;


### PR DESCRIPTION
## What does this PR do?

The pull request removes the directory separator from the test host source directory path.

## Why is it important?

The trailing directory path separator is optional. .NET does not normalize paths. If the test host source directory path ends with a separator (`/`, `\`) the first character from the filename was accidentally removed.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
