### PR TITLE
feat: Extend the "wait until file exists" API to distinguish between the test host and container filesystem

### DIFF
--- a/src/Testcontainers/Configurations/FileSystem.cs
+++ b/src/Testcontainers/Configurations/FileSystem.cs
@@ -9,7 +9,7 @@ namespace DotNet.Testcontainers.Configurations
   public enum FileSystem
   {
     /// <summary>
-    /// The file system of the host machine.
+    /// The test host file system.
     /// </summary>
     Host = 0,
 

--- a/src/Testcontainers/Configurations/FileSystem.cs
+++ b/src/Testcontainers/Configurations/FileSystem.cs
@@ -1,0 +1,21 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Indicates the file system for file operations.
+  /// </summary>
+  [PublicAPI]
+  public enum FileSystem
+  {
+    /// <summary>
+    /// The file system of the host machine.
+    /// </summary>
+    Host = 0,
+
+    /// <summary>
+    /// The container file system.
+    /// </summary>
+    Container = 1,
+  }
+}

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
@@ -55,7 +55,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="file">The file to be checked.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     [PublicAPI]
-    IWaitForContainerOS UntilFileExists(string file);
+    IWaitForContainerOS UntilFileExists(string file, FileSystem fileSystem = FileSystem.Host);
 
     /// <summary>
     /// Waits until the message is logged.

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
@@ -52,10 +52,11 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Waits until the file exists.
     /// </summary>
-    /// <param name="file">The file to be checked.</param>
+    /// <param name="filePath">The file path to be checked.</param>
+    /// <param name="fileSystem">The file system to be checked.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     [PublicAPI]
-    IWaitForContainerOS UntilFileExists(string file, FileSystem fileSystem = FileSystem.Host);
+    IWaitForContainerOS UntilFileExists(string filePath, FileSystem fileSystem = FileSystem.Host);
 
     /// <summary>
     /// Waits until the message is logged.

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilFileExistsInContainer.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilFileExistsInContainer.cs
@@ -4,11 +4,11 @@ namespace DotNet.Testcontainers.Configurations
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
 
-  internal class UntilFilesExistsInContainer : IWaitUntil
+  internal class UntilFileExistsInContainer : IWaitUntil
   {
     private readonly string _file;
 
-    public UntilFilesExistsInContainer(string file)
+    public UntilFileExistsInContainer(string file)
     {
       _file = file;
     }
@@ -17,7 +17,9 @@ namespace DotNet.Testcontainers.Configurations
     {
       try
       {
-        await container.ReadFileAsync(_file);
+        _ = await container.ReadFileAsync(_file)
+          .ConfigureAwait(false);
+
         return true;
       }
       catch (FileNotFoundException)

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilFileExistsInContainer.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilFileExistsInContainer.cs
@@ -1,0 +1,29 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System.IO;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Containers;
+
+  internal class UntilFilesExistsInContainer : IWaitUntil
+  {
+    private readonly string _file;
+
+    public UntilFilesExistsInContainer(string file)
+    {
+      _file = file;
+    }
+
+    public async Task<bool> UntilAsync(IContainer container)
+    {
+      try
+      {
+        await container.ReadFileAsync(_file);
+        return true;
+      }
+      catch (FileNotFoundException)
+      {
+        return false;
+      }
+    }
+  }
+}

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilFileExistsOnHost.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilFileExistsOnHost.cs
@@ -4,11 +4,11 @@ namespace DotNet.Testcontainers.Configurations
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Containers;
 
-  internal class UntilFilesExists : IWaitUntil
+  internal class UntilFileExistsOnHost : IWaitUntil
   {
     private readonly string _file;
 
-    public UntilFilesExists(string file)
+    public UntilFileExistsOnHost(string file)
     {
       _file = file;
     }

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
@@ -34,15 +34,15 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS UntilFileExists(string file, FileSystem fileSystem = FileSystem.Host)
+    public virtual IWaitForContainerOS UntilFileExists(string filePath, FileSystem fileSystem = FileSystem.Host)
     {
       switch (fileSystem)
       {
         case FileSystem.Container:
-          return AddCustomWaitStrategy(new UntilFilesExistsInContainer(file));
+          return AddCustomWaitStrategy(new UntilFileExistsInContainer(filePath));
         case FileSystem.Host:
         default:
-          return AddCustomWaitStrategy(new UntilFilesExists(file));
+          return AddCustomWaitStrategy(new UntilFileExistsOnHost(filePath));
       }
     }
 

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
@@ -34,9 +34,16 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS UntilFileExists(string file)
+    public virtual IWaitForContainerOS UntilFileExists(string file, FileSystem fileSystem = FileSystem.Host)
     {
-      return AddCustomWaitStrategy(new UntilFilesExists(file));
+      switch (fileSystem)
+      {
+        case FileSystem.Container:
+          return AddCustomWaitStrategy(new UntilFilesExistsInContainer(file));
+        case FileSystem.Host:
+        default:
+          return AddCustomWaitStrategy(new UntilFilesExists(file));
+      }
     }
 
     /// <inheritdoc />

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilFileExistsInContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilFileExistsInContainerTest.cs
@@ -1,17 +1,37 @@
 namespace DotNet.Testcontainers.Tests.Unit
 {
-  using DotNet.Testcontainers.Builders;
-  using DotNet.Testcontainers.Commons;
-  using DotNet.Testcontainers.Configurations;
   using System;
   using System.Collections.Generic;
   using System.Threading;
   using System.Threading.Tasks;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Commons;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Containers;
   using Xunit;
 
-  public sealed class WaitUntilFileExistsInContainerTest : IDisposable
+  public sealed class WaitUntilFileExistsInContainerTest : IAsyncLifetime, IDisposable
   {
-    private readonly CancellationTokenSource _cts = new(TimeSpan.FromMinutes(1));
+    private const string ContainerFilePath = "/tmp/hostname";
+
+    private readonly CancellationTokenSource _cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
+
+    private readonly IContainer _container = new ContainerBuilder()
+      .WithImage(CommonImages.Alpine)
+      .WithEntrypoint("/bin/sh", "-c")
+      .WithCommand("hostname > " + ContainerFilePath + "; trap : TERM INT; sleep infinity & wait")
+      .WithWaitStrategy(Wait.ForUnixContainer().UntilFileExists(ContainerFilePath, FileSystem.Container))
+      .Build();
+
+    public Task InitializeAsync()
+    {
+      return _container.StartAsync(_cts.Token);
+    }
+
+    public Task DisposeAsync()
+    {
+      return _container.DisposeAsync().AsTask();
+    }
 
     public void Dispose()
     {
@@ -21,25 +41,10 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public async Task ContainerIsRunning()
     {
-      // Given
-      const string target = "tmp";
-
-      const string file = "hostname";
-
-      await using var container = new ContainerBuilder()
-        .WithImage(CommonImages.Nginx)
-        .WithEntrypoint("/bin/sh", "-c")
-        .WithCommand($"hostname > /{target}/{file}; trap : TERM INT; sleep infinity & wait")
-        .WithWaitStrategy(Wait.ForUnixContainer().UntilFileExists($"/{target}/{file}", FileSystem.Container))
-        .Build();
-
-      // When
-      await container.StartAsync(_cts.Token)
+      var execResult = await _container.ExecAsync(new List<string> { "test", "-f", ContainerFilePath })
         .ConfigureAwait(false);
 
-      // Then
-      var catResult = await container.ExecAsync(new List<string> { "cat", $"/{target}/{file}" });
-      Assert.NotEmpty(catResult.Stdout);
+      Assert.Equal(0, execResult.ExitCode);
     }
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilFileExistsInContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilFileExistsInContainerTest.cs
@@ -1,0 +1,45 @@
+namespace DotNet.Testcontainers.Tests.Unit
+{
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Commons;
+  using DotNet.Testcontainers.Configurations;
+  using System;
+  using System.Collections.Generic;
+  using System.Threading;
+  using System.Threading.Tasks;
+  using Xunit;
+
+  public sealed class WaitUntilFileExistsInContainerTest : IDisposable
+  {
+    private readonly CancellationTokenSource _cts = new(TimeSpan.FromMinutes(1));
+
+    public void Dispose()
+    {
+      _cts.Dispose();
+    }
+
+    [Fact]
+    public async Task ContainerIsRunning()
+    {
+      // Given
+      const string target = "tmp";
+
+      const string file = "hostname";
+
+      await using var container = new ContainerBuilder()
+        .WithImage(CommonImages.Nginx)
+        .WithEntrypoint("/bin/sh", "-c")
+        .WithCommand($"hostname > /{target}/{file}; trap : TERM INT; sleep infinity & wait")
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilFileExists($"/{target}/{file}", FileSystem.Container))
+        .Build();
+
+      // When
+      await container.StartAsync(_cts.Token)
+        .ConfigureAwait(false);
+
+      // Then
+      var catResult = await container.ExecAsync(new List<string> { "cat", $"/{target}/{file}" });
+      Assert.NotEmpty(catResult.Stdout);
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?
The existing implementation of the UntilFileExists WaitStrategy seems to look for a file in the host's file system instead of the container's.
This PR changes that so UntilFileExists looks for the file in the container's file system instead.

## Why is it important?
Looking for a file on the host instead of the container seems like incorrect behavior.
