### PR TITLE
chore: Disable signing NuGet dependencies

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -142,7 +142,7 @@ Task("Create-NuGet-Packages")
 });
 
 Task("Sign-NuGet-Packages")
-  .WithCriteria(() => param.ShouldPublish)
+  .WithCriteria(() => param.ShouldPublish && false /* We do not have access to a valid code signing certificate anymore. */)
   .Does(() =>
 {
   StartProcess("dotnet", new ProcessSettings


### PR DESCRIPTION
## What does this PR do?

Disables singing NuGet packages.

## Why is it important?

We do not have access to a valid code signing certificate anymore. We need to disable the Cake task to publish dependencies to nuget.org.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
