### PR TITLE
chore: Add test coverage to unbound port bindings

### DIFF
--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -109,8 +109,8 @@ public abstract class TarOutputMemoryStreamTest
                 .WithImage(CommonImages.Alpine)
                 .WithEntrypoint(CommonCommands.SleepInfinity)
                 .WithResourceMapping(_testFile, new FileInfo(targetFilePath1))
-                .WithResourceMapping(_testFile, targetDirectoryPath1)
-                .WithResourceMapping(_testFile.Directory, targetDirectoryPath2)
+                .WithResourceMapping(_testFile.FullName, targetDirectoryPath1)
+                .WithResourceMapping(_testFile.Directory.FullName, targetDirectoryPath2)
                 .Build();
 
             // When
@@ -123,10 +123,10 @@ public abstract class TarOutputMemoryStreamTest
             await container.CopyAsync(fileContent, targetFilePath2)
                 .ConfigureAwait(false);
 
-            await container.CopyAsync(_testFile, targetDirectoryPath3)
+            await container.CopyAsync(_testFile.FullName, targetDirectoryPath3)
                 .ConfigureAwait(false);
 
-            await container.CopyAsync(_testFile.Directory, targetDirectoryPath4)
+            await container.CopyAsync(_testFile.Directory.FullName, targetDirectoryPath4)
                 .ConfigureAwait(false);
 
             // Then


### PR DESCRIPTION
## What does this PR do?

Adds a test to cover unbound port binding configurations.

## Why is it important?

Make sure `GetMappedPublicPort(int)` throws an exception if the port (arg) is not bound.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #965

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
