### PR TITLE
chore: Invert #if NETSTANDARD* conditional compilation conditions

### DIFF
--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -271,10 +271,11 @@ namespace DotNet.Testcontainers.Clients
 
 #if NETSTANDARD2_0
         _ = await tarInputStream.ReadAsync(readBytes, 0, readBytes.Length, ct)
+          .ConfigureAwait(false);
 #else
         _ = await tarInputStream.ReadAsync(readBytes, ct)
-#endif
           .ConfigureAwait(false);
+#endif
 
         return readBytes;
       }

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -98,10 +98,10 @@ namespace DotNet.Testcontainers.Clients
     /// <inheritdoc />
     public Task<(string Stdout, string Stderr)> GetContainerLogsAsync(string id, DateTime since = default, DateTime until = default, bool timestampsEnabled = true, CancellationToken ct = default)
     {
-#if NETSTANDARD2_1_OR_GREATER
-      var unixEpoch = DateTime.UnixEpoch;
-#else
+#if NETSTANDARD2_0
       var unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+#else
+      var unixEpoch = DateTime.UnixEpoch;
 #endif
 
       if (default(DateTime).Equals(since))
@@ -269,13 +269,12 @@ namespace DotNet.Testcontainers.Clients
 
         var readBytes = new byte[entry.Size];
 
-#if NETSTANDARD2_1_OR_GREATER
-        _ = await tarInputStream.ReadAsync(new Memory<byte>(readBytes), ct)
-          .ConfigureAwait(false);
-#else
+#if NETSTANDARD2_0
         _ = await tarInputStream.ReadAsync(readBytes, 0, readBytes.Length, ct)
-          .ConfigureAwait(false);
+#else
+        _ = await tarInputStream.ReadAsync(readBytes, ct)
 #endif
+          .ConfigureAwait(false);
 
         return readBytes;
       }

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -308,10 +308,11 @@ namespace DotNet.Testcontainers.Containers
               {
 #if NETSTANDARD2_0
                 await stream.WriteAsync(sendBytes, 0, sendBytes.Length, ct)
+                  .ConfigureAwait(false);
 #else
                 await stream.WriteAsync(sendBytes, ct)
-#endif
                   .ConfigureAwait(false);
+#endif
 
                 await stream.FlushAsync(ct)
                   .ConfigureAwait(false);
@@ -322,10 +323,11 @@ namespace DotNet.Testcontainers.Containers
                 {
 #if NETSTANDARD2_0
                   var numberOfBytes = await stream.ReadAsync(readBytes, 0, readBytes.Length, ct)
+                    .ConfigureAwait(false);
 #else
                   var numberOfBytes = await stream.ReadAsync(readBytes, ct)
-#endif
                     .ConfigureAwait(false);
+#endif
 
                   if (numberOfBytes == 0)
                   {
@@ -367,10 +369,11 @@ namespace DotNet.Testcontainers.Containers
               // Keep the connection to Ryuk up.
 #if NETSTANDARD2_0
               _ = await stream.ReadAsync(readBytes, 0, readBytes.Length, _maintainConnectionCts.Token)
+                .ConfigureAwait(false);
 #else
               _ = await stream.ReadAsync(readBytes, _maintainConnectionCts.Token)
-#endif
                 .ConfigureAwait(false);
+#endif
             }
           }
           catch (OperationCanceledException)

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -306,13 +306,12 @@ namespace DotNet.Testcontainers.Containers
             {
               using (var messageBuffer = new MemoryStream())
               {
-#if NETSTANDARD2_1_OR_GREATER
-                await stream.WriteAsync(new ReadOnlyMemory<byte>(sendBytes), ct)
-                  .ConfigureAwait(false);
-#else
+#if NETSTANDARD2_0
                 await stream.WriteAsync(sendBytes, 0, sendBytes.Length, ct)
-                  .ConfigureAwait(false);
+#else
+                await stream.WriteAsync(sendBytes, ct)
 #endif
+                  .ConfigureAwait(false);
 
                 await stream.FlushAsync(ct)
                   .ConfigureAwait(false);
@@ -321,13 +320,12 @@ namespace DotNet.Testcontainers.Containers
 
                 do
                 {
-#if NETSTANDARD2_1_OR_GREATER
-                  var numberOfBytes = await stream.ReadAsync(new Memory<byte>(readBytes), ct)
-                    .ConfigureAwait(false);
-#else
+#if NETSTANDARD2_0
                   var numberOfBytes = await stream.ReadAsync(readBytes, 0, readBytes.Length, ct)
-                    .ConfigureAwait(false);
+#else
+                  var numberOfBytes = await stream.ReadAsync(readBytes, ct)
 #endif
+                    .ConfigureAwait(false);
 
                   if (numberOfBytes == 0)
                   {
@@ -367,13 +365,12 @@ namespace DotNet.Testcontainers.Containers
             while (!_maintainConnectionCts.IsCancellationRequested)
             {
               // Keep the connection to Ryuk up.
-#if NETSTANDARD2_1_OR_GREATER
-              _ = await stream.ReadAsync(new Memory<byte>(readBytes), _maintainConnectionCts.Token)
-                .ConfigureAwait(false);
-#else
+#if NETSTANDARD2_0
               _ = await stream.ReadAsync(readBytes, 0, readBytes.Length, _maintainConnectionCts.Token)
-                .ConfigureAwait(false);
+#else
+              _ = await stream.ReadAsync(readBytes, _maintainConnectionCts.Token)
 #endif
+                .ConfigureAwait(false);
             }
           }
           catch (OperationCanceledException)

--- a/src/Testcontainers/Containers/TarOutputMemoryStream.cs
+++ b/src/Testcontainers/Containers/TarOutputMemoryStream.cs
@@ -76,10 +76,11 @@ namespace DotNet.Testcontainers.Containers
 
 #if NETSTANDARD2_0
       await WriteAsync(fileContent, 0, fileContent.Length, ct)
+        .ConfigureAwait(false);
 #else
       await WriteAsync(fileContent, ct)
-#endif
         .ConfigureAwait(false);
+#endif
 
       await CloseEntryAsync(ct)
         .ConfigureAwait(false);

--- a/src/Testcontainers/Containers/TarOutputMemoryStream.cs
+++ b/src/Testcontainers/Containers/TarOutputMemoryStream.cs
@@ -74,13 +74,12 @@ namespace DotNet.Testcontainers.Containers
       await PutNextEntryAsync(tarEntry, ct)
         .ConfigureAwait(false);
 
-#if NETSTANDARD2_1_OR_GREATER
-      await WriteAsync(fileContent, ct)
-        .ConfigureAwait(false);
-#else
+#if NETSTANDARD2_0
       await WriteAsync(fileContent, 0, fileContent.Length, ct)
-        .ConfigureAwait(false);
+#else
+      await WriteAsync(fileContent, ct)
 #endif
+        .ConfigureAwait(false);
 
       await CloseEntryAsync(ct)
         .ConfigureAwait(false);

--- a/src/Testcontainers/Images/IgnoreFile.cs
+++ b/src/Testcontainers/Images/IgnoreFile.cs
@@ -193,10 +193,10 @@ namespace DotNet.Testcontainers.Images
         }
 
         // Replace the last non recursive wildcard with a match-zero-or-one quantifier regular expression.
-#if NETSTANDARD2_1_OR_GREATER
-        if (input.Contains('*') && index >= 0)
-#else
+#if NETSTANDARD2_0
         if (input.Contains("*") && index >= 0)
+#else
+        if (input.Contains('*') && index >= 0)
 #endif
         {
           input = input.Remove(index, 1).Insert(index, $"{MatchAllExceptPathSeparator}?");


### PR DESCRIPTION
While conceptually .NET 5, 6, 7, 8 are greater than .NET Standard 2.1 it does not apply to the `NETSTANDARD2_1_OR_GREATER` macro.

So it's safer to conditionally compile on NETSTANDARD2_0 and assume that the #else branch targets a newer framework where the new bits are available in order not to use the old code path on the newest frameworks.
