### PR TITLE
chore: Update BouncyCastle.Cryptography to 2.2.1 (previous Portable.BouncyCastle)

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -6,7 +6,7 @@
     <PackageReference Update="Docker.DotNet.X509" Version="3.125.15" />
     <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
-    <PackageReference Update="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Update="BouncyCastle.Cryptography" Version="2.2.1" />
     <PackageReference Update="SharpZipLib" Version="1.4.2" />
     <PackageReference Update="SSH.NET" Version="2020.0.2" />
     <PackageReference Update="System.Text.Json" Version="6.0.8" />

--- a/src/Testcontainers/Testcontainers.csproj
+++ b/src/Testcontainers/Testcontainers.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Docker.DotNet.X509" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-    <PackageReference Include="Portable.BouncyCastle" />
+    <PackageReference Include="BouncyCastle.Cryptography" />
     <PackageReference Include="SharpZipLib" />
     <PackageReference Include="SSH.NET" />
     <PackageReference Include="System.Text.Json" />


### PR DESCRIPTION
Dependency update.

## What does this PR do?

Moving back to the main distro of BouncyCastle.Crypto now that it supports netstandard etc.
https://www.nuget.org/packages/BouncyCastle.Cryptography

## Why is it important?

Portable.BouncyCastle hasn't been updated in almost 2 years, and I assume Claire didn't intend to own it forever.

## Related issues

n/a (that I know of)

## How to test this PR

This builds but the tests have some failures I'm not able to diagnose; also the test process stalled on the last step (see gist) for more than 15 minutes before I killed it.
https://gist.github.com/jcmrva/c83912eb5834b4c0d67f07671b0771d0