### PR TITLE
fix: Check container response null pointer

### DIFF
--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -7,7 +7,6 @@ namespace DotNet.Testcontainers.Containers
   using System.Linq;
   using System.Threading;
   using System.Threading.Tasks;
-  using Docker.DotNet;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Configurations;
@@ -472,15 +471,8 @@ namespace DotNet.Testcontainers.Containers
       await _client.StopAsync(_container.ID, ct)
         .ConfigureAwait(false);
 
-      try
-      {
-        _container = await _client.Container.ByIdAsync(_container.ID, ct)
-          .ConfigureAwait(false);
-      }
-      catch (DockerApiException)
-      {
-        _container = new ContainerInspectResponse();
-      }
+      _container = await _client.Container.ByIdAsync(_container.ID, ct)
+        .ConfigureAwait(false);
 
       Stopped?.Invoke(this, EventArgs.Empty);
     }
@@ -488,7 +480,7 @@ namespace DotNet.Testcontainers.Containers
     /// <inheritdoc />
     protected override bool Exists()
     {
-      return ContainerHasBeenCreatedStates.HasFlag(State);
+      return _container != null && ContainerHasBeenCreatedStates.HasFlag(State);
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

The PR adds a null pointer check.

## Why is it important?

With the recent adjustments, getting the container response will no longer throw an exception. Instead, it will return a null value. The `Exists()` did not check for a null value and threw an exception. This bug was introduced in the development version.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
