### PR TITLE
feat: Use Docker's inspect API to get resource information

### DIFF
--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -84,7 +84,7 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    public TBuilderEntity WithImagePullPolicy(Func<ImagesListResponse, bool> imagePullPolicy)
+    public TBuilderEntity WithImagePullPolicy(Func<ImageInspectResponse, bool> imagePullPolicy)
     {
       return Clone(new ContainerConfiguration(imagePullPolicy: imagePullPolicy));
     }

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -78,7 +78,7 @@ namespace DotNet.Testcontainers.Builders
     /// <param name="imagePullPolicy">The image pull policy.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
-    TBuilderEntity WithImagePullPolicy(Func<ImagesListResponse, bool> imagePullPolicy);
+    TBuilderEntity WithImagePullPolicy(Func<ImageInspectResponse, bool> imagePullPolicy);
 
     /// <summary>
     /// Sets the name.

--- a/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
+++ b/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
@@ -59,7 +59,7 @@ namespace DotNet.Testcontainers.Builders
     /// <param name="imageBuildPolicy">The image build policy.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
-    TBuilderEntity WithImageBuildPolicy(Func<ImagesListResponse, bool> imageBuildPolicy);
+    TBuilderEntity WithImageBuildPolicy(Func<ImageInspectResponse, bool> imageBuildPolicy);
 
     /// <summary>
     /// Removes an existing image before building it again.

--- a/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
@@ -81,7 +81,7 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    public ImageFromDockerfileBuilder WithImageBuildPolicy(Func<ImagesListResponse, bool> imageBuildPolicy)
+    public ImageFromDockerfileBuilder WithImageBuildPolicy(Func<ImageInspectResponse, bool> imageBuildPolicy)
     {
       return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(imageBuildPolicy: imageBuildPolicy));
     }

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -14,8 +14,6 @@ namespace DotNet.Testcontainers.Clients
 
   internal sealed class DockerContainerOperations : DockerApiClient, IDockerContainerOperations
   {
-    private static readonly ContainerInspectResponse NoSuchContainer = new ContainerInspectResponse();
-
     private readonly ILogger _logger;
 
     public DockerContainerOperations(Guid sessionId, IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig, ILogger logger)
@@ -55,7 +53,7 @@ namespace DotNet.Testcontainers.Clients
       }
       catch (DockerApiException)
       {
-        return NoSuchContainer;
+        return null;
       }
     }
 
@@ -64,7 +62,7 @@ namespace DotNet.Testcontainers.Clients
       var response = await ByIdAsync(id, ct)
         .ConfigureAwait(false);
 
-      return !NoSuchContainer.Equals(response);
+      return response != null;
     }
 
     public async Task<bool> ExistsWithNameAsync(string name, CancellationToken ct = default)
@@ -72,7 +70,7 @@ namespace DotNet.Testcontainers.Clients
       var response = await ByNameAsync(name, ct)
         .ConfigureAwait(false);
 
-      return !NoSuchContainer.Equals(response);
+      return response != null;
     }
 
     public async Task<long> GetExitCodeAsync(string id, CancellationToken ct = default)

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -4,7 +4,6 @@ namespace DotNet.Testcontainers.Clients
   using System.Collections.Generic;
   using System.Globalization;
   using System.IO;
-  using System.Linq;
   using System.Threading;
   using System.Threading.Tasks;
   using Docker.DotNet.Models;
@@ -24,25 +23,29 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<IEnumerable<ContainerListResponse>> GetAllAsync(CancellationToken ct = default)
     {
-      return (await Docker.Containers.ListContainersAsync(new ContainersListParameters { All = true }, ct)
-        .ConfigureAwait(false)).ToArray();
+      return await Docker.Containers.ListContainersAsync(new ContainersListParameters { All = true }, ct)
+        .ConfigureAwait(false);
     }
 
-    public Task<ContainerListResponse> ByIdAsync(string id, CancellationToken ct = default)
+    public async Task<IEnumerable<ContainerListResponse>> GetAllAsync(FilterByProperty filters, CancellationToken ct = default)
+    {
+      return await Docker.Containers.ListContainersAsync(new ContainersListParameters { All = true, Filters = filters }, ct)
+        .ConfigureAwait(false);
+    }
+
+    public Task<ContainerInspectResponse> ByIdAsync(string id, CancellationToken ct = default)
     {
       return ByPropertyAsync("id", id, ct);
     }
 
-    public Task<ContainerListResponse> ByNameAsync(string name, CancellationToken ct = default)
+    public Task<ContainerInspectResponse> ByNameAsync(string name, CancellationToken ct = default)
     {
       return ByPropertyAsync("name", name, ct);
     }
 
-    public async Task<ContainerListResponse> ByPropertyAsync(string property, string value, CancellationToken ct = default)
+    public Task<ContainerInspectResponse> ByPropertyAsync(string property, string value, CancellationToken ct = default)
     {
-      var filters = new FilterByProperty { { property, value } };
-      return (await Docker.Containers.ListContainersAsync(new ContainersListParameters { All = true, Filters = filters }, ct)
-        .ConfigureAwait(false)).FirstOrDefault();
+      return Docker.Containers.InspectContainerAsync(value, ct);
     }
 
     public async Task<bool> ExistsWithIdAsync(string id, CancellationToken ct = default)
@@ -213,11 +216,6 @@ namespace DotNet.Testcontainers.Clients
 
       _logger.DockerContainerCreated(createContainerResponse.ID);
       return createContainerResponse.ID;
-    }
-
-    public Task<ContainerInspectResponse> InspectAsync(string id, CancellationToken ct = default)
-    {
-      return Docker.Containers.InspectContainerAsync(id, ct);
     }
   }
 }

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -18,8 +18,6 @@ namespace DotNet.Testcontainers.Clients
 
     private readonly TraceProgress _traceProgress;
 
-    public static readonly ImageInspectResponse NoSuchImage = new ImageInspectResponse();
-
     public DockerImageOperations(Guid sessionId, IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig, ILogger logger)
       : base(sessionId, dockerEndpointAuthConfig)
     {
@@ -58,7 +56,7 @@ namespace DotNet.Testcontainers.Clients
       }
       catch (DockerApiException)
       {
-        return NoSuchImage;
+        return null;
       }
     }
 
@@ -67,7 +65,7 @@ namespace DotNet.Testcontainers.Clients
       var response = await ByIdAsync(id, ct)
         .ConfigureAwait(false);
 
-      return !NoSuchImage.Equals(response);
+      return response != null;
     }
 
     public async Task<bool> ExistsWithNameAsync(string name, CancellationToken ct = default)
@@ -75,7 +73,7 @@ namespace DotNet.Testcontainers.Clients
       var response = await ByNameAsync(name, ct)
         .ConfigureAwait(false);
 
-      return !NoSuchImage.Equals(response);
+      return response != null;
     }
 
     public async Task CreateAsync(IImage image, IDockerRegistryAuthenticationConfiguration dockerRegistryAuthConfig, CancellationToken ct = default)

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -26,26 +26,29 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<IEnumerable<ImagesListResponse>> GetAllAsync(CancellationToken ct = default)
     {
-      return (await Docker.Images.ListImagesAsync(new ImagesListParameters { All = true }, ct)
-        .ConfigureAwait(false)).ToArray();
+      return await Docker.Images.ListImagesAsync(new ImagesListParameters { All = true }, ct)
+        .ConfigureAwait(false);
     }
 
-    public async Task<ImagesListResponse> ByIdAsync(string id, CancellationToken ct = default)
+    public async Task<IEnumerable<ImagesListResponse>> GetAllAsync(FilterByProperty filters, CancellationToken ct = default)
     {
-      return (await GetAllAsync(ct)
-        .ConfigureAwait(false)).FirstOrDefault(image => image.ID.Equals(id, StringComparison.OrdinalIgnoreCase));
+      return await Docker.Images.ListImagesAsync(new ImagesListParameters { All = true, Filters = filters }, ct)
+        .ConfigureAwait(false);
     }
 
-    public Task<ImagesListResponse> ByNameAsync(string name, CancellationToken ct = default)
+    public Task<ImageInspectResponse> ByIdAsync(string id, CancellationToken ct = default)
     {
-      return ByPropertyAsync("reference", name, ct);
+      return ByPropertyAsync("id", id, ct);
     }
 
-    public async Task<ImagesListResponse> ByPropertyAsync(string property, string value, CancellationToken ct = default)
+    public Task<ImageInspectResponse> ByNameAsync(string name, CancellationToken ct = default)
     {
-      var filters = new FilterByProperty { { property, value } };
-      return (await Docker.Images.ListImagesAsync(new ImagesListParameters { All = true, Filters = filters }, ct)
-        .ConfigureAwait(false)).FirstOrDefault();
+      return ByPropertyAsync("name", name, ct);
+    }
+
+    public Task<ImageInspectResponse> ByPropertyAsync(string property, string value, CancellationToken ct = default)
+    {
+      return Docker.Images.InspectImageAsync(value, ct);
     }
 
     public async Task<bool> ExistsWithIdAsync(string id, CancellationToken ct = default)

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -14,11 +14,11 @@ namespace DotNet.Testcontainers.Clients
 
   internal sealed class DockerImageOperations : DockerApiClient, IDockerImageOperations
   {
-    private static readonly ImageInspectResponse NoSuchImage = new ImageInspectResponse();
-
     private readonly ILogger _logger;
 
     private readonly TraceProgress _traceProgress;
+
+    public static readonly ImageInspectResponse NoSuchImage = new ImageInspectResponse();
 
     public DockerImageOperations(Guid sessionId, IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig, ILogger logger)
       : base(sessionId, dockerEndpointAuthConfig)
@@ -46,7 +46,7 @@ namespace DotNet.Testcontainers.Clients
 
     public Task<ImageInspectResponse> ByNameAsync(string name, CancellationToken ct = default)
     {
-      return ByPropertyAsync("name", name, ct);
+      return ByPropertyAsync("reference", name, ct);
     }
 
     public async Task<ImageInspectResponse> ByPropertyAsync(string property, string value, CancellationToken ct = default)

--- a/src/Testcontainers/Clients/DockerNetworkOperations.cs
+++ b/src/Testcontainers/Clients/DockerNetworkOperations.cs
@@ -12,8 +12,6 @@ namespace DotNet.Testcontainers.Clients
 
   internal sealed class DockerNetworkOperations : DockerApiClient, IDockerNetworkOperations
   {
-    private static readonly NetworkResponse NoSuchNetwork = new NetworkResponse();
-
     private readonly ILogger _logger;
 
     public DockerNetworkOperations(Guid sessionId, IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig, ILogger logger)
@@ -53,7 +51,7 @@ namespace DotNet.Testcontainers.Clients
       }
       catch (DockerApiException)
       {
-        return NoSuchNetwork;
+        return null;
       }
     }
 
@@ -62,7 +60,7 @@ namespace DotNet.Testcontainers.Clients
       var response = await ByIdAsync(id, ct)
         .ConfigureAwait(false);
 
-      return !NoSuchNetwork.Equals(response);
+      return response != null;
     }
 
     public async Task<bool> ExistsWithNameAsync(string name, CancellationToken ct = default)
@@ -70,7 +68,7 @@ namespace DotNet.Testcontainers.Clients
       var response = await ByNameAsync(name, ct)
         .ConfigureAwait(false);
 
-      return !NoSuchNetwork.Equals(response);
+      return response != null;
     }
 
     public async Task<string> CreateAsync(INetworkConfiguration configuration, CancellationToken ct = default)

--- a/src/Testcontainers/Clients/DockerNetworkOperations.cs
+++ b/src/Testcontainers/Clients/DockerNetworkOperations.cs
@@ -21,14 +21,19 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<IEnumerable<NetworkResponse>> GetAllAsync(CancellationToken ct = default)
     {
-      return (await Docker.Networks.ListNetworksAsync(new NetworksListParameters(), ct)
-        .ConfigureAwait(false)).ToArray();
+      return await Docker.Networks.ListNetworksAsync(new NetworksListParameters(), ct)
+        .ConfigureAwait(false);
     }
 
-    public async Task<NetworkResponse> ByIdAsync(string id, CancellationToken ct = default)
+    public async Task<IEnumerable<NetworkResponse>> GetAllAsync(FilterByProperty filters, CancellationToken ct = default)
     {
-      return (await GetAllAsync(ct)
-        .ConfigureAwait(false)).FirstOrDefault(image => image.ID.Equals(id, StringComparison.OrdinalIgnoreCase));
+      return await Docker.Networks.ListNetworksAsync(new NetworksListParameters { Filters = filters }, ct)
+        .ConfigureAwait(false);
+    }
+
+    public Task<NetworkResponse> ByIdAsync(string id, CancellationToken ct = default)
+    {
+      return ByPropertyAsync("id", id, ct);
     }
 
     public Task<NetworkResponse> ByNameAsync(string name, CancellationToken ct = default)
@@ -36,11 +41,9 @@ namespace DotNet.Testcontainers.Clients
       return ByPropertyAsync("name", name, ct);
     }
 
-    public async Task<NetworkResponse> ByPropertyAsync(string property, string value, CancellationToken ct = default)
+    public Task<NetworkResponse> ByPropertyAsync(string property, string value, CancellationToken ct = default)
     {
-      var filters = new FilterByProperty { { property, value } };
-      return (await Docker.Networks.ListNetworksAsync(new NetworksListParameters { Filters = filters }, ct)
-        .ConfigureAwait(false)).FirstOrDefault();
+      return Docker.Networks.InspectNetworkAsync(value, ct);
     }
 
     public async Task<bool> ExistsWithIdAsync(string id, CancellationToken ct = default)

--- a/src/Testcontainers/Clients/DockerVolumeOperations.cs
+++ b/src/Testcontainers/Clients/DockerVolumeOperations.cs
@@ -12,8 +12,6 @@ namespace DotNet.Testcontainers.Clients
 
   internal sealed class DockerVolumeOperations : DockerApiClient, IDockerVolumeOperations
   {
-    private static readonly VolumeResponse NoSuchVolume = new VolumeResponse();
-
     private readonly ILogger _logger;
 
     public DockerVolumeOperations(Guid sessionId, IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig, ILogger logger)
@@ -57,7 +55,7 @@ namespace DotNet.Testcontainers.Clients
       }
       catch (DockerApiException)
       {
-        return NoSuchVolume;
+        return null;
       }
     }
 
@@ -66,7 +64,7 @@ namespace DotNet.Testcontainers.Clients
       var response = await ByIdAsync(id, ct)
         .ConfigureAwait(false);
 
-      return !NoSuchVolume.Equals(response);
+      return response != null;
     }
 
     public async Task<bool> ExistsWithNameAsync(string name, CancellationToken ct = default)
@@ -74,7 +72,7 @@ namespace DotNet.Testcontainers.Clients
       var response = await ByNameAsync(name, ct)
         .ConfigureAwait(false);
 
-      return !NoSuchVolume.Equals(response);
+      return response != null;
     }
 
     public async Task<string> CreateAsync(IVolumeConfiguration configuration, CancellationToken ct = default)

--- a/src/Testcontainers/Clients/DockerVolumeOperations.cs
+++ b/src/Testcontainers/Clients/DockerVolumeOperations.cs
@@ -21,13 +21,23 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<IEnumerable<VolumeResponse>> GetAllAsync(CancellationToken ct = default)
     {
-      return (await Docker.Volumes.ListAsync(ct)
-        .ConfigureAwait(false)).Volumes.ToArray();
+      var response = await Docker.Volumes.ListAsync(ct)
+        .ConfigureAwait(false);
+
+      return response.Volumes;
+    }
+
+    public async Task<IEnumerable<VolumeResponse>> GetAllAsync(FilterByProperty filters, CancellationToken ct = default)
+    {
+      var response = await Docker.Volumes.ListAsync(new VolumesListParameters { Filters = filters }, ct)
+        .ConfigureAwait(false);
+
+      return response.Volumes;
     }
 
     public Task<VolumeResponse> ByIdAsync(string id, CancellationToken ct = default)
     {
-      return Task.FromResult<VolumeResponse>(null);
+      return ByPropertyAsync("id", id, ct);
     }
 
     public Task<VolumeResponse> ByNameAsync(string name, CancellationToken ct = default)
@@ -35,11 +45,9 @@ namespace DotNet.Testcontainers.Clients
       return ByPropertyAsync("name", name, ct);
     }
 
-    public async Task<VolumeResponse> ByPropertyAsync(string property, string value, CancellationToken ct = default)
+    public Task<VolumeResponse> ByPropertyAsync(string property, string value, CancellationToken ct = default)
     {
-      var filters = new FilterByProperty { { property, value } };
-      return (await Docker.Volumes.ListAsync(new VolumesListParameters { Filters = filters }, ct)
-        .ConfigureAwait(false)).Volumes.FirstOrDefault();
+      return Docker.Volumes.InspectAsync(value, ct);
     }
 
     public async Task<bool> ExistsWithIdAsync(string id, CancellationToken ct = default)

--- a/src/Testcontainers/Clients/IDockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/IDockerContainerOperations.cs
@@ -9,7 +9,7 @@ namespace DotNet.Testcontainers.Clients
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
 
-  internal interface IDockerContainerOperations : IHasListOperations<ContainerListResponse>
+  internal interface IDockerContainerOperations : IHasListOperations<ContainerListResponse, ContainerInspectResponse>
   {
     Task<long> GetExitCodeAsync(string id, CancellationToken ct = default);
 
@@ -30,7 +30,5 @@ namespace DotNet.Testcontainers.Clients
     Task<ExecResult> ExecAsync(string id, IList<string> command, CancellationToken ct = default);
 
     Task<string> RunAsync(IContainerConfiguration configuration, CancellationToken ct = default);
-
-    Task<ContainerInspectResponse> InspectAsync(string id, CancellationToken ct = default);
   }
 }

--- a/src/Testcontainers/Clients/IDockerImageOperations.cs
+++ b/src/Testcontainers/Clients/IDockerImageOperations.cs
@@ -6,7 +6,7 @@ namespace DotNet.Testcontainers.Clients
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Images;
 
-  internal interface IDockerImageOperations : IHasListOperations<ImagesListResponse>
+  internal interface IDockerImageOperations : IHasListOperations<ImagesListResponse, ImageInspectResponse>
   {
     Task CreateAsync(IImage image, IDockerRegistryAuthenticationConfiguration dockerRegistryAuthConfig, CancellationToken ct = default);
 

--- a/src/Testcontainers/Clients/IDockerNetworkOperations.cs
+++ b/src/Testcontainers/Clients/IDockerNetworkOperations.cs
@@ -5,7 +5,7 @@ namespace DotNet.Testcontainers.Clients
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
 
-  internal interface IDockerNetworkOperations : IHasListOperations<NetworkResponse>
+  internal interface IDockerNetworkOperations : IHasListOperations<NetworkResponse, NetworkResponse>
   {
     Task<string> CreateAsync(INetworkConfiguration configuration, CancellationToken ct = default);
 

--- a/src/Testcontainers/Clients/IDockerVolumeOperations.cs
+++ b/src/Testcontainers/Clients/IDockerVolumeOperations.cs
@@ -5,7 +5,7 @@ namespace DotNet.Testcontainers.Clients
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
 
-  internal interface IDockerVolumeOperations : IHasListOperations<VolumeResponse>
+  internal interface IDockerVolumeOperations : IHasListOperations<VolumeResponse, VolumeResponse>
   {
     Task<string> CreateAsync(IVolumeConfiguration configuration, CancellationToken ct = default);
 

--- a/src/Testcontainers/Clients/IHasListOperations.cs
+++ b/src/Testcontainers/Clients/IHasListOperations.cs
@@ -4,15 +4,17 @@ namespace DotNet.Testcontainers.Clients
   using System.Threading;
   using System.Threading.Tasks;
 
-  internal interface IHasListOperations<T>
+  internal interface IHasListOperations<TListEntity, TInspectEntity>
   {
-    Task<IEnumerable<T>> GetAllAsync(CancellationToken ct = default);
+    Task<IEnumerable<TListEntity>> GetAllAsync(CancellationToken ct = default);
 
-    Task<T> ByIdAsync(string id, CancellationToken ct = default);
+    Task<IEnumerable<TListEntity>> GetAllAsync(FilterByProperty filters, CancellationToken ct = default);
 
-    Task<T> ByNameAsync(string name, CancellationToken ct = default);
+    Task<TInspectEntity> ByIdAsync(string id, CancellationToken ct = default);
 
-    Task<T> ByPropertyAsync(string property, string value, CancellationToken ct = default);
+    Task<TInspectEntity> ByNameAsync(string name, CancellationToken ct = default);
+
+    Task<TInspectEntity> ByPropertyAsync(string property, string value, CancellationToken ct = default);
 
     Task<bool> ExistsWithIdAsync(string id, CancellationToken ct = default);
 

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -64,14 +64,6 @@ namespace DotNet.Testcontainers.Clients
     Task<(string Stdout, string Stderr)> GetContainerLogsAsync(string id, DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default);
 
     /// <summary>
-    /// Gets the container low-level information object.
-    /// </summary>
-    /// <param name="id">The container id.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that gets the container low-level information object.</returns>
-    Task<ContainerInspectResponse> InspectContainerAsync(string id, CancellationToken ct = default);
-
-    /// <summary>
     /// Starts the container.
     /// </summary>
     /// <param name="id">The container id.</param>

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -5,7 +5,6 @@ namespace DotNet.Testcontainers.Clients
   using System.IO;
   using System.Threading;
   using System.Threading.Tasks;
-  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
 

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -119,12 +119,6 @@ namespace DotNet.Testcontainers.Clients
     }
 
     /// <inheritdoc />
-    public Task<ContainerInspectResponse> InspectContainerAsync(string id, CancellationToken ct = default)
-    {
-      return Container.InspectAsync(id, ct);
-    }
-
-    /// <inheritdoc />
     public async Task StartAsync(string id, CancellationToken ct = default)
     {
       if (await Container.ExistsWithIdAsync(id, ct)

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -9,7 +9,6 @@ namespace DotNet.Testcontainers.Clients
   using System.Threading;
   using System.Threading.Tasks;
   using Docker.DotNet;
-  using Docker.DotNet.Models;
   using DotNet.Testcontainers.Builders;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;

--- a/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
@@ -42,7 +42,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="privileged">A value indicating whether the privileged flag is set or not.</param>
     public ContainerConfiguration(
       IImage image = null,
-      Func<ImagesListResponse, bool> imagePullPolicy = null,
+      Func<ImageInspectResponse, bool> imagePullPolicy = null,
       string name = null,
       string hostname = null,
       string macAddress = null,
@@ -148,7 +148,7 @@ namespace DotNet.Testcontainers.Configurations
     public IImage Image { get; }
 
     /// <inheritdoc />
-    public Func<ImagesListResponse, bool> ImagePullPolicy { get; }
+    public Func<ImageInspectResponse, bool> ImagePullPolicy { get; }
 
     /// <inheritdoc />
     public string Name { get; }

--- a/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
@@ -34,7 +34,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Gets the image pull policy.
     /// </summary>
-    Func<ImagesListResponse, bool> ImagePullPolicy { get; }
+    Func<ImageInspectResponse, bool> ImagePullPolicy { get; }
 
     /// <summary>
     /// Gets the name.

--- a/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
@@ -35,7 +35,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Gets the image build policy.
     /// </summary>
-    Func<ImagesListResponse, bool> ImageBuildPolicy { get; }
+    Func<ImageInspectResponse, bool> ImageBuildPolicy { get; }
 
     /// <summary>
     /// Gets a list of build arguments.

--- a/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
@@ -24,7 +24,7 @@ namespace DotNet.Testcontainers.Configurations
       string dockerfile = null,
       string dockerfileDirectory = null,
       IImage image = null,
-      Func<ImagesListResponse, bool> imageBuildPolicy = null,
+      Func<ImageInspectResponse, bool> imageBuildPolicy = null,
       IReadOnlyDictionary<string, string> buildArguments = null,
       bool? deleteIfExists = null)
     {
@@ -83,7 +83,7 @@ namespace DotNet.Testcontainers.Configurations
     public IImage Image { get; }
 
     /// <inheritdoc />
-    public Func<ImagesListResponse, bool> ImageBuildPolicy { get; }
+    public Func<ImageInspectResponse, bool> ImageBuildPolicy { get; }
 
     /// <inheritdoc />
     public IReadOnlyDictionary<string, string> BuildArguments { get; }

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -368,7 +368,7 @@ namespace DotNet.Testcontainers.Containers
       var id = await _client.RunAsync(_configuration, ct)
         .ConfigureAwait(false);
 
-      _container = await _client.InspectContainerAsync(id, ct)
+      _container = await _client.Container.ByIdAsync(id, ct)
         .ConfigureAwait(false);
 
       Created?.Invoke(this, EventArgs.Empty);
@@ -407,7 +407,7 @@ namespace DotNet.Testcontainers.Containers
 
       async Task<bool> CheckPortBindingsAsync()
       {
-        _container = await _client.InspectContainerAsync(_container.ID, ct)
+        _container = await _client.Container.ByIdAsync(_container.ID, ct)
           .ConfigureAwait(false);
 
         var boundPorts = _container.NetworkSettings.Ports.Values.Where(portBindings => portBindings != null).SelectMany(portBinding => portBinding).Count(portBinding => !string.IsNullOrEmpty(portBinding.HostPort));
@@ -416,7 +416,7 @@ namespace DotNet.Testcontainers.Containers
 
       async Task<bool> CheckWaitStrategyAsync(IWaitUntil wait)
       {
-        _container = await _client.InspectContainerAsync(_container.ID, ct)
+        _container = await _client.Container.ByIdAsync(_container.ID, ct)
           .ConfigureAwait(false);
 
         return await wait.UntilAsync(this)
@@ -474,7 +474,7 @@ namespace DotNet.Testcontainers.Containers
 
       try
       {
-        _container = await _client.InspectContainerAsync(_container.ID, ct)
+        _container = await _client.Container.ByIdAsync(_container.ID, ct)
           .ConfigureAwait(false);
       }
       catch (DockerApiException)

--- a/src/Testcontainers/Images/FutureDockerImage.cs
+++ b/src/Testcontainers/Images/FutureDockerImage.cs
@@ -16,7 +16,7 @@ namespace DotNet.Testcontainers.Images
 
     private readonly IImageFromDockerfileConfiguration _configuration;
 
-    private ImagesListResponse _image = new ImagesListResponse();
+    private ImageInspectResponse _image = new ImageInspectResponse();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FutureDockerImage" /> class.
@@ -132,7 +132,7 @@ namespace DotNet.Testcontainers.Images
       await _client.Image.DeleteAsync(_configuration.Image, ct)
         .ConfigureAwait(false);
 
-      _image = new ImagesListResponse();
+      _image = new ImageInspectResponse();
     }
   }
 }

--- a/src/Testcontainers/Images/PullPolicy.cs
+++ b/src/Testcontainers/Images/PullPolicy.cs
@@ -13,7 +13,7 @@ namespace DotNet.Testcontainers.Images
     /// <summary>
     /// Gets the policy that never pulls images.
     /// </summary>
-    public static Func<ImagesListResponse, bool> Never
+    public static Func<ImageInspectResponse, bool> Never
     {
       get
       {
@@ -24,7 +24,7 @@ namespace DotNet.Testcontainers.Images
     /// <summary>
     /// Gets the policy that pulls missing images (not cached).
     /// </summary>
-    public static Func<ImagesListResponse, bool> Missing
+    public static Func<ImageInspectResponse, bool> Missing
     {
       get
       {
@@ -35,7 +35,7 @@ namespace DotNet.Testcontainers.Images
     /// <summary>
     /// Gets the policy that always pulls images.
     /// </summary>
-    public static Func<ImagesListResponse, bool> Always
+    public static Func<ImageInspectResponse, bool> Always
     {
       get
       {

--- a/src/Testcontainers/Images/PullPolicy.cs
+++ b/src/Testcontainers/Images/PullPolicy.cs
@@ -2,6 +2,7 @@ namespace DotNet.Testcontainers.Images
 {
   using System;
   using Docker.DotNet.Models;
+  using DotNet.Testcontainers.Clients;
   using JetBrains.Annotations;
 
   /// <summary>
@@ -28,7 +29,7 @@ namespace DotNet.Testcontainers.Images
     {
       get
       {
-        return cachedImage => cachedImage == null;
+        return cachedImage => DockerImageOperations.NoSuchImage.Equals(cachedImage);
       }
     }
 

--- a/src/Testcontainers/Images/PullPolicy.cs
+++ b/src/Testcontainers/Images/PullPolicy.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Images
 {
   using System;
   using Docker.DotNet.Models;
-  using DotNet.Testcontainers.Clients;
   using JetBrains.Annotations;
 
   /// <summary>
@@ -29,7 +28,7 @@ namespace DotNet.Testcontainers.Images
     {
       get
       {
-        return cachedImage => DockerImageOperations.NoSuchImage.Equals(cachedImage);
+        return cachedImage => cachedImage == null;
       }
     }
 

--- a/src/Testcontainers/Volumes/DockerVolume.cs
+++ b/src/Testcontainers/Volumes/DockerVolume.cs
@@ -94,10 +94,10 @@ namespace DotNet.Testcontainers.Volumes
         return;
       }
 
-      var name = await _client.Volume.CreateAsync(_configuration, ct)
+      var id = await _client.Volume.CreateAsync(_configuration, ct)
         .ConfigureAwait(false);
 
-      _volume = await _client.Volume.ByNameAsync(name, ct)
+      _volume = await _client.Volume.ByIdAsync(id, ct)
         .ConfigureAwait(false);
     }
 


### PR DESCRIPTION
## What does this PR do?

The pull request replaces the list resource API calls with the inspect API call.

## Why is it important?

This simplifies the internal Testcontainers' API. In addition, it reduces the number of operations and might result in slight performance improvements. Furthermore, the pull image policy callback will contain additional information to determine whether Testcontainers should pull an image or not.

The container and image builder members `WithImagePullPolicy` and `WithImageBuildPolicy` received a callback argument of type `ImagesListResponse`. We updated these callbacks, they will now receive an argument of type `ImageInspectResponse`. This change has been made to provide more detailed information about the actual cached image.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups

Testcontainers currently pre-pulls images before building an image from a Dockerfile. Right now, Testcontainers always attempts to pull base images, even if they already exist on the Docker host. After this pull request, we will be able to skip pre-pulling images for those that already exist locally.