### PR TITLE
fix: Do not dispose a custom HTTP message handler in an HTTP wait strategy

### DIFF
--- a/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
@@ -66,7 +66,7 @@ namespace DotNet.Testcontainers.Configurations
         return false;
       }
 
-      using (var httpClient = new HttpClient(_httpMessageHandler ?? new HttpClientHandler()))
+      using (var httpClient = new HttpClient(_httpMessageHandler ?? new HttpClientHandler(), disposeHandler: _httpMessageHandler == null))
       {
         using (var httpRequestMessage = new HttpRequestMessage(_httpMethod, new UriBuilder(_schemeName, host, port, _pathValue).Uri))
         {

--- a/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/HttpWaitStrategy.cs
@@ -82,7 +82,7 @@ namespace DotNet.Testcontainers.Configurations
             httpResponseMessage = await httpClient.SendAsync(httpRequestMessage)
               .ConfigureAwait(false);
           }
-          catch
+          catch (HttpRequestException)
           {
             return false;
           }


### PR DESCRIPTION
Resolves #957 