### PR TITLE
fix: Prevent invalid negative timestamps getting container logs

### DIFF
--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -69,8 +69,8 @@ namespace DotNet.Testcontainers.Clients
       {
         ShowStdout = true,
         ShowStderr = true,
-        Since = since.TotalSeconds.ToString("0", CultureInfo.InvariantCulture),
-        Until = until.TotalSeconds.ToString("0", CultureInfo.InvariantCulture),
+        Since = Math.Max(0, since.TotalSeconds).ToString("0", CultureInfo.InvariantCulture),
+        Until = Math.Max(0, until.TotalSeconds).ToString("0", CultureInfo.InvariantCulture),
         Timestamps = timestampsEnabled,
       };
 

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -106,12 +106,12 @@ namespace DotNet.Testcontainers.Clients
 
       if (default(DateTime).Equals(since))
       {
-        since = DateTime.MinValue;
+        since = unixEpoch;
       }
 
       if (default(DateTime).Equals(until))
       {
-        until = DateTime.MaxValue;
+        until = unixEpoch;
       }
 
       return Container.GetLogsAsync(id, since.ToUniversalTime().Subtract(unixEpoch), until.ToUniversalTime().Subtract(unixEpoch), timestampsEnabled, ct);


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

Fixes https://github.com/testcontainers/testcontainers-dotnet/issues/1035

The other way to go about this would be fixing the arguments at callsites and throwing in this GetLogsAsync() method if the value is negative... though it feels that should be the job of Docker.DotNet.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

explained in https://github.com/testcontainers/testcontainers-dotnet/issues/1035

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
