### PR TITLE
Change WithDatabase method to public

### DIFF
--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -104,7 +104,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// </remarks>
     /// <param name="database">The MsSql database.</param>
     /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
-    private MsSqlBuilder WithDatabase(string database)
+    public MsSqlBuilder WithDatabase(string database)
     {
         return Merge(DockerResourceConfiguration, new MsSqlConfiguration(database: database))
             .WithEnvironment("SQLCMDDBNAME", database);


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Expose the `WithDatabase` method of `MsSqlBuilder`

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

By default the initial catalog of the connectionstring is set to master. In some cases we want to just delete and recreate the whole database which is not possible for the master database.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
