### PR TITLE
chore: Remove `CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT` env var

### DIFF
--- a/src/Testcontainers.ClickHouse/ClickHouseBuilder.cs
+++ b/src/Testcontainers.ClickHouse/ClickHouseBuilder.cs
@@ -85,7 +85,6 @@ public sealed class ClickHouseBuilder : ContainerBuilder<ClickHouseBuilder, Clic
             .WithImage(ClickHouseImage)
             .WithPortBinding(HttpPort, true)
             .WithPortBinding(NativePort, true)
-            .WithEnvironment("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1")
             .WithDatabase(DefaultDatabase)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)


### PR DESCRIPTION
`CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT` is not needed for database
initialization.

This will align with [tc-go ](https://github.com/testcontainers/testcontainers-go/pull/1372#discussion_r1287495976)and [tc-java](https://github.com/testcontainers/testcontainers-java/pull/7403)