### PR TITLE
chore: Use the `pg_isready` command to assess whether PostgreSQL is ready or not

### DIFF
--- a/src/Testcontainers.PostgreSql/PostgreSqlBuilder.cs
+++ b/src/Testcontainers.PostgreSql/PostgreSqlBuilder.cs
@@ -73,7 +73,11 @@ public sealed class PostgreSqlBuilder : ContainerBuilder<PostgreSqlBuilder, Post
     public override PostgreSqlContainer Build()
     {
         Validate();
-        return new PostgreSqlContainer(DockerResourceConfiguration, TestcontainersSettings.Logger);
+
+        // By default, the base builder waits until the container is running. However, for PostgreSql, a more advanced waiting strategy is necessary that requires access to the configured database and username.
+        // If the user does not provide a custom waiting strategy, append the default PostgreSql waiting strategy.
+        var postgreSqlBuilder = DockerResourceConfiguration.WaitStrategies.Count() > 1 ? this : WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil(DockerResourceConfiguration)));
+        return new PostgreSqlContainer(postgreSqlBuilder.DockerResourceConfiguration, TestcontainersSettings.Logger);
     }
 
     /// <inheritdoc />
@@ -88,8 +92,7 @@ public sealed class PostgreSqlBuilder : ContainerBuilder<PostgreSqlBuilder, Post
             // Disable durability: https://www.postgresql.org/docs/current/non-durability.html.
             .WithCommand("-c", "fsync=off")
             .WithCommand("-c", "full_page_writes=off")
-            .WithCommand("-c", "synchronous_commit=off")
-            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil()));
+            .WithCommand("-c", "synchronous_commit=off");
     }
 
     /// <inheritdoc />
@@ -123,19 +126,37 @@ public sealed class PostgreSqlBuilder : ContainerBuilder<PostgreSqlBuilder, Post
     /// <inheritdoc cref="IWaitUntil" />
     private sealed class WaitUntil : IWaitUntil
     {
-        private const string IPv4Listening = "listening on IPv4";
+        private readonly string[] _command;
 
-        private const string IPv6Listening = "listening on IPv6";
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WaitUntil" /> class.
+        /// </summary>
+        /// <param name="configuration">The container configuration.</param>
+        public WaitUntil(PostgreSqlConfiguration configuration)
+        {
+            _command = new[] {
+                "pg_isready",
+                "--host", "localhost", // Explicitly specify localhost in order to be ready only after the initdb scripts have run and the server is listening over TCP/IP
+                "--dbname", configuration.Database,
+                "--username", configuration.Username,
+            };
+        }
 
-        private const string DatabaseSystemReady = "database system is ready to accept connections";
-
-        /// <inheritdoc />
+        /// <summary>
+        /// Test whether the database is ready to accept connections or not with the <a href="https://www.postgresql.org/docs/current/app-pg-isready.html">pg_isready</a> command.
+        /// </summary>
+        /// <returns><see langword="true"/> if the database is ready to accept connections; <see langword="false"/> if the database is not yet ready.</returns>
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var (_, stderr) = await container.GetLogsAsync(since: container.StoppedTime, timestampsEnabled: false)
+            var execResult = await container.ExecAsync(_command)
                 .ConfigureAwait(false);
 
-            return new[] { IPv4Listening, IPv6Listening, DatabaseSystemReady }.All(stderr.Contains);
+            if (execResult.Stderr.Contains("pg_isready was not found"))
+            {
+                throw new NotSupportedException($"The {container.Image.FullName} image is not supported. Please use postgres:9.3 onwards.");
+            }
+
+            return 0L.Equals(execResult.ExitCode);
         }
     }
 }


### PR DESCRIPTION
This strategy aligns with the MySQL and MariaDb wait strategies.

Also, logs have changed over time and the current strategy doesn't work with older PostgreSQL Docker images (for example v9.6) which does not produce the same logs as recent versions of the PostgreSQL docker image.