### PR TITLE
fix: Replace mysql with mariadb binary in MariaDB module

### DIFF
--- a/src/Testcontainers.MariaDb/MariaDbBuilder.cs
+++ b/src/Testcontainers.MariaDb/MariaDbBuilder.cs
@@ -135,7 +135,7 @@ public sealed class MariaDbBuilder : ContainerBuilder<MariaDbBuilder, MariaDbCon
         /// <param name="configuration">The container configuration.</param>
         public WaitUntil(MariaDbConfiguration configuration)
         {
-            _command = new List<string> { "mysql", "--protocol=TCP", $"--port={MariaDbPort}", $"--user={configuration.Username}", $"--password={configuration.Password}", configuration.Database, "--wait", "--silent", "--execute=SELECT 1;" };
+            _command = new List<string> { "mariadb", "--protocol=TCP", $"--port={MariaDbPort}", $"--user={configuration.Username}", $"--password={configuration.Password}", configuration.Database, "--wait", "--silent", "--execute=SELECT 1;" };
         }
 
         /// <inheritdoc />

--- a/src/Testcontainers.MariaDb/MariaDbContainer.cs
+++ b/src/Testcontainers.MariaDb/MariaDbContainer.cs
@@ -45,7 +45,7 @@ public sealed class MariaDbContainer : DockerContainer
         await CopyAsync(Encoding.Default.GetBytes(scriptContent), scriptFilePath, Unix.FileMode644, ct)
             .ConfigureAwait(false);
 
-        return await ExecAsync(new[] { "mysql", "--protocol=TCP", $"--port={MariaDbBuilder.MariaDbPort}", $"--user={_configuration.Username}", $"--password={_configuration.Password}", _configuration.Database, $"--execute=source {scriptFilePath};" }, ct)
+        return await ExecAsync(new[] { "mariadb", "--protocol=TCP", $"--port={MariaDbBuilder.MariaDbPort}", $"--user={_configuration.Username}", $"--password={_configuration.Password}", _configuration.Database, $"--execute=source {scriptFilePath};" }, ct)
             .ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
The command has been renamed from `mysql` to `mariadb` and it looks like the symlink that has been in place for many versions has also been removed in newer MariaDB versions.



<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

`mysql` command changed to `mariadb` for the MariaDB module.

## Why is it important?

Wait policy fails otherwise for newer MariaDB images.

## Related issues

- Closes #941

## How to test this PR

Try to use the MariaDB image with a new tag, like `latest`.


