### PR TITLE
chore: Use relative ProjectReference paths instead of $(SolutionDir)

### DIFF
--- a/.cake-scripts/version.cake
+++ b/.cake-scripts/version.cake
@@ -27,7 +27,7 @@ internal sealed class BuildInformation
 
     var publishNuGetPackage = context.EnvironmentVariable("PUBLISH_NUGET_PACKAGE");
 
-    var version = context.XmlPeek(propertiesFilePath, "/Project/PropertyGroup[2]/Version/text()");
+    var version = context.XmlPeek(propertiesFilePath, "/Project/PropertyGroup[1]/Version/text()");
 
     var git = context.GitBranchCurrent(".");
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <SolutionDir Condition=" '$(SolutionDir)' == '' ">$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', 'Testcontainers.sln'))/</SolutionDir>
-  </PropertyGroup>
-  <PropertyGroup>
     <PackageId>$(AssemblyName)</PackageId>
     <Version>3.8.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
@@ -35,10 +32,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="$(SolutionDir)docs/banner.png" Visible="false" Pack="true" PackagePath="docs/" />
-    <None Include="$(SolutionDir)docs/logo.png" Visible="false" Pack="true" PackagePath="docs/" />
-    <None Include="$(SolutionDir)LICENSE" Visible="false" Pack="true" PackagePath="" />
-    <None Include="$(SolutionDir)README.md" Visible="false" Pack="true" PackagePath="" />
+    <None Include="$(MSBuildThisFileDirectory)docs/banner.png" Visible="false" Pack="true" PackagePath="docs/" />
+    <None Include="$(MSBuildThisFileDirectory)docs/logo.png" Visible="false" Pack="true" PackagePath="docs/" />
+    <None Include="$(MSBuildThisFileDirectory)LICENSE" Visible="false" Pack="true" PackagePath="" />
+    <None Include="$(MSBuildThisFileDirectory)README.md" Visible="false" Pack="true" PackagePath="" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/examples/Flyway/Directory.Build.props
+++ b/examples/Flyway/Directory.Build.props
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <SolutionDir Condition=" '$(SolutionDir)' == '' ">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Flyway.sln))/</SolutionDir>
-    </PropertyGroup>
-    <PropertyGroup>
         <Version>0.1.0</Version>
         <PackageId>$(AssemblyName)</PackageId>
         <AssemblyVersion>$(Version)</AssemblyVersion>

--- a/examples/WeatherForecast/Directory.Build.props
+++ b/examples/WeatherForecast/Directory.Build.props
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <SolutionDir Condition=" '$(SolutionDir)' == '' ">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), WeatherForecast.sln))/</SolutionDir>
-  </PropertyGroup>
-  <PropertyGroup>
     <Version>0.1.0</Version>
     <PackageId>$(AssemblyName)</PackageId>
     <AssemblyVersion>$(Version)</AssemblyVersion>

--- a/examples/WeatherForecast/src/WeatherForecast.Contexts/WeatherForecast.Contexts.csproj
+++ b/examples/WeatherForecast/src/WeatherForecast.Contexts/WeatherForecast.Contexts.csproj
@@ -8,6 +8,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)src/WeatherForecast.Repositories/WeatherForecast.Repositories.csproj"/>
+    <ProjectReference Include="../WeatherForecast.Repositories/WeatherForecast.Repositories.csproj"/>
   </ItemGroup>
 </Project>

--- a/examples/WeatherForecast/src/WeatherForecast.Interactors/WeatherForecast.Interactors.csproj
+++ b/examples/WeatherForecast/src/WeatherForecast.Interactors/WeatherForecast.Interactors.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="JetBrains.Annotations"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)src/WeatherForecast.Entities/WeatherForecast.Entities.csproj"/>
-    <ProjectReference Include="$(SolutionDir)src/WeatherForecast.Repositories/WeatherForecast.Repositories.csproj"/>
+    <ProjectReference Include="../WeatherForecast.Entities/WeatherForecast.Entities.csproj"/>
+    <ProjectReference Include="../WeatherForecast.Repositories/WeatherForecast.Repositories.csproj"/>
   </ItemGroup>
 </Project>

--- a/examples/WeatherForecast/src/WeatherForecast.Repositories/WeatherForecast.Repositories.csproj
+++ b/examples/WeatherForecast/src/WeatherForecast.Repositories/WeatherForecast.Repositories.csproj
@@ -7,6 +7,6 @@
     <PackageReference Include="JetBrains.Annotations"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)src/WeatherForecast.Entities/WeatherForecast.Entities.csproj"/>
+    <ProjectReference Include="../WeatherForecast.Entities/WeatherForecast.Entities.csproj"/>
   </ItemGroup>
 </Project>

--- a/examples/WeatherForecast/src/WeatherForecast/WeatherForecast.csproj
+++ b/examples/WeatherForecast/src/WeatherForecast/WeatherForecast.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="Testcontainers.SqlEdge"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)src/WeatherForecast.Contexts/WeatherForecast.Contexts.csproj"/>
-    <ProjectReference Include="$(SolutionDir)src/WeatherForecast.Interactors/WeatherForecast.Interactors.csproj"/>
-    <ProjectReference Include="$(SolutionDir)src/WeatherForecast.Repositories/WeatherForecast.Repositories.csproj"/>
+    <ProjectReference Include="../WeatherForecast.Contexts/WeatherForecast.Contexts.csproj"/>
+    <ProjectReference Include="../WeatherForecast.Interactors/WeatherForecast.Interactors.csproj"/>
+    <ProjectReference Include="../WeatherForecast.Repositories/WeatherForecast.Repositories.csproj"/>
   </ItemGroup>
   <ItemGroup>
     <!-- https://learn.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-6.0#basic-tests-with-the-default-webapplicationfactory-1 -->

--- a/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecast.InProcess.Tests.csproj
+++ b/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecast.InProcess.Tests.csproj
@@ -11,6 +11,6 @@
     <PackageReference Include="xunit"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)src/WeatherForecast/WeatherForecast.csproj"/>
+    <ProjectReference Include="../../src/WeatherForecast/WeatherForecast.csproj"/>
   </ItemGroup>
 </Project>

--- a/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecast.Tests.csproj
+++ b/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecast.Tests.csproj
@@ -12,6 +12,6 @@
     <PackageReference Include="xunit"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)src/WeatherForecast/WeatherForecast.csproj"/>
+    <ProjectReference Include="../../src/WeatherForecast/WeatherForecast.csproj"/>
   </ItemGroup>
 </Project>

--- a/src/Templates/CSharp/Testcontainers.ModuleName/Testcontainers.ModuleName.csproj
+++ b/src/Templates/CSharp/Testcontainers.ModuleName/Testcontainers.ModuleName.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.ActiveMq/Testcontainers.ActiveMq.csproj
+++ b/src/Testcontainers.ActiveMq/Testcontainers.ActiveMq.csproj
@@ -8,6 +8,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.ArangoDb/Testcontainers.ArangoDb.csproj
+++ b/src/Testcontainers.ArangoDb/Testcontainers.ArangoDb.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Azurite/Testcontainers.Azurite.csproj
+++ b/src/Testcontainers.Azurite/Testcontainers.Azurite.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.BigQuery/Testcontainers.BigQuery.csproj
+++ b/src/Testcontainers.BigQuery/Testcontainers.BigQuery.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Bigtable/Testcontainers.Bigtable.csproj
+++ b/src/Testcontainers.Bigtable/Testcontainers.Bigtable.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj
+++ b/src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Consul/Testcontainers.Consul.csproj
+++ b/src/Testcontainers.Consul/Testcontainers.Consul.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.CosmosDb/Testcontainers.CosmosDb.csproj
+++ b/src/Testcontainers.CosmosDb/Testcontainers.CosmosDb.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.CouchDb/Testcontainers.CouchDb.csproj
+++ b/src/Testcontainers.CouchDb/Testcontainers.CouchDb.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Couchbase/Testcontainers.Couchbase.csproj
+++ b/src/Testcontainers.Couchbase/Testcontainers.Couchbase.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj
+++ b/src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj
+++ b/src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj
+++ b/src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.FakeGcsServer/Testcontainers.FakeGcsServer.csproj
+++ b/src/Testcontainers.FakeGcsServer/Testcontainers.FakeGcsServer.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.FirebirdSql/Testcontainers.FirebirdSql.csproj
+++ b/src/Testcontainers.FirebirdSql/Testcontainers.FirebirdSql.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Firestore/Testcontainers.Firestore.csproj
+++ b/src/Testcontainers.Firestore/Testcontainers.Firestore.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.InfluxDb/Testcontainers.InfluxDb.csproj
+++ b/src/Testcontainers.InfluxDb/Testcontainers.InfluxDb.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.JanusGraph/Testcontainers.JanusGraph.csproj
+++ b/src/Testcontainers.JanusGraph/Testcontainers.JanusGraph.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.K3s/Testcontainers.K3s.csproj
+++ b/src/Testcontainers.K3s/Testcontainers.K3s.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Kafka/Testcontainers.Kafka.csproj
+++ b/src/Testcontainers.Kafka/Testcontainers.Kafka.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj
+++ b/src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Kusto/Testcontainers.Kusto.csproj
+++ b/src/Testcontainers.Kusto/Testcontainers.Kusto.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.LocalStack/Testcontainers.LocalStack.csproj
+++ b/src/Testcontainers.LocalStack/Testcontainers.LocalStack.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj
+++ b/src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Minio/Testcontainers.Minio.csproj
+++ b/src/Testcontainers.Minio/Testcontainers.Minio.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.MongoDb/Testcontainers.MongoDb.csproj
+++ b/src/Testcontainers.MongoDb/Testcontainers.MongoDb.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.MsSql/Testcontainers.MsSql.csproj
+++ b/src/Testcontainers.MsSql/Testcontainers.MsSql.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.MySql/Testcontainers.MySql.csproj
+++ b/src/Testcontainers.MySql/Testcontainers.MySql.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Nats/Testcontainers.Nats.csproj
+++ b/src/Testcontainers.Nats/Testcontainers.Nats.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Neo4j/Testcontainers.Neo4j.csproj
+++ b/src/Testcontainers.Neo4j/Testcontainers.Neo4j.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Oracle/Testcontainers.Oracle.csproj
+++ b/src/Testcontainers.Oracle/Testcontainers.Oracle.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Papercut/Testcontainers.Papercut.csproj
+++ b/src/Testcontainers.Papercut/Testcontainers.Papercut.csproj
@@ -10,6 +10,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj
+++ b/src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.PubSub/Testcontainers.PubSub.csproj
+++ b/src/Testcontainers.PubSub/Testcontainers.PubSub.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.RabbitMq/Testcontainers.RabbitMq.csproj
+++ b/src/Testcontainers.RabbitMq/Testcontainers.RabbitMq.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.RavenDb/Testcontainers.RavenDb.csproj
+++ b/src/Testcontainers.RavenDb/Testcontainers.RavenDb.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Redis/Testcontainers.Redis.csproj
+++ b/src/Testcontainers.Redis/Testcontainers.Redis.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.Redpanda/Testcontainers.Redpanda.csproj
+++ b/src/Testcontainers.Redpanda/Testcontainers.Redpanda.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.SqlEdge/Testcontainers.SqlEdge.csproj
+++ b/src/Testcontainers.SqlEdge/Testcontainers.SqlEdge.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/src/Testcontainers.WebDriver/Testcontainers.WebDriver.csproj
+++ b/src/Testcontainers.WebDriver/Testcontainers.WebDriver.csproj
@@ -7,6 +7,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0" PrivateAssets="All"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj" />
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj" />
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.ActiveMq.Tests/Testcontainers.ActiveMq.Tests.csproj
+++ b/tests/Testcontainers.ActiveMq.Tests/Testcontainers.ActiveMq.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Apache.NMS.ActiveMQ" Version="2.1.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.ActiveMq/Testcontainers.ActiveMq.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.ActiveMq/Testcontainers.ActiveMq.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.ArangoDb.Tests/Testcontainers.ArangoDb.Tests.csproj
+++ b/tests/Testcontainers.ArangoDb.Tests/Testcontainers.ArangoDb.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="ArangoDBNetStandard" Version="2.0.1"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.ArangoDb/Testcontainers.ArangoDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.ArangoDb/Testcontainers.ArangoDb.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Azurite.Tests/Testcontainers.Azurite.Tests.csproj
+++ b/tests/Testcontainers.Azurite.Tests/Testcontainers.Azurite.Tests.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="Azure.Storage.Queues" Version="12.15.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Azurite/Testcontainers.Azurite.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Azurite/Testcontainers.Azurite.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.BigQuery.Tests/Testcontainers.BigQuery.Tests.csproj
+++ b/tests/Testcontainers.BigQuery.Tests/Testcontainers.BigQuery.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Google.Cloud.BigQuery.V2" Version="3.4.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.BigQuery/Testcontainers.BigQuery.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.BigQuery/Testcontainers.BigQuery.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Bigtable.Tests/Testcontainers.Bigtable.Tests.csproj
+++ b/tests/Testcontainers.Bigtable.Tests/Testcontainers.Bigtable.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Google.Cloud.Bigtable.Admin.V2" Version="3.7.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Bigtable/Testcontainers.Bigtable.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Bigtable/Testcontainers.Bigtable.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.ClickHouse.Tests/Testcontainers.ClickHouse.Tests.csproj
+++ b/tests/Testcontainers.ClickHouse.Tests/Testcontainers.ClickHouse.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="ClickHouse.Client" Version="6.7.1"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
+++ b/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
@@ -10,6 +10,6 @@
         <PackageReference Include="JetBrains.Annotations" Version="2023.3.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers/Testcontainers.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers/Testcontainers.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Consul.Tests/Testcontainers.Consul.Tests.csproj
+++ b/tests/Testcontainers.Consul.Tests/Testcontainers.Consul.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Consul" Version="1.6.10.9" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Consul/Testcontainers.Consul.csproj" />
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj" />
+        <ProjectReference Include="../../src/Testcontainers.Consul/Testcontainers.Consul.csproj" />
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj" />
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.CosmosDb.Tests/Testcontainers.CosmosDb.Tests.csproj
+++ b/tests/Testcontainers.CosmosDb.Tests/Testcontainers.CosmosDb.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.32.1"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.CosmosDb/Testcontainers.CosmosDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.CosmosDb/Testcontainers.CosmosDb.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
+++ b/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="MyCouch" Version="7.6.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.CouchDb/Testcontainers.CouchDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.CouchDb/Testcontainers.CouchDb.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
+++ b/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="CouchbaseNetClient" Version="3.4.3"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Couchbase/Testcontainers.Couchbase.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Couchbase/Testcontainers.Couchbase.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
+++ b/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="xunit" Version="2.6.5"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.*.Tests/Testcontainers.*.Tests.csproj"/>
-        <ProjectReference Remove="$(SolutionDir)tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj"/>
+        <ProjectReference Include="../Testcontainers.*.Tests/Testcontainers.*.Tests.csproj"/>
+        <ProjectReference Remove="Testcontainers.Databases.Tests.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
+++ b/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.101.42"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
+++ b/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.5"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
+++ b/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.FakeGcsServer.Tests/Testcontainers.FakeGcsServer.Tests.csproj
+++ b/tests/Testcontainers.FakeGcsServer.Tests/Testcontainers.FakeGcsServer.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Google.Cloud.Storage.V1" Version="4.6.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.FakeGcsServer/Testcontainers.FakeGcsServer.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.FakeGcsServer/Testcontainers.FakeGcsServer.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.FirebirdSql.Tests/Testcontainers.FirebirdSql.Tests.csproj
+++ b/tests/Testcontainers.FirebirdSql.Tests/Testcontainers.FirebirdSql.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="10.0.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.FirebirdSql/Testcontainers.FirebirdSql.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.FirebirdSql/Testcontainers.FirebirdSql.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Firestore.Tests/Testcontainers.Firestore.Tests.csproj
+++ b/tests/Testcontainers.Firestore.Tests/Testcontainers.Firestore.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Google.Cloud.Firestore" Version="3.1.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Firestore/Testcontainers.Firestore.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Firestore/Testcontainers.Firestore.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.InfluxDb.Tests/Testcontainers.InfluxDb.Tests.csproj
+++ b/tests/Testcontainers.InfluxDb.Tests/Testcontainers.InfluxDb.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="InfluxDB.Client" Version="4.12.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.InfluxDb/Testcontainers.InfluxDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.InfluxDb/Testcontainers.InfluxDb.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.JanusGraph.Tests/Testcontainers.JanusGraph.Tests.csproj
+++ b/tests/Testcontainers.JanusGraph.Tests/Testcontainers.JanusGraph.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="JanusGraph.Net" Version="1.0.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.JanusGraph/Testcontainers.JanusGraph.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.JanusGraph/Testcontainers.JanusGraph.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.K3s.Tests/Testcontainers.K3s.Tests.csproj
+++ b/tests/Testcontainers.K3s.Tests/Testcontainers.K3s.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="KubernetesClient" Version="10.1.4"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.K3s/Testcontainers.K3s.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.K3s/Testcontainers.K3s.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
+++ b/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Confluent.Kafka" Version="2.0.2"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Kafka/Testcontainers.Kafka.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Kafka/Testcontainers.Kafka.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
+++ b/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Keycloak.Net.Core" Version="1.0.20"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Kusto.Tests/Testcontainers.Kusto.Tests.csproj
+++ b/tests/Testcontainers.Kusto.Tests/Testcontainers.Kusto.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Azure.Kusto.Data" Version="11.3.3"/>
   </ItemGroup>
   <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Kusto/Testcontainers.Kusto.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Kusto/Testcontainers.Kusto.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
   </ItemGroup>
 </Project>

--- a/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
+++ b/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="AWSSDK.SQS" Version="3.7.100.71"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.LocalStack/Testcontainers.LocalStack.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.LocalStack/Testcontainers.LocalStack.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
+++ b/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="MySqlConnector" Version="2.2.5"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
+++ b/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="AWSSDK.S3" Version="3.7.103.3"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Minio/Testcontainers.Minio.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Minio/Testcontainers.Minio.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
+++ b/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="MongoDB.Driver" Version="2.19.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.MongoDb/Testcontainers.MongoDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.MongoDb/Testcontainers.MongoDb.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
+++ b/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.3"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.MsSql/Testcontainers.MsSql.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.MsSql/Testcontainers.MsSql.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
+++ b/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="MySqlConnector" Version="2.2.5"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.MySql/Testcontainers.MySql.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.MySql/Testcontainers.MySql.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Nats.Tests/Testcontainers.Nats.Tests.csproj
+++ b/tests/Testcontainers.Nats.Tests/Testcontainers.Nats.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="NATS.Client" Version="1.0.8"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Nats/Testcontainers.Nats.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Nats/Testcontainers.Nats.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
+++ b/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Neo4j.Driver" Version="5.5.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Neo4j/Testcontainers.Neo4j.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Neo4j/Testcontainers.Neo4j.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
+++ b/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.90"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Oracle/Testcontainers.Oracle.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Oracle/Testcontainers.Oracle.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Papercut.Tests/Testcontainers.Papercut.Tests.csproj
+++ b/tests/Testcontainers.Papercut.Tests/Testcontainers.Papercut.Tests.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="xunit" Version="2.6.5"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Papercut/Testcontainers.Papercut.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Papercut/Testcontainers.Papercut.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
+++ b/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
@@ -11,6 +11,6 @@
         <PackageReference Include="xunit" Version="2.6.5"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
+++ b/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
@@ -11,6 +11,6 @@
         <PackageReference Include="xunit" Version="2.6.5"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
+++ b/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Npgsql" Version="6.0.10"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.PubSub.Tests/Testcontainers.PubSub.Tests.csproj
+++ b/tests/Testcontainers.PubSub.Tests/Testcontainers.PubSub.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Google.Cloud.PubSub.V1" Version="3.5.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.PubSub/Testcontainers.PubSub.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.PubSub/Testcontainers.PubSub.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
+++ b/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="RabbitMQ.Client" Version="6.4.0"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.RabbitMq/Testcontainers.RabbitMq.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.RabbitMq/Testcontainers.RabbitMq.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
+++ b/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="RavenDB.Client" Version="5.4.100"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.RavenDb/Testcontainers.RavenDb.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.RavenDb/Testcontainers.RavenDb.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
+++ b/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="StackExchange.Redis" Version="2.6.90"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Redis/Testcontainers.Redis.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Redis/Testcontainers.Redis.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
+++ b/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Confluent.Kafka" Version="2.0.2"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.Redpanda/Testcontainers.Redpanda.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Redpanda/Testcontainers.Redpanda.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
+++ b/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
@@ -14,6 +14,6 @@
     <PackageReference Include="xunit" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj" />
+    <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/Testcontainers.SqlEdge.Tests/Testcontainers.SqlEdge.Tests.csproj
+++ b/tests/Testcontainers.SqlEdge.Tests/Testcontainers.SqlEdge.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.3"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.SqlEdge/Testcontainers.SqlEdge.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.SqlEdge/Testcontainers.SqlEdge.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
+++ b/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="xunit" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj" />
+    <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Assets/**/*">

--- a/tests/Testcontainers.WebDriver.Tests/Testcontainers.WebDriver.Tests.csproj
+++ b/tests/Testcontainers.WebDriver.Tests/Testcontainers.WebDriver.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Selenium.WebDriver" Version="4.8.1"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="$(SolutionDir)src/Testcontainers.WebDriver/Testcontainers.WebDriver.csproj"/>
-        <ProjectReference Include="$(SolutionDir)tests/Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.WebDriver/Testcontainers.WebDriver.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## What does this PR do?

This pull request replaces all usage of `$(SolutionDir)` with relative paths instead.

## Why is it important?

When using Testcontainers project directly from source, using `$(SolutionDir)` interferes since the `$(SolutionDir)` will be defined for the currently opened solution instead of `Testcontainers.sln`. Using relative paths work both for `Testcontainers.sln` and `MyApp.sln`. Using Testcontainers direclty from source is required to test bleeding edge feature such as `WithReuse(true)` which was introduced a few days ago.

> [!NOTE]  
> _directly from source_ means using
> ```xml
> <ProjectReference Include="..\..\testcontainers-dotnet\src\Testcontainers.PostgreSql\Testcontainers.PostgreSql.csproj" />
> ```
> instead of
> ```xml
> <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
> ```

## Related issues

None