### PR TITLE
Make ESDB container implement IDatabaseContainer

### DIFF
--- a/src/Testcontainers.EventStoreDb/EventStoreDbContainer.cs
+++ b/src/Testcontainers.EventStoreDb/EventStoreDbContainer.cs
@@ -2,7 +2,7 @@ namespace Testcontainers.EventStoreDb;
 
 /// <inheritdoc cref="DockerContainer" />
 [PublicAPI]
-public sealed class EventStoreDbContainer : DockerContainer
+public sealed class EventStoreDbContainer : DockerContainer, IDatabaseContainer
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="EventStoreDbContainer" /> class.


### PR DESCRIPTION
## What does this PR do?

`EvebtStoreDbContainer` class implements the `GetConnectionString` method so it can inherit from `IDatabaseContainer`.

## Why is it important?

When creating an abstraction for tests, I can't currently use `IDatabaseContainer` and its `GetConnectionString` because `EventStoreDbContainer` doesn't implement the interface.
