### PR TITLE
chore: Remove WithResourceMapping(string, string, UnixFileModes) obsolete flag

### DIFF
--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -195,10 +195,18 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    [Obsolete("The next release will change how this member behaves. The target argument, which used to be a file path, will be a directory path where the file will be copied to, similar to WithResourceMapping(DirectoryInfo, string) and WithResourceMapping(FileInfo, string).\nTo retain the old behavior, use WithResourceMapping(FileInfo, FileInfo) instead.")]
     public TBuilderEntity WithResourceMapping(string source, string target, UnixFileModes fileMode = Unix.FileMode644)
     {
-      return WithResourceMapping(new FileInfo(source), new FileInfo(target), fileMode);
+      var fileAttributes = File.GetAttributes(source);
+
+      if ((fileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
+      {
+        return WithResourceMapping(new DirectoryInfo(source), target, fileMode);
+      }
+      else
+      {
+        return WithResourceMapping(new FileInfo(source), target, fileMode);
+      }
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## What does this PR do?

The pull request removes the obsolete flag from the `WithResourceMapping(string, string, UnixFileModes)` member.

## Why is it important?

The behavior of the member has changed. Now, the target (2nd) argument should be a target directory instead of a file path. If the source is a file, the implementation will automatically append the filename to the target directory path.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
