### PR TITLE
feat: Ignore FROM args when pre-pulling images

### DIFF
--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -20,19 +20,15 @@ using Elastic.Transport;
 using Testcontainers.Elasticsearch;
 using Xunit;
 
-namespace TestcontainersModules;
-
-public class ElasticsearchContainerTest : IAsyncLifetime
+public sealed class ElasticsearchContainerTest : IAsyncLifetime
 {
-    private readonly ElasticsearchContainer elasticsearch
-        = new ElasticsearchBuilder()
-            .Build();
+    private readonly ElasticsearchContainer _elasticsearch
+        = new ElasticsearchBuilder().Build();
 
     [Fact]
     public async Task ReadFromElasticsearch()
     {
-        var connectionString = elasticsearch.GetConnectionString();
-        var settings = new ElasticsearchClientSettings(new Uri(connectionString));
+        var settings = new ElasticsearchClientSettings(new Uri(_elasticsearch.GetConnectionString()));
         settings.ServerCertificateValidationCallback(CertificateValidations.AllowAll);
 
         var client = new ElasticsearchClient(settings);
@@ -43,10 +39,10 @@ public class ElasticsearchContainerTest : IAsyncLifetime
     }
 
     public Task InitializeAsync()
-        => elasticsearch.StartAsync();
+        => _elasticsearch.StartAsync();
 
     public Task DisposeAsync()
-        => elasticsearch.DisposeAsync().AsTask();
+        => _elasticsearch.DisposeAsync().AsTask();
 }
 ```
 

--- a/docs/modules/mongodb.md
+++ b/docs/modules/mongodb.md
@@ -21,16 +21,15 @@ using Xunit;
 
 namespace TestcontainersModules;
 
-public class MongoDbContainerTest : IAsyncLifetime
+public sealed class MongoDbContainerTest : IAsyncLifetime
 {
-    private readonly MongoDbContainer mongoDbContainer =
-        new MongoDbBuilder()
-            .Build();
+    private readonly MongoDbContainer _mongoDbContainer =
+        new MongoDbBuilder().Build();
 
     [Fact]
     public async Task ReadFromMongoDbDatabase()
     {
-        var client = new MongoClient(mongoDbContainer.GetConnectionString());
+        var client = new MongoClient(_mongoDbContainer.GetConnectionString());
 
         using var databases = await client.ListDatabasesAsync();
 
@@ -38,10 +37,10 @@ public class MongoDbContainerTest : IAsyncLifetime
     }
 
     public Task InitializeAsync()
-        => mongoDbContainer.StartAsync();
+        => _mongoDbContainer.StartAsync();
 
     public Task DisposeAsync()
-        => mongoDbContainer.DisposeAsync().AsTask();
+        => _mongoDbContainer.DisposeAsync().AsTask();
 }
 ```
 

--- a/docs/modules/mssql.md
+++ b/docs/modules/mssql.md
@@ -21,30 +21,29 @@ using Xunit;
 
 namespace TestcontainersModules;
 
-public class MsSqlServerContainerTest : IAsyncLifetime
+public sealed class MsSqlServerContainerTest : IAsyncLifetime
 {
-    private readonly MsSqlContainer msSqlContainer
-        = new MsSqlBuilder()
-            .Build();
+    private readonly MsSqlContainer _msSqlContainer
+        = new MsSqlBuilder().Build();
 
     [Fact]
     public async Task ReadFromMsSqlDatabase()
     {
-        await using var connection = new SqlConnection(msSqlContainer.GetConnectionString());
+        await using var connection = new SqlConnection(_msSqlContainer.GetConnectionString());
         await connection.OpenAsync();
 
         await using var command = connection.CreateCommand();
-        command.CommandText = "Select 1;";
+        command.CommandText = "SELECT 1;";
 
         var actual = await command.ExecuteScalarAsync() as int?;
-        Assert.Equal(expected: 1, actual: actual.GetValueOrDefault());
+        Assert.Equal(1, actual.GetValueOrDefault());
     }
 
     public Task InitializeAsync()
-        => msSqlContainer.StartAsync();
+        => _msSqlContainer.StartAsync();
 
     public Task DisposeAsync()
-        => msSqlContainer.DisposeAsync().AsTask();
+        => _msSqlContainer.DisposeAsync().AsTask();
 }
 ```
 

--- a/docs/modules/neo4j.md
+++ b/docs/modules/neo4j.md
@@ -21,18 +21,17 @@ using Xunit;
 
 namespace TestcontainersModules;
 
-public class Neo4jContainerTest : IAsyncLifetime
+public sealed class Neo4jContainerTest : IAsyncLifetime
 {
-    private readonly Neo4jContainer neo4jContainer
-        = new Neo4jBuilder()
-            .Build();
+    private readonly Neo4jContainer _neo4jContainer
+        = new Neo4jBuilder().Build();
 
     [Fact]
     public async Task CanReadNeo4jDatabase()
     {
         const string database = "neo4j";
 
-        await using var client = GraphDatabase.Driver(neo4jContainer.GetConnectionString());
+        await using var client = GraphDatabase.Driver(_neo4jContainer.GetConnectionString());
 
         await using var session = client.AsyncSession(cfg => cfg.WithDatabase(database));
 
@@ -40,10 +39,10 @@ public class Neo4jContainerTest : IAsyncLifetime
     }
 
     public Task InitializeAsync()
-        => neo4jContainer.StartAsync();
+        => _neo4jContainer.StartAsync();
 
     public Task DisposeAsync()
-        => neo4jContainer.DisposeAsync().AsTask();
+        => _neo4jContainer.DisposeAsync().AsTask();
 }
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,5 +39,9 @@ nav:
     - examples/aspnet.md
   - Modules:
     - modules/index.md
+    - modules/elasticsearch.md
+    - modules/mongodb.md
+    - modules/mssql.md
+    - modules/neo4j.md
     - modules/postgres.md
     - modules/rabbitmq.md

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -102,6 +102,8 @@ namespace DotNet.Testcontainers.Images
       var images = lines
         .Select(match => match.Groups[imageGroup])
         .Select(match => match.Value)
+        // Until now, we are unable to resolve variables within Dockerfiles. Ignore base
+        // images that utilize variables. Expect them to exist on the host.
         .Where(line => !line.Contains('$'))
         .Where(line => !line.Any(char.IsUpper))
         .Where(value => !stages.Contains(value))

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -89,10 +89,6 @@ namespace DotNet.Testcontainers.Images
         .Where(line => !line.StartsWith("#", StringComparison.Ordinal))
         .Select(line => FromLinePattern.Match(line))
         .Where(match => match.Success)
-        // Until now, we are unable to resolve variables within Dockerfiles. Ignore base
-        // images that utilize variables. Expect them to exist on the host.
-        .Where(match => !match.Groups[imageGroup].Value.Contains('$'))
-        .Where(match => !match.Groups[imageGroup].Value.Any(char.IsUpper))
         .ToArray();
 
       var stages = lines
@@ -105,7 +101,9 @@ namespace DotNet.Testcontainers.Images
 
       var images = lines
         .Select(match => match.Groups[imageGroup])
-        .Select(group => group.Value)
+        .Select(match => match.Value)
+        .Where(line => !line.Contains('$'))
+        .Where(line => !line.Any(char.IsUpper))
         .Where(value => !stages.Contains(value))
         .Distinct()
         .Select(value => new DockerImage(value))

--- a/tests/Testcontainers.Neo4j.Tests/Neo4jContainerTest.cs
+++ b/tests/Testcontainers.Neo4j.Tests/Neo4jContainerTest.cs
@@ -24,7 +24,7 @@ public sealed class Neo4jContainerTest : IAsyncLifetime
         using var driver = GraphDatabase.Driver(_neo4jContainer.GetConnectionString());
 
         // When
-        using var session = driver.AsyncSession(sessionConfigBuilder => sessionConfigBuilder.WithDatabase("neo4j"));
+        using var session = driver.AsyncSession(sessionConfigBuilder => sessionConfigBuilder.WithDatabase(database));
 
         // Then
         Assert.Equal(database, session.SessionConfig.Database);

--- a/tests/Testcontainers.Tests/Assets/pullBaseImages/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/pullBaseImages/Dockerfile
@@ -6,3 +6,4 @@ FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
 FROM build
 FROM build AS publish
 FROM mcr.microsoft.com/dotnet/aspnet:6.0.21-jammy-amd64
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0.22-jammy-amd64

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -21,13 +21,17 @@ namespace DotNet.Testcontainers.Tests.Unit
       // Given
       IImage image = new DockerImage("localhost/testcontainers", Guid.NewGuid().ToString("D"), string.Empty);
 
-      var dockerfileArchive = new DockerfileArchive("Assets//pullBaseImages/", "Dockerfile", image, NullLogger.Instance);
+      var dockerfileArchive = new DockerfileArchive("Assets/pullBaseImages/", "Dockerfile", image, NullLogger.Instance);
 
       // When
-      var baseImages = dockerfileArchive.GetBaseImages();
+      var baseImages = dockerfileArchive.GetBaseImages().ToArray();
 
       // Then
-      Assert.Equal(3, baseImages.Count());
+      Assert.Equal(4, baseImages.Length);
+      Assert.Contains(baseImages, item => "mcr.microsoft.com/dotnet/sdk:6.0".Equals(item.FullName));
+      Assert.Contains(baseImages, item => "mcr.microsoft.com/dotnet/runtime:6.0".Equals(item.FullName));
+      Assert.Contains(baseImages, item => "mcr.microsoft.com/dotnet/aspnet:6.0.21-jammy-amd64".Equals(item.FullName));
+      Assert.Contains(baseImages, item => "mcr.microsoft.com/dotnet/aspnet:6.0.22-jammy-amd64".Equals(item.FullName));
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

Besides the changes made to the `docs`, the pull request changes the way we resolve base images from Dockerfiles. It ignores arguments like `--platform` following the `FROM` statement and pre-pulls the actual image.

## Why is it important?

The previous implementation omitted those images and did not pre-pull them. @MartinSchmidt, I believe these changes will accommodate your use case. Could you possibly test it? Your feedback would be appreciated.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #993

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
