### PR TITLE
chore: Update SSH.NET to version 2023.0.0

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -8,7 +8,7 @@
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4" />
     <PackageReference Update="BouncyCastle.Cryptography" Version="2.2.1" />
     <PackageReference Update="SharpZipLib" Version="1.4.2" />
-    <PackageReference Update="SSH.NET" Version="2020.0.2" />
+    <PackageReference Update="SSH.NET" Version="2023.0.0" />
     <PackageReference Update="System.Text.Json" Version="6.0.8" />
     <!-- Unit and integration test dependencies: -->
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.2" />


### PR DESCRIPTION
Update SSH.NET to the latest version https://www.nuget.org/packages/SSH.NET/2023.0.0

## New features:
* Support for .NET 6, 7, and .NET Standard 2.0/2.1
* Support for RSA-SHA256/512 signature algorithms
* Support for parsing OpenSSH keys with ECDSA 256/384/521 and RSA
* Support for SHA256 and MD5 fingerprints for host key validation
* Added async support to SftpClient and SftpFileStream
* Added ISftpFile interface to SftpFile
* Removed support for old target frameworks
* Improved performance and stability
* Added the ability to set the last write and access time for Sftp files