### PR TITLE
chore: Ensure that ConfigureAwait is always called on awaited tasks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,7 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <NoWarn>CS0618,CS1591,SA0001,SA1600,SA1633,SA1649,CA1859,CA1861</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,2 @@
+[*.cs]
+dotnet_diagnostic.CA2007.severity = error


### PR DESCRIPTION
## What does this PR do?

This pull requests enables [code quality analysis](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview#code-quality-analysis) and turns [CA2007: Do not directly await a Task](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007) into an error.

## Why is it important?

Testcontainers for .NET calls `ConfigureAwait(false)` everywhere so this pull request enforces this rule so that authors contributors can't forget about it.

## Follow-ups

Note that this was only enabled in the `src` directory and not at the root of the project to avoid enabling it for the test projects. It becomes problematic in `TestcontainersContainerTest` because of `await using` of IAsyncDisposable where it would generate an error.

And now the big question: is it really necessary to always call `.ConfigureAwait(true)` everywhere in the tests? I understand why calling `.ConfigureAwait(false)` is important in library code but I don't think it matters at all for the test project. Does it? I think we could suppress all `.ConfigureAwait(true)` in the tests and increase the readability of the tests.