### PR TITLE
change private accesss modifier to public modifier in MsSqlBuilder File

### DIFF
--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -104,7 +104,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// </remarks>
     /// <param name="database">The MsSql database.</param>
     /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
-    private MsSqlBuilder WithDatabase(string database)
+    public MsSqlBuilder WithDatabase(string database)
     {
         return Merge(DockerResourceConfiguration, new MsSqlConfiguration(database: database))
             .WithEnvironment("SQLCMDDBNAME", database);
@@ -118,7 +118,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// </remarks>
     /// <param name="username">The MsSql username.</param>
     /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
-    private MsSqlBuilder WithUsername(string username)
+    public MsSqlBuilder WithUsername(string username)
     {
         return Merge(DockerResourceConfiguration, new MsSqlConfiguration(username: username))
             .WithEnvironment("SQLCMDUSER", username);


### PR DESCRIPTION
## What does this PR do?

In `MsSqlBuilder` class, there are `WithDatabase` and `WithUsername` methods that have `private access modifiers`. These should be `public access modifiers`. 

## Why is it important?

There is no way to change `Username `and `Database `rather than reflection. By changing `private `to `public `access modifier, we can easily change Username and Database name.

## Related issues

N/A


## How to test this PR

N/A

## Follow-ups

N/A