### PR TITLE
chore: Update .NET SDK to version 8 (LTS)

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -9,9 +9,9 @@
     <PackageReference Update="BouncyCastle.Cryptography" Version="2.2.1" />
     <PackageReference Update="SharpZipLib" Version="1.4.2" />
     <PackageReference Update="SSH.NET" Version="2023.0.0" />
-    <PackageReference Update="System.Text.Json" Version="6.0.8" />
+    <PackageReference Update="System.Text.Json" Version="6.0.9" />
     <!-- Unit and integration test dependencies: -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Update="coverlet.collector" Version="6.0.0" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Update="xunit" Version="2.5.0" />

--- a/examples/Flyway/Packages.props
+++ b/examples/Flyway/Packages.props
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <ItemGroup>
-        <PackageReference Update="JetBrains.Annotations" Version="2023.2.0" PrivateAssets="all"/>
+        <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="all"/>
         <PackageReference Update="Testcontainers.PostgreSql" Version="3.5.0"/>
-        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Update="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Update="xunit" Version="2.5.0"/>
         <PackageReference Update="Npgsql" Version="6.0.10"/>

--- a/examples/WeatherForecast/Packages.props
+++ b/examples/WeatherForecast/Packages.props
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <PackageReference Update="JetBrains.Annotations" Version="2023.2.0" PrivateAssets="all"/>
+    <PackageReference Update="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="all"/>
     <PackageReference Update="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.23"/>
     <PackageReference Update="Microsoft.EntityFrameworkCore" Version="6.0.23"/>
     <PackageReference Update="Microsoft.Fast.Components.FluentUI" Version="3.2.0"/>
     <PackageReference Update="Testcontainers.SqlEdge" Version="3.5.0"/>
     <PackageReference Update="System.ComponentModel.Annotations" Version="5.0.0"/>
-    <PackageReference Update="System.Text.Json" Version="6.0.8"/>
+    <PackageReference Update="System.Text.Json" Version="6.0.9"/>
     <PackageReference Update="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.23"/>
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
     <PackageReference Update="Selenium.WebDriver.ChromeDriver" Version="106.0.5249.6100"/>
     <PackageReference Update="Selenium.WebDriver" Version="4.9.1"/>
     <PackageReference Update="xunit.runner.visualstudio" Version="2.5.0"/>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.400",
+    "version": "8.0.100",
     "rollForward": "latestPatch"
   }
 }

--- a/src/Templates/CSharp/Testcontainers.ModuleName/Testcontainers.ModuleName.csproj
+++ b/src/Templates/CSharp/Testcontainers.ModuleName/Testcontainers.ModuleName.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Azurite/Testcontainers.Azurite.csproj
+++ b/src/Testcontainers.Azurite/Testcontainers.Azurite.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.BigQuery/Testcontainers.BigQuery.csproj
+++ b/src/Testcontainers.BigQuery/Testcontainers.BigQuery.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj
+++ b/src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Consul/Testcontainers.Consul.csproj
+++ b/src/Testcontainers.Consul/Testcontainers.Consul.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.CosmosDb/Testcontainers.CosmosDb.csproj
+++ b/src/Testcontainers.CosmosDb/Testcontainers.CosmosDb.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.CouchDb/Testcontainers.CouchDb.csproj
+++ b/src/Testcontainers.CouchDb/Testcontainers.CouchDb.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Couchbase/Testcontainers.Couchbase.csproj
+++ b/src/Testcontainers.Couchbase/Testcontainers.Couchbase.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj
+++ b/src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj
+++ b/src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj
+++ b/src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.FakeGcsServer/Testcontainers.FakeGcsServer.csproj
+++ b/src/Testcontainers.FakeGcsServer/Testcontainers.FakeGcsServer.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Firestore/Testcontainers.Firestore.csproj
+++ b/src/Testcontainers.Firestore/Testcontainers.Firestore.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.InfluxDb/Testcontainers.InfluxDb.csproj
+++ b/src/Testcontainers.InfluxDb/Testcontainers.InfluxDb.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.JanusGraph/Testcontainers.JanusGraph.csproj
+++ b/src/Testcontainers.JanusGraph/Testcontainers.JanusGraph.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.K3s/Testcontainers.K3s.csproj
+++ b/src/Testcontainers.K3s/Testcontainers.K3s.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Kafka/Testcontainers.Kafka.csproj
+++ b/src/Testcontainers.Kafka/Testcontainers.Kafka.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj
+++ b/src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Kusto/Testcontainers.Kusto.csproj
+++ b/src/Testcontainers.Kusto/Testcontainers.Kusto.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.LocalStack/Testcontainers.LocalStack.csproj
+++ b/src/Testcontainers.LocalStack/Testcontainers.LocalStack.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj
+++ b/src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Minio/Testcontainers.Minio.csproj
+++ b/src/Testcontainers.Minio/Testcontainers.Minio.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.MongoDb/Testcontainers.MongoDb.csproj
+++ b/src/Testcontainers.MongoDb/Testcontainers.MongoDb.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.MsSql/Testcontainers.MsSql.csproj
+++ b/src/Testcontainers.MsSql/Testcontainers.MsSql.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.MySql/Testcontainers.MySql.csproj
+++ b/src/Testcontainers.MySql/Testcontainers.MySql.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Nats/Testcontainers.Nats.csproj
+++ b/src/Testcontainers.Nats/Testcontainers.Nats.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Neo4j/Testcontainers.Neo4j.csproj
+++ b/src/Testcontainers.Neo4j/Testcontainers.Neo4j.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Oracle/Testcontainers.Oracle.csproj
+++ b/src/Testcontainers.Oracle/Testcontainers.Oracle.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Papercut/Testcontainers.Papercut.csproj
+++ b/src/Testcontainers.Papercut/Testcontainers.Papercut.csproj
@@ -7,8 +7,8 @@
         <Description>A Testcontainers Papercut module for testing SMTP clients and sending emails.</Description>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj
+++ b/src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.PubSub/Testcontainers.PubSub.csproj
+++ b/src/Testcontainers.PubSub/Testcontainers.PubSub.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.RabbitMq/Testcontainers.RabbitMq.csproj
+++ b/src/Testcontainers.RabbitMq/Testcontainers.RabbitMq.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.RavenDb/Testcontainers.RavenDb.csproj
+++ b/src/Testcontainers.RavenDb/Testcontainers.RavenDb.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Redis/Testcontainers.Redis.csproj
+++ b/src/Testcontainers.Redis/Testcontainers.Redis.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.Redpanda/Testcontainers.Redpanda.csproj
+++ b/src/Testcontainers.Redpanda/Testcontainers.Redpanda.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.SqlEdge/Testcontainers.SqlEdge.csproj
+++ b/src/Testcontainers.SqlEdge/Testcontainers.SqlEdge.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/src/Testcontainers.WebDriver/Testcontainers.WebDriver.csproj
+++ b/src/Testcontainers.WebDriver/Testcontainers.WebDriver.csproj
@@ -4,8 +4,8 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj" />

--- a/src/Testcontainers/Testcontainers.csproj
+++ b/src/Testcontainers/Testcontainers.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>DotNet.Testcontainers</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" VersionOverride="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="JetBrains.Annotations" VersionOverride="2022.3.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" VersionOverride="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" VersionOverride="2023.3.0" PrivateAssets="All" />
     <PackageReference Include="Docker.DotNet" />
     <PackageReference Include="Docker.DotNet.X509" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />

--- a/tests/Testcontainers.Azurite.Tests/Testcontainers.Azurite.Tests.csproj
+++ b/tests/Testcontainers.Azurite.Tests/Testcontainers.Azurite.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Azurite.Tests/Testcontainers.Azurite.Tests.csproj
+++ b/tests/Testcontainers.Azurite.Tests/Testcontainers.Azurite.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.BigQuery.Tests/Testcontainers.BigQuery.Tests.csproj
+++ b/tests/Testcontainers.BigQuery.Tests/Testcontainers.BigQuery.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.BigQuery.Tests/Testcontainers.BigQuery.Tests.csproj
+++ b/tests/Testcontainers.BigQuery.Tests/Testcontainers.BigQuery.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.ClickHouse.Tests/Testcontainers.ClickHouse.Tests.csproj
+++ b/tests/Testcontainers.ClickHouse.Tests/Testcontainers.ClickHouse.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.ClickHouse.Tests/Testcontainers.ClickHouse.Tests.csproj
+++ b/tests/Testcontainers.ClickHouse.Tests/Testcontainers.ClickHouse.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
+++ b/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
@@ -7,7 +7,7 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.3.1"/>
+        <PackageReference Include="JetBrains.Annotations" Version="2023.3.0"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>

--- a/tests/Testcontainers.Consul.Tests/Testcontainers.Consul.Tests.csproj
+++ b/tests/Testcontainers.Consul.Tests/Testcontainers.Consul.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Consul" Version="1.6.10.9" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
         <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="Consul" Version="1.6.10.9" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="$(SolutionDir)src/Testcontainers.Consul/Testcontainers.Consul.csproj" />

--- a/tests/Testcontainers.Consul.Tests/Testcontainers.Consul.Tests.csproj
+++ b/tests/Testcontainers.Consul.Tests/Testcontainers.Consul.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
         <PackageReference Include="xunit" Version="2.5.0" />

--- a/tests/Testcontainers.CosmosDb.Tests/Testcontainers.CosmosDb.Tests.csproj
+++ b/tests/Testcontainers.CosmosDb.Tests/Testcontainers.CosmosDb.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.CosmosDb.Tests/Testcontainers.CosmosDb.Tests.csproj
+++ b/tests/Testcontainers.CosmosDb.Tests/Testcontainers.CosmosDb.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
+++ b/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
+++ b/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
+++ b/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
+++ b/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
+++ b/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
+++ b/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
+++ b/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
+++ b/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
+++ b/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
+++ b/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
+++ b/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
+++ b/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.FakeGcsServer.Tests/Testcontainers.FakeGcsServer.Tests.csproj
+++ b/tests/Testcontainers.FakeGcsServer.Tests/Testcontainers.FakeGcsServer.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.FakeGcsServer.Tests/Testcontainers.FakeGcsServer.Tests.csproj
+++ b/tests/Testcontainers.FakeGcsServer.Tests/Testcontainers.FakeGcsServer.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Firestore.Tests/Testcontainers.Firestore.Tests.csproj
+++ b/tests/Testcontainers.Firestore.Tests/Testcontainers.Firestore.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Firestore.Tests/Testcontainers.Firestore.Tests.csproj
+++ b/tests/Testcontainers.Firestore.Tests/Testcontainers.Firestore.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.InfluxDb.Tests/Testcontainers.InfluxDb.Tests.csproj
+++ b/tests/Testcontainers.InfluxDb.Tests/Testcontainers.InfluxDb.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.InfluxDb.Tests/Testcontainers.InfluxDb.Tests.csproj
+++ b/tests/Testcontainers.InfluxDb.Tests/Testcontainers.InfluxDb.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.JanusGraph.Tests/Testcontainers.JanusGraph.Tests.csproj
+++ b/tests/Testcontainers.JanusGraph.Tests/Testcontainers.JanusGraph.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.JanusGraph.Tests/Testcontainers.JanusGraph.Tests.csproj
+++ b/tests/Testcontainers.JanusGraph.Tests/Testcontainers.JanusGraph.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.K3s.Tests/Testcontainers.K3s.Tests.csproj
+++ b/tests/Testcontainers.K3s.Tests/Testcontainers.K3s.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.K3s.Tests/Testcontainers.K3s.Tests.csproj
+++ b/tests/Testcontainers.K3s.Tests/Testcontainers.K3s.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
+++ b/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
+++ b/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
+++ b/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
+++ b/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Kusto.Tests/Testcontainers.Kusto.Tests.csproj
+++ b/tests/Testcontainers.Kusto.Tests/Testcontainers.Kusto.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Kusto.Tests/Testcontainers.Kusto.Tests.csproj
+++ b/tests/Testcontainers.Kusto.Tests/Testcontainers.Kusto.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
+++ b/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
+++ b/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
+++ b/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
+++ b/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
+++ b/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
+++ b/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
+++ b/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
+++ b/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
+++ b/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
+++ b/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
+++ b/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
+++ b/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Nats.Tests/Testcontainers.Nats.Tests.csproj
+++ b/tests/Testcontainers.Nats.Tests/Testcontainers.Nats.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Nats.Tests/Testcontainers.Nats.Tests.csproj
+++ b/tests/Testcontainers.Nats.Tests/Testcontainers.Nats.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
+++ b/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
+++ b/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
+++ b/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
+++ b/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Papercut.Tests/Testcontainers.Papercut.Tests.csproj
+++ b/tests/Testcontainers.Papercut.Tests/Testcontainers.Papercut.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Papercut.Tests/Testcontainers.Papercut.Tests.csproj
+++ b/tests/Testcontainers.Papercut.Tests/Testcontainers.Papercut.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
+++ b/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
+++ b/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
+++ b/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
+++ b/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
+++ b/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
+++ b/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.PubSub.Tests/Testcontainers.PubSub.Tests.csproj
+++ b/tests/Testcontainers.PubSub.Tests/Testcontainers.PubSub.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.PubSub.Tests/Testcontainers.PubSub.Tests.csproj
+++ b/tests/Testcontainers.PubSub.Tests/Testcontainers.PubSub.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
+++ b/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
+++ b/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
+++ b/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
+++ b/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
+++ b/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
+++ b/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
+++ b/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
+++ b/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
+++ b/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Testcontainers.SqlEdge.Tests/Testcontainers.SqlEdge.Tests.csproj
+++ b/tests/Testcontainers.SqlEdge.Tests/Testcontainers.SqlEdge.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.SqlEdge.Tests/Testcontainers.SqlEdge.Tests.csproj
+++ b/tests/Testcontainers.SqlEdge.Tests/Testcontainers.SqlEdge.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>

--- a/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
+++ b/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.1.3" />
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
     <Configurations>Debug;Release</Configurations>

--- a/tests/Testcontainers.WebDriver.Tests/Testcontainers.WebDriver.Tests.csproj
+++ b/tests/Testcontainers.WebDriver.Tests/Testcontainers.WebDriver.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net6.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>

--- a/tests/Testcontainers.WebDriver.Tests/Testcontainers.WebDriver.Tests.csproj
+++ b/tests/Testcontainers.WebDriver.Tests/Testcontainers.WebDriver.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0"/>
         <PackageReference Include="xunit" Version="2.5.0"/>


### PR DESCRIPTION
## What does this PR do?

Updates the .NET SDK to version 8 (latest LTS).

## Why is it important?

We are trying to run our tests utilizing the latest .NET SDK (LTS). Testcontainers itself, including the modules, still targets `netstandard2.0` and `netstandard2.1` to provide support for most .NET Framework and .NET versions.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
