### PR TITLE
chore: Always run the Upload Test And Coverage Results step

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -82,14 +82,14 @@ jobs:
       # actions/upload-artifact@v4 updates: https://github.com/dorny/test-reporter/issues/363.
       - name: Upload Test And Coverage Results
         uses: actions/upload-artifact@v3
-        if: true
+        if: always()
         with:
           name: ${{ matrix.os }}-v3
           path: test-results
 
       - name: Upload Test And Coverage Results
         uses: actions/upload-artifact@v4
-        if: true
+        if: always()
         with:
           name: ${{ matrix.os }}
           path: test-results


### PR DESCRIPTION
Use `if: always() `instead of `if: true` in order to always run a step even if the previous one fails. This is surprising but that's how GitHub actions work, see https://stackoverflow.com/questions/58858429/how-to-run-a-github-actions-step-even-if-the-previous-step-fails-while-still-f#comment112735158_58859404

Proof that `if: true` does not work.

<img width="1012" alt="Screenshot 2024-02-11 at 13 24 19" src="https://github.com/testcontainers/testcontainers-dotnet/assets/51363/1a212964-3511-498e-8666-bf700a834991">
