### PR TITLE
fix: Consider the timestamp in the log message wait strategy (read the correct log message chunk)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Run Tests
         run: dotnet cake --target=Tests --test-filter=${{ startsWith(matrix.os, 'ubuntu') && 'FullyQualifiedName~Testcontainers' || 'DockerPlatform=Windows' }}
 
-      # The Test Reporter GH Action is not yet compatible with the recent
-      # actions/upload-artifact updates: https://github.com/dorny/test-reporter/issues/363.
+      # The Test Reporter GH Action is not compatible with the recent
+      # actions/upload-artifact@v4 updates: https://github.com/dorny/test-reporter/issues/363.
       - name: Upload Test And Coverage Results
         uses: actions/upload-artifact@v3
         if: true
@@ -175,7 +175,7 @@ jobs:
         run: dotnet cake --target=Publish
 
       # Cake sets the semVer environment variable
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         with:
           version: ${{ env.semVer }}
         env:

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -25,6 +25,6 @@ jobs:
         uses: dorny/test-reporter@v1.8.0
         with:
           artifact: ${{ matrix.os }}-v3
-          name: Test Report
+          name: report (${{ matrix.os }})
           path: '*.trx'
           reporter: dotnet-trx

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -25,6 +25,6 @@ jobs:
         uses: dorny/test-reporter@v1.8.0
         with:
           artifact: ${{ matrix.os }}-v3
-          name: ${{ matrix.os }}
+          name: Test Report
           path: '*.trx'
           reporter: dotnet-trx

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageVersion Include="coverlet.collector" Version="6.0.0"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6"/>
-        <PackageVersion Include="xunit" Version="2.6.5"/>
+        <PackageVersion Include="xunit" Version="2.6.6"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->
         <PackageVersion Include="Apache.NMS.ActiveMQ" Version="2.1.0"/>
         <PackageVersion Include="ArangoDBNetStandard" Version="2.0.1"/>

--- a/src/Testcontainers.Elasticsearch/ElasticsearchBuilder.cs
+++ b/src/Testcontainers.Elasticsearch/ElasticsearchBuilder.cs
@@ -126,7 +126,7 @@ public sealed class ElasticsearchBuilder : ContainerBuilder<ElasticsearchBuilder
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var (stdout, _) = await container.GetLogsAsync(timestampsEnabled: false)
+            var (stdout, _) = await container.GetLogsAsync(since: container.StoppedTime, timestampsEnabled: false)
                 .ConfigureAwait(false);
 
             return Pattern.Any(stdout.Contains);

--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -136,7 +136,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var (stdout, stderr) = await container.GetLogsAsync(timestampsEnabled: false)
+            var (stdout, stderr) = await container.GetLogsAsync(since: container.StoppedTime, timestampsEnabled: false)
                 .ConfigureAwait(false);
 
             return _count.Equals(Array.Empty<string>()

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -69,8 +69,8 @@ namespace DotNet.Testcontainers.Clients
       {
         ShowStdout = true,
         ShowStderr = true,
-        Since = Math.Max(0, since.TotalSeconds).ToString("0", CultureInfo.InvariantCulture),
-        Until = Math.Max(0, until.TotalSeconds).ToString("0", CultureInfo.InvariantCulture),
+        Since = Math.Max(0, Math.Floor(since.TotalSeconds)).ToString("0", CultureInfo.InvariantCulture),
+        Until = Math.Max(0, Math.Floor(until.TotalSeconds)).ToString("0", CultureInfo.InvariantCulture),
         Timestamps = timestampsEnabled,
       };
 

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
@@ -21,7 +21,7 @@ namespace DotNet.Testcontainers.Configurations
 
     public async Task<bool> UntilAsync(IContainer container)
     {
-      var (stdout, stderr) = await container.GetLogsAsync(timestampsEnabled: false)
+      var (stdout, stderr) = await container.GetLogsAsync(since: container.StoppedTime, timestampsEnabled: false)
         .ConfigureAwait(false);
 
       return _pattern.IsMatch(stdout) || _pattern.IsMatch(stderr);

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -62,6 +62,15 @@ namespace DotNet.Testcontainers.Containers
     public ILogger Logger { get; }
 
     /// <inheritdoc />
+    public DateTime CreatedTime { get; private set; }
+
+    /// <inheritdoc />
+    public DateTime StartedTime { get; private set; }
+
+    /// <inheritdoc />
+    public DateTime StoppedTime { get; private set; }
+
+    /// <inheritdoc />
     public string Id
     {
       get
@@ -400,6 +409,7 @@ namespace DotNet.Testcontainers.Containers
       _container = await _client.Container.ByIdAsync(id, ct)
         .ConfigureAwait(false);
 
+      CreatedTime = DateTime.UtcNow;
       Created?.Invoke(this, EventArgs.Empty);
     }
 
@@ -420,6 +430,10 @@ namespace DotNet.Testcontainers.Containers
         .ConfigureAwait(false);
 
       _container = new ContainerInspectResponse();
+
+      CreatedTime = default;
+      StartedTime = default;
+      StoppedTime = default;
     }
 
     /// <summary>
@@ -476,6 +490,7 @@ namespace DotNet.Testcontainers.Containers
 
       Logger.CompleteReadinessCheck(_container.ID);
 
+      StartedTime = DateTime.UtcNow;
       Started?.Invoke(this, EventArgs.Empty);
     }
 
@@ -504,6 +519,7 @@ namespace DotNet.Testcontainers.Containers
       _container = await _client.Container.ByIdAsync(_container.ID, ct)
         .ConfigureAwait(false);
 
+      StoppedTime = DateTime.UtcNow;
       Stopped?.Invoke(this, EventArgs.Empty);
     }
 

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -59,6 +59,21 @@ namespace DotNet.Testcontainers.Containers
     ILogger Logger { get; }
 
     /// <summary>
+    /// Gets the created timestamp.
+    /// </summary>
+    DateTime CreatedTime { get; }
+
+    /// <summary>
+    /// Gets the started timestamp.
+    /// </summary>
+    DateTime StartedTime { get; }
+
+    /// <summary>
+    /// Gets the stopped timestamp.
+    /// </summary>
+    DateTime StoppedTime { get; }
+
+    /// <summary>
     /// Gets the container id.
     /// </summary>
     /// <exception cref="InvalidOperationException">Container has not been created.</exception>

--- a/tests/Testcontainers.Commons/SharedContainerInstance.cs
+++ b/tests/Testcontainers.Commons/SharedContainerInstance.cs
@@ -1,0 +1,23 @@
+﻿namespace DotNet.Testcontainers.Commons;
+
+[PublicAPI]
+public abstract class SharedContainerInstance<TContainer> : IAsyncLifetime
+    where TContainer : IContainer
+{
+    public SharedContainerInstance(TContainer container)
+    {
+        Container = container;
+    }
+
+    public TContainer Container { get; }
+
+    public Task InitializeAsync()
+    {
+        return Container.StartAsync();
+    }
+
+    public Task DisposeAsync()
+    {
+        return Container.DisposeAsync().AsTask();
+    }
+}

--- a/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
+++ b/tests/Testcontainers.Commons/Testcontainers.Commons.csproj
@@ -3,11 +3,13 @@
         <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <IsTestProject>false</IsTestProject>
         <SignAssembly>true</SignAssembly>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" VersionOverride="2023.3.0"/>
+        <PackageReference Include="xunit"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers/Testcontainers.csproj"/>

--- a/tests/Testcontainers.Commons/Usings.cs
+++ b/tests/Testcontainers.Commons/Usings.cs
@@ -2,5 +2,8 @@ global using System;
 global using System.Diagnostics;
 global using System.IO;
 global using System.Text;
+global using System.Threading.Tasks;
+global using DotNet.Testcontainers.Containers;
 global using DotNet.Testcontainers.Images;
 global using JetBrains.Annotations;
+global using Xunit;

--- a/tests/Testcontainers.PostgreSql.Tests/Usings.cs
+++ b/tests/Testcontainers.PostgreSql.Tests/Usings.cs
@@ -1,6 +1,9 @@
+global using System;
 global using System.Data;
 global using System.Data.Common;
+global using System.Threading;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using JetBrains.Annotations;
 global using Npgsql;
 global using Xunit;


### PR DESCRIPTION
## What does this PR do?

The PR adds three new properties, `CreatedTime`, `StartedTime`, and `StoppedTime`, to the `IContainer` interface. The timestamp is assigned to the properties according to the state of the container.

## Why is it important?

The log message wait strategy, until now, did not consider the timestamp from when it should read the container logs. Starting an already existing container (`StopAsync()`, `StartAsync()`) indicated the readiness of the container too early because the log messages were already present from the previous start. With the introduced changes, the log messages wait strategy will only include container log messages after the stopped timeout. This ensures that the wait strategy does not test against log messages generated from previous runs.

Starting an existing container may still run into issues if the log message wait strategy is not compatible with the different behaviors or outputs of the container. In some cases, the wait strategies need to be adjusted. We have noticed cases where container logs differ on the first attempt.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- #1092

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
