### PR TITLE
chore: Add User-Agent HTTP header to Docker.DotNet client

### DIFF
--- a/src/Testcontainers/Clients/DefaultLabels.cs
+++ b/src/Testcontainers/Clients/DefaultLabels.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Clients
 {
   using System.Collections.Generic;
   using System.Collections.ObjectModel;
-  using System.Reflection;
   using DotNet.Testcontainers.Containers;
 
   internal sealed class DefaultLabels : ReadOnlyDictionary<string, string>
@@ -16,7 +15,7 @@ namespace DotNet.Testcontainers.Clients
       {
         { TestcontainersClient.TestcontainersLabel, bool.TrueString.ToLowerInvariant() },
         { TestcontainersClient.TestcontainersLangLabel, "dotnet" },
-        { TestcontainersClient.TestcontainersVersionLabel, typeof(DefaultLabels).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion },
+        { TestcontainersClient.TestcontainersVersionLabel, TestcontainersClient.Version },
         { TestcontainersClient.TestcontainersSessionIdLabel, ResourceReaper.DefaultSessionId.ToString("D") },
         { ResourceReaper.ResourceReaperSessionLabel, ResourceReaper.DefaultSessionId.ToString("D") },
       })

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -4,6 +4,7 @@ namespace DotNet.Testcontainers.Clients
   using System.Collections.Generic;
   using System.IO;
   using System.Linq;
+  using System.Reflection;
   using System.Text;
   using System.Text.RegularExpressions;
   using System.Threading;
@@ -27,6 +28,8 @@ namespace DotNet.Testcontainers.Clients
     public const string TestcontainersVersionLabel = TestcontainersLabel + ".version";
 
     public const string TestcontainersSessionIdLabel = TestcontainersLabel + ".session-id";
+
+    public static readonly string Version = typeof(TestcontainersClient).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
     private static readonly string OSRootDirectory = Path.GetPathRoot(Directory.GetCurrentDirectory());
 

--- a/src/Testcontainers/Configurations/AuthConfigs/DockerEndpointAuthenticationConfiguration.cs
+++ b/src/Testcontainers/Configurations/AuthConfigs/DockerEndpointAuthenticationConfiguration.cs
@@ -1,3 +1,6 @@
+using System.Reflection;
+using DotNet.Testcontainers.Clients;
+
 namespace DotNet.Testcontainers.Configurations
 {
   using System;
@@ -30,7 +33,12 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     public DockerClientConfiguration GetDockerClientConfiguration(Guid sessionId = default)
     {
-      var defaultHttpRequestHeaders = new ReadOnlyDictionary<string, string>(new Dictionary<string, string> { { "x-tc-sid", sessionId.ToString("D") } });
+      var testcontainersVersion = typeof(DefaultLabels).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+      var defaultHttpRequestHeaders = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>
+      {
+        { "x-tc-sid", sessionId.ToString("D") },
+        { "User-Agent", "tc-dotnet/" + testcontainersVersion}
+      });
       return new DockerClientConfiguration(Endpoint, Credentials, defaultHttpRequestHeaders: defaultHttpRequestHeaders);
     }
   }

--- a/src/Testcontainers/Configurations/AuthConfigs/DockerEndpointAuthenticationConfiguration.cs
+++ b/src/Testcontainers/Configurations/AuthConfigs/DockerEndpointAuthenticationConfiguration.cs
@@ -1,12 +1,10 @@
-using System.Reflection;
-using DotNet.Testcontainers.Clients;
-
 namespace DotNet.Testcontainers.Configurations
 {
   using System;
   using System.Collections.Generic;
   using System.Collections.ObjectModel;
   using Docker.DotNet;
+  using DotNet.Testcontainers.Clients;
   using JetBrains.Annotations;
 
   /// <inheritdoc cref="IDockerEndpointAuthenticationConfiguration" />
@@ -33,12 +31,12 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     public DockerClientConfiguration GetDockerClientConfiguration(Guid sessionId = default)
     {
-      var testcontainersVersion = typeof(DefaultLabels).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
       var defaultHttpRequestHeaders = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>
       {
+        { "User-Agent", "tc-dotnet/" + TestcontainersClient.Version },
         { "x-tc-sid", sessionId.ToString("D") },
-        { "User-Agent", "tc-dotnet/" + testcontainersVersion}
       });
+
       return new DockerClientConfiguration(Endpoint, Credentials, defaultHttpRequestHeaders: defaultHttpRequestHeaders);
     }
   }


### PR DESCRIPTION
Add User-Agent with value `tc-dotnet/<version>`.
