### PR TITLE
fix: Do not pre pull Dockerfile build stages that do not correspond to base images

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,18 +14,20 @@
       "moby": true
     },
     "ghcr.io/devcontainers/features/dotnet:1": {
-      "version": "6.0.405",
+      "version": "6.0.413",
       "installUsingApt": false
     }
   },
-  "extensions": [
-    "formulahendry.dotnet-test-explorer",
-    "ms-azuretools.vscode-docker",
-    "ms-dotnettools.csharp"
-  ],
-  "settings": {
-    "omnisharp.path": "latest" // https://github.com/OmniSharp/omnisharp-vscode/issues/5410#issuecomment-1284531542.
+  "customizations": {
+    "extensions": [
+      "formulahendry.dotnet-test-explorer",
+      "ms-azuretools.vscode-docker",
+      "ms-dotnettools.csharp"
+    ],
+    "settings": {
+      "omnisharp.path": "latest" // https://github.com/OmniSharp/omnisharp-vscode/issues/5410#issuecomment-1284531542.
+    }
   },
-  "postCreateCommand": ["git", "lfs", "pull"],
+  "postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && git lfs checkout",
   "postStartCommand": ["dotnet", "build"]
 }

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -88,11 +88,9 @@ namespace DotNet.Testcontainers.Clients
       return Docker.Images.DeleteImageAsync(image.FullName, new ImageDeleteParameters { Force = true }, ct);
     }
 
-    public async Task<string> BuildAsync(IImageFromDockerfileConfiguration configuration, CancellationToken ct = default)
+    public async Task<string> BuildAsync(IImageFromDockerfileConfiguration configuration, ITarArchive dockerfileArchive, CancellationToken ct = default)
     {
       var image = configuration.Image;
-
-      ITarArchive dockerfileArchive = new DockerfileArchive(configuration.DockerfileDirectory, configuration.Dockerfile, image, _logger);
 
       var imageExists = await ExistsWithNameAsync(image.FullName, ct)
         .ConfigureAwait(false);

--- a/src/Testcontainers/Clients/IDockerImageOperations.cs
+++ b/src/Testcontainers/Clients/IDockerImageOperations.cs
@@ -12,6 +12,6 @@ namespace DotNet.Testcontainers.Clients
 
     Task DeleteAsync(IImage image, CancellationToken ct = default);
 
-    Task<string> BuildAsync(IImageFromDockerfileConfiguration configuration, CancellationToken ct = default);
+    Task<string> BuildAsync(IImageFromDockerfileConfiguration configuration, ITarArchive dockerfileArchive, CancellationToken ct = default);
   }
 }

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
@@ -103,7 +103,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Returns a collection with all configured wait strategies.
     /// </summary>
-    /// <returns>List with all configured wait strategies.</returns>
+    /// <returns>Returns a list with all configured wait strategies.</returns>
     [PublicAPI]
     IEnumerable<IWaitUntil> Build();
   }

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -97,7 +97,7 @@ namespace DotNet.Testcontainers.Images
 
       var stages = lines
         .Select(line => line.Value)
-        .Select(line => line.Split(new [] { " AS " }, StringSplitOptions.RemoveEmptyEntries))
+        .Select(line => line.Split(new [] { " AS ", " As ", " aS ", " as " }, StringSplitOptions.RemoveEmptyEntries))
         .Where(substrings => substrings.Length > 1)
         .Select(substrings => substrings[substrings.Length - 1])
         .Distinct()

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -72,7 +72,7 @@ namespace DotNet.Testcontainers.Images
     /// <remarks>
     /// This method reads the Dockerfile and collects a list of base images. It
     /// excludes stages that do not correspond to base images. For example, it will not include
-    /// the second line in the Dockerfile below:
+    /// the second line from the following Dockerfile configuration:
     /// <code>
     ///   FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
     ///   FROM build

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -89,6 +89,8 @@ namespace DotNet.Testcontainers.Images
         .Where(line => !line.StartsWith("#", StringComparison.Ordinal))
         .Select(line => FromLinePattern.Match(line))
         .Where(match => match.Success)
+        // Until now, we are unable to resolve variables within Dockerfiles. Ignore base
+        // images that utilize variables. Expect them to exist on the host.
         .Where(match => !match.Groups[imageGroup].Value.Contains('$'))
         .Where(match => !match.Groups[imageGroup].Value.Any(char.IsUpper))
         .ToArray();

--- a/tests/Testcontainers.Tests/Assets/.dockerignore
+++ b/tests/Testcontainers.Tests/Assets/.dockerignore
@@ -2,4 +2,5 @@ Dockerfile
 credHelpers
 credsStore
 healthWaitStrategy
+pullBaseImages
 **/*.md

--- a/tests/Testcontainers.Tests/Assets/pullBaseImages/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/pullBaseImages/Dockerfile
@@ -1,0 +1,7 @@
+ARG REPO=mcr.microsoft.com/dotnet/aspnet
+FROM $REPO:6.0.21-jammy-amd64
+FROM ${REPO}:6.0.21-jammy-amd64
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
+FROM build AS publish
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.21-jammy-amd64

--- a/tests/Testcontainers.Tests/Assets/pullBaseImages/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/pullBaseImages/Dockerfile
@@ -3,5 +3,6 @@ FROM $REPO:6.0.21-jammy-amd64
 FROM ${REPO}:6.0.21-jammy-amd64
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
+FROM build
 FROM build AS publish
 FROM mcr.microsoft.com/dotnet/aspnet:6.0.21-jammy-amd64

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -3,6 +3,7 @@ namespace DotNet.Testcontainers.Tests.Unit
   using System;
   using System.Collections.Generic;
   using System.IO;
+  using System.Linq;
   using System.Text;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Builders;
@@ -15,16 +16,31 @@ namespace DotNet.Testcontainers.Tests.Unit
   public sealed class ImageFromDockerfileTest
   {
     [Fact]
+    public void DockerfileArchiveGetBaseImages()
+    {
+      // Given
+      IImage image = new DockerImage("localhost/testcontainers", Guid.NewGuid().ToString("D"), string.Empty);
+
+      var dockerfileArchive = new DockerfileArchive("Assets//pullBaseImages/", "Dockerfile", image, NullLogger.Instance);
+
+      // When
+      var baseImages = dockerfileArchive.GetBaseImages();
+
+      // Then
+      Assert.Equal(3, baseImages.Count());
+    }
+
+    [Fact]
     public async Task DockerfileArchiveTar()
     {
       // Given
-      var image = new DockerImage("testcontainers", "test", "0.1.0");
+      IImage image = new DockerImage("localhost/testcontainers", Guid.NewGuid().ToString("D"), string.Empty);
 
       var expected = new SortedSet<string> { ".dockerignore", "Dockerfile", "setup/setup.sh" };
 
       var actual = new SortedSet<string>();
 
-      var dockerfileArchive = new DockerfileArchive("Assets", "Dockerfile", image, NullLogger.Instance);
+      var dockerfileArchive = new DockerfileArchive("Assets/", "Dockerfile", image, NullLogger.Instance);
 
       var dockerfileArchiveFilePath = await dockerfileArchive.Tar()
         .ConfigureAwait(false);
@@ -91,7 +107,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
         .WithName(tag1)
         .WithDockerfile("Dockerfile")
-        .WithDockerfileDirectory("Assets")
+        .WithDockerfileDirectory("Assets/")
         .WithDeleteIfExists(true)
         .WithCreateParameterModifier(parameterModifier => parameterModifier.Tags.Add(tag2.FullName))
         .Build();


### PR DESCRIPTION
## What does this PR do?

This pull request excludes Dockerfile build stages that do not correspond to base images.

## Why is it important?

This pull request addresses an issue related to building Docker images that have dependencies on base images from private registries. Currently, Testcontainers encounters an issue when attempting to pull actual images. Testcontainers does not distinguish between base images and intermediate build stages. Intermediate build stages cannot be pulled; Testcontainers must ignore these stages. E.g. the second line of the following Dockerfile:

```Dockerfile
FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
FROM build
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #972
- Relates #980

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Follow-ups

Testcontainers for .NET cannot resolve variables (`ARG`s) during the Docker image build process. Currently, Testcontainers ignores all base images that utilize variables. To pull these base images in advance too, Testcontainers needs to have the capability to resolve the default values or build arguments of variables.