### PR TITLE
feat: Restore output consumer support

### DIFF
--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -116,7 +116,7 @@ Assert.Equal(MagicNumber, magicNumber);
 ## Supported commands
 
 | Builder method                | Description                                                                                                                                                                          |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `DependsOn`                   | Sets the dependent resource to resolve and create or start before starting this container configuration.                                                                             |
 | `WithDockerEndpoint`          | Sets the Docker daemon socket to connect to.                                                                                                                                         |
 | `WithAutoRemove`              | Will remove the stopped container automatically, similar to `--rm`.                                                                                                                  |

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -116,7 +116,7 @@ Assert.Equal(MagicNumber, magicNumber);
 ## Supported commands
 
 | Builder method                | Description                                                                                                                                                                          |
-|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `DependsOn`                   | Sets the dependent resource to resolve and create or start before starting this container configuration.                                                                             |
 | `WithDockerEndpoint`          | Sets the Docker daemon socket to connect to.                                                                                                                                         |
 | `WithAutoRemove`              | Will remove the stopped container automatically, similar to `--rm`.                                                                                                                  |
@@ -141,6 +141,7 @@ Assert.Equal(MagicNumber, magicNumber);
 | `WithNetworkAliases`          | Assigns a network-scoped aliases to the container e.g. `--network-alias "alias"`.                                                                                                    |
 | `WithExtraHost`               | Adds a custom host-to-IP mapping to the container's `/etc/hosts` respectively `%WINDIR%\\system32\\drivers\\etc\\hosts` e.g. `--add-host "host.testcontainers.internal:172.17.0.2"`. |
 | `WithPrivileged`              | Sets the `--privileged` flag.                                                                                                                                                        |
+| `WithOutputConsumer`          | Redirects `stdout` and `stderr` to capture the container output.                                                                                                                     |
 | `WithWaitStrategy`            | Sets the wait strategy to complete the container start and indicates when it is ready.                                                                                               |
 | `WithStartupCallback`         | Sets the startup callback to invoke after the container start.                                                                                                                       |
 | `WithCreateParameterModifier` | Allows low level modifications of the Docker container create parameter.                                                                                                             |

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -328,7 +328,6 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    [Obsolete("It is no longer necessary to assign an output consumer to read the container's log messages.\nUse IContainer.GetLogsAsync(DateTime, DateTime, bool, CancellationToken) instead.")]
     public TBuilderEntity WithOutputConsumer(IOutputConsumer outputConsumer)
     {
       return Clone(new ContainerConfiguration(outputConsumer: outputConsumer));

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -96,6 +96,15 @@ namespace DotNet.Testcontainers.Clients
     Task RemoveAsync(string id, CancellationToken ct = default);
 
     /// <summary>
+    /// Attaches to the container and copies the output to the <see cref="IOutputConsumer" />.
+    /// </summary>
+    /// <param name="id">The container id.</param>
+    /// <param name="outputConsumer">The stdout and stderr consumer.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container's stdout and stderr has been copied to the consumer.</returns>
+    Task AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default);
+
+    /// <summary>
     /// Executes a command in the container.
     /// </summary>
     /// <param name="id">The container id.</param>

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -165,6 +165,12 @@ namespace DotNet.Testcontainers.Clients
     }
 
     /// <inheritdoc />
+    public Task AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default)
+    {
+      return Container.AttachAsync(id, outputConsumer, ct);
+    }
+
+    /// <inheritdoc />
     public Task<ExecResult> ExecAsync(string id, IList<string> command, CancellationToken ct = default)
     {
       return Container.ExecAsync(id, command, ct);

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Configurations
 {
   using System;
   using System.Collections.Generic;
-  using System.IO;
   using System.Text.RegularExpressions;
   using JetBrains.Annotations;
 
@@ -73,16 +72,6 @@ namespace DotNet.Testcontainers.Configurations
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     [PublicAPI]
     IWaitForContainerOS UntilMessageIsLogged(Regex pattern);
-
-    /// <summary>
-    /// Waits until the message is logged in the steam.
-    /// </summary>
-    /// <param name="stream">The stream to be searched.</param>
-    /// <param name="message">The message to be checked.</param>
-    /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
-    [PublicAPI]
-    [Obsolete("It is no longer necessary to assign an output consumer to read the container's log messages.\nUse IWaitForContainerOS.UntilMessageIsLogged(string) or IWaitForContainerOS.UntilMessageIsLogged(Regex) instead.")]
-    IWaitForContainerOS UntilMessageIsLogged(Stream stream, string message);
 
     /// <summary>
     /// Waits until the operation is completed successfully.

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Configurations
 {
   using System;
   using System.Collections.Generic;
-  using System.IO;
   using System.Text.RegularExpressions;
 
   /// <inheritdoc cref="IWaitForContainerOS" />
@@ -50,12 +49,6 @@ namespace DotNet.Testcontainers.Configurations
     public IWaitForContainerOS UntilMessageIsLogged(Regex pattern)
     {
       return AddCustomWaitStrategy(new UntilMessageIsLogged(pattern));
-    }
-
-    /// <inheritdoc />
-    public virtual IWaitForContainerOS UntilMessageIsLogged(Stream stream, string message)
-    {
-      return AddCustomWaitStrategy(new UntilMessageIsLogged(message));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -423,7 +423,8 @@ namespace DotNet.Testcontainers.Containers
           .ConfigureAwait(false);
       }
 
-      await _client.Container.AttachAsync(_container.ID, _configuration.OutputConsumer, ct);
+      await _client.AttachAsync(_container.ID, _configuration.OutputConsumer, ct)
+        .ConfigureAwait(false);
 
       await _client.StartAsync(_container.ID, ct)
         .ConfigureAwait(false);

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -423,6 +423,8 @@ namespace DotNet.Testcontainers.Containers
           .ConfigureAwait(false);
       }
 
+      await _client.Container.AttachAsync(_container.ID, _configuration.OutputConsumer, ct);
+
       await _client.StartAsync(_container.ID, ct)
         .ConfigureAwait(false);
 

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
@@ -90,10 +90,10 @@ namespace DotNet.Testcontainers.Tests.Unit
       var cookieContainer = new CookieContainer();
       cookieContainer.Add(new Cookie("Key1", "Value1", "/", _container.Hostname));
 
-      var httpWaitStrategy = new HttpWaitStrategy().UsingHttpMessageHandler(new HttpClientHandler
-      {
-        CookieContainer = cookieContainer
-      });
+      using var httpMessageHandler = new HttpClientHandler();
+      httpMessageHandler.CookieContainer = cookieContainer;
+
+      var httpWaitStrategy = new HttpWaitStrategy().UsingHttpMessageHandler(httpMessageHandler);
 
       // When
       var succeeded = await httpWaitStrategy.UntilAsync(_container)
@@ -115,7 +115,9 @@ namespace DotNet.Testcontainers.Tests.Unit
     public async Task HttpWaitStrategyCanReuseCustomHttpClientHandler()
     {
       // Given
-      var httpWaitStrategy = new HttpWaitStrategy().UsingHttpMessageHandler(new HttpClientHandler());
+      using var httpMessageHandler = new HttpClientHandler();
+
+      var httpWaitStrategy = new HttpWaitStrategy().UsingHttpMessageHandler(httpMessageHandler);
 
       // When
       await httpWaitStrategy.UntilAsync(_container)

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -307,7 +307,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         var stdout = await stdoutReader.ReadToEndAsync()
           .ConfigureAwait(false);
 
-        using var stderrReader = new StreamReader(consumer.Stdout, leaveOpen: true);
+        using var stderrReader = new StreamReader(consumer.Stderr, leaveOpen: true);
         var stderr = await stderrReader.ReadToEndAsync()
           .ConfigureAwait(false);
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Re-enables support for registering a provided `IOutputConsumer` for streaming stdout/stderr from the container.

Note that the [`IWaitForContainerOS.UntilMessageIsLogged(Stream, string)`](https://github.com/testcontainers/testcontainers-dotnet/blob/develop/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs#L84) method is still marked obsolete as utilising an output consumer for the purposes of wait strategies remains redundant; favouring the improvements made in #793.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

This is rather useful to enable developers to stream their container output to a location of their choice. It's useful for debugging, monitoring, etc.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Resolves #952

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->