### PR TITLE
chore: Remove Microsoft.SourceLink.GitHub

### DIFF
--- a/src/Templates/CSharp/Testcontainers.ModuleName/Testcontainers.ModuleName.csproj
+++ b/src/Templates/CSharp/Testcontainers.ModuleName/Testcontainers.ModuleName.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Azurite/Testcontainers.Azurite.csproj
+++ b/src/Testcontainers.Azurite/Testcontainers.Azurite.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.BigQuery/Testcontainers.BigQuery.csproj
+++ b/src/Testcontainers.BigQuery/Testcontainers.BigQuery.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Bigtable/Testcontainers.Bigtable.csproj
+++ b/src/Testcontainers.Bigtable/Testcontainers.Bigtable.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj
+++ b/src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Consul/Testcontainers.Consul.csproj
+++ b/src/Testcontainers.Consul/Testcontainers.Consul.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.CosmosDb/Testcontainers.CosmosDb.csproj
+++ b/src/Testcontainers.CosmosDb/Testcontainers.CosmosDb.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.CouchDb/Testcontainers.CouchDb.csproj
+++ b/src/Testcontainers.CouchDb/Testcontainers.CouchDb.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Couchbase/Testcontainers.Couchbase.csproj
+++ b/src/Testcontainers.Couchbase/Testcontainers.Couchbase.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj
+++ b/src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj
+++ b/src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj
+++ b/src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.FakeGcsServer/Testcontainers.FakeGcsServer.csproj
+++ b/src/Testcontainers.FakeGcsServer/Testcontainers.FakeGcsServer.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Firestore/Testcontainers.Firestore.csproj
+++ b/src/Testcontainers.Firestore/Testcontainers.Firestore.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.InfluxDb/Testcontainers.InfluxDb.csproj
+++ b/src/Testcontainers.InfluxDb/Testcontainers.InfluxDb.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.JanusGraph/Testcontainers.JanusGraph.csproj
+++ b/src/Testcontainers.JanusGraph/Testcontainers.JanusGraph.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.K3s/Testcontainers.K3s.csproj
+++ b/src/Testcontainers.K3s/Testcontainers.K3s.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Kafka/Testcontainers.Kafka.csproj
+++ b/src/Testcontainers.Kafka/Testcontainers.Kafka.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj
+++ b/src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Kusto/Testcontainers.Kusto.csproj
+++ b/src/Testcontainers.Kusto/Testcontainers.Kusto.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.LocalStack/Testcontainers.LocalStack.csproj
+++ b/src/Testcontainers.LocalStack/Testcontainers.LocalStack.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj
+++ b/src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Minio/Testcontainers.Minio.csproj
+++ b/src/Testcontainers.Minio/Testcontainers.Minio.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.MongoDb/Testcontainers.MongoDb.csproj
+++ b/src/Testcontainers.MongoDb/Testcontainers.MongoDb.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.MsSql/Testcontainers.MsSql.csproj
+++ b/src/Testcontainers.MsSql/Testcontainers.MsSql.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.MySql/Testcontainers.MySql.csproj
+++ b/src/Testcontainers.MySql/Testcontainers.MySql.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Nats/Testcontainers.Nats.csproj
+++ b/src/Testcontainers.Nats/Testcontainers.Nats.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Neo4j/Testcontainers.Neo4j.csproj
+++ b/src/Testcontainers.Neo4j/Testcontainers.Neo4j.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Oracle/Testcontainers.Oracle.csproj
+++ b/src/Testcontainers.Oracle/Testcontainers.Oracle.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Papercut/Testcontainers.Papercut.csproj
+++ b/src/Testcontainers.Papercut/Testcontainers.Papercut.csproj
@@ -7,7 +7,6 @@
         <Description>A Testcontainers Papercut module for testing SMTP clients and sending emails.</Description>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj
+++ b/src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.PubSub/Testcontainers.PubSub.csproj
+++ b/src/Testcontainers.PubSub/Testcontainers.PubSub.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.RabbitMq/Testcontainers.RabbitMq.csproj
+++ b/src/Testcontainers.RabbitMq/Testcontainers.RabbitMq.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.RavenDb/Testcontainers.RavenDb.csproj
+++ b/src/Testcontainers.RavenDb/Testcontainers.RavenDb.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Redis/Testcontainers.Redis.csproj
+++ b/src/Testcontainers.Redis/Testcontainers.Redis.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.Redpanda/Testcontainers.Redpanda.csproj
+++ b/src/Testcontainers.Redpanda/Testcontainers.Redpanda.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.SqlEdge/Testcontainers.SqlEdge.csproj
+++ b/src/Testcontainers.SqlEdge/Testcontainers.SqlEdge.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.WebDriver/Testcontainers.WebDriver.csproj
+++ b/src/Testcontainers.WebDriver/Testcontainers.WebDriver.csproj
@@ -4,7 +4,6 @@
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers/Testcontainers.csproj
+++ b/src/Testcontainers/Testcontainers.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>DotNet.Testcontainers</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" VersionOverride="8.0.0" PrivateAssets="All" />
     <PackageReference Include="JetBrains.Annotations" VersionOverride="2023.3.0" PrivateAssets="All" />
     <PackageReference Include="Docker.DotNet" />
     <PackageReference Include="Docker.DotNet.X509" />


### PR DESCRIPTION
## What does this PR do?

The PR removes the `Microsoft.SourceLink.GitHub` dependency.

## Why is it important?

This dependency is now included in the .NET SDK (https://github.com/testcontainers/testcontainers-dotnet/pull/1054#issuecomment-1828082264), it is no longer necessary to include it in every project. Thanks, @0xced.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
