### PR TITLE
chore: Add Test Reporter GitHub Action

### DIFF
--- a/.cake-scripts/parameters.cake
+++ b/.cake-scripts/parameters.cake
@@ -29,7 +29,6 @@ internal sealed class BuildParameters
   public NuGetCredentials NuGetCredentials { get; private set; }
   public BuildProjects Projects { get; private set; }
   public BuildPaths Paths { get; private set; }
-  public DotNetMSBuildSettings MSBuildSettings { get; private set; }
 
   public static BuildParameters Instance(ICakeContext context)
   {
@@ -60,7 +59,6 @@ internal sealed class BuildParameters
       NuGetCredentials = NuGetCredentials.GetNuGetCredentials(context),
       Projects = BuildProjects.Instance(context, solutionFilePath),
       Paths = BuildPaths.Instance(context, buildInformation.Version),
-      MSBuildSettings = new DotNetMSBuildSettings()
     };
   }
 }

--- a/.cake-scripts/parameters.cake
+++ b/.cake-scripts/parameters.cake
@@ -58,7 +58,7 @@ internal sealed class BuildParameters
       SonarQubeCredentials = SonarQubeCredentials.GetSonarQubeCredentials(context),
       NuGetCredentials = NuGetCredentials.GetNuGetCredentials(context),
       Projects = BuildProjects.Instance(context, solutionFilePath),
-      Paths = BuildPaths.Instance(context, buildInformation.Version),
+      Paths = BuildPaths.Instance(context, buildInformation.Version)
     };
   }
 }

--- a/.cake-scripts/parameters.cake
+++ b/.cake-scripts/parameters.cake
@@ -29,6 +29,7 @@ internal sealed class BuildParameters
   public NuGetCredentials NuGetCredentials { get; private set; }
   public BuildProjects Projects { get; private set; }
   public BuildPaths Paths { get; private set; }
+  public DotNetMSBuildSettings MSBuildSettings { get; private set; }
 
   public static BuildParameters Instance(ICakeContext context)
   {
@@ -58,7 +59,8 @@ internal sealed class BuildParameters
       SonarQubeCredentials = SonarQubeCredentials.GetSonarQubeCredentials(context),
       NuGetCredentials = NuGetCredentials.GetNuGetCredentials(context),
       Projects = BuildProjects.Instance(context, solutionFilePath),
-      Paths = BuildPaths.Instance(context, buildInformation.Version)
+      Paths = BuildPaths.Instance(context, buildInformation.Version),
+      MSBuildSettings = new DotNetMSBuildSettings()
     };
   }
 }

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -66,6 +66,7 @@ jobs:
 
       - name: Upload Test And Coverage Results
         uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: ${{ matrix.os }}
           path: test-results

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -80,6 +80,7 @@ jobs:
 
       - name: Upload Test And Coverage Results
         uses: actions/upload-artifact@v4
+        if: true
         with:
           name: ${{ matrix.os }}
           path: test-results

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,30 @@
+name: 'Test Report'
+
+on:
+  workflow_run:
+    workflows: ['Continuous Integration & Delivery']
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04, windows-2022 ]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Publish ${{ matrix.os }} Test Results
+      uses: dorny/test-reporter@v1
+      with:
+        artifact: ${{ matrix.os }}
+        name: Test Results (${{ matrix.os }})
+        path: '*.trx'
+        reporter: dotnet-trx

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,15 +1,10 @@
-name: 'Test Report'
+name: Test Report
 
 on:
   workflow_run:
     workflows: ['Continuous Integration & Delivery']
     types:
       - completed
-
-permissions:
-  contents: read
-  actions: read
-  checks: write
 
 jobs:
   report:
@@ -18,13 +13,18 @@ jobs:
       matrix:
         os: [ ubuntu-22.04, windows-2022 ]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+
+    permissions:
+      actions: read
+      checks: write
+      contents: read
 
     steps:
-    - name: Publish ${{ matrix.os }} Test Results
-      uses: dorny/test-reporter@v1
-      with:
-        artifact: ${{ matrix.os }}
-        name: Test Results (${{ matrix.os }})
-        path: '*.trx'
-        reporter: dotnet-trx
+      - name: Publish '${{ matrix.os }}' Test Report
+        uses: dorny/test-reporter@v1
+        with:
+          artifact: ${{ matrix.os }}
+          name: ${{ matrix.os }}
+          path: '*.trx'
+          reporter: dotnet-trx

--- a/build.cake
+++ b/build.cake
@@ -80,7 +80,7 @@ Task("Tests")
     NoRestore = true,
     NoBuild = true,
     Collectors = new[] { "XPlat Code Coverage;Format=opencover" },
-    Loggers = new[] { "trx" },
+    MSBuildSettings = param.MSBuildSettings.WithProperty("UseTrxLogger", "true"),
     Filter = param.TestFilter,
     ResultsDirectory = param.Paths.Directories.TestResultsDirectoryPath,
     ArgumentCustomization = args => args

--- a/build.cake
+++ b/build.cake
@@ -80,7 +80,6 @@ Task("Tests")
     NoRestore = true,
     NoBuild = true,
     Collectors = new[] { "XPlat Code Coverage;Format=opencover" },
-    MSBuildSettings = param.MSBuildSettings.WithProperty("UseTrxLogger", "true"),
     Filter = param.TestFilter,
     ResultsDirectory = param.Paths.Directories.TestResultsDirectoryPath,
     ArgumentCustomization = args => args

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -4,4 +4,10 @@
   <PropertyGroup>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
+  <ItemGroup>
+    <VSTestLogger Include="trx%3BLogFileName=$(MSBuildProjectName).trx" Condition="$(UseTrxLogger) == 'true'" />
+  </ItemGroup>
+  <PropertyGroup>
+    <VSTestLogger>@(VSTestLogger)</VSTestLogger>
+  </PropertyGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  <PropertyGroup>
-    <SignAssembly>false</SignAssembly>
-  </PropertyGroup>
-  <ItemGroup>
-    <VSTestLogger Include="trx%3BLogFileName=$(MSBuildProjectName).trx" Condition="$(UseTrxLogger) == 'true'" />
-  </ItemGroup>
-  <PropertyGroup>
-    <VSTestLogger>@(VSTestLogger)</VSTestLogger>
-  </PropertyGroup>
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"/>
+    <PropertyGroup>
+        <SignAssembly>false</SignAssembly>
+    </PropertyGroup>
+    <PropertyGroup>
+        <VSTestLogger>trx%3BLogFileName=$(MSBuildProjectName).trx</VSTestLogger>
+    </PropertyGroup>
 </Project>


### PR DESCRIPTION
## What does this PR do?

This pull request introduces [Test Reporter](https://github.com/dorny/test-reporter) in the CI/CD pipeline to get visibility over the test that has been run as part of a GitHub action run.

## Why is it important?

It's extremely hard to find a failed test deep inside the _Run Tests_ step logs. Using [Test Reporter](https://github.com/dorny/test-reporter) is a very convenient way to see all the tests (passes/failed/skipped) at a glance.

## Related issues

Related to https://github.com/testcontainers/testcontainers-dotnet/issues/1092#issuecomment-1907994037 where I absolutely had to do something to figure out which tests were failing.

## How to test this PR

Just look at the results in a GitHub action run. For example: https://github.com/0xced/testcontainers-dotnet/actions/runs/7642079627/job/20821394193

And here's a screenshot in case in case this job expires.

![Screenshot of a run with all tests passing](https://github.com/testcontainers/testcontainers-dotnet/assets/51363/cf51b83f-0477-433a-8290-537f45288eac)