### PR TITLE
feat: Add URL-based resource mapping container builder API

### DIFF
--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -197,7 +197,7 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc />
     public TBuilderEntity WithResourceMapping(string source, string target, UnixFileModes fileMode = Unix.FileMode644)
     {
-      if (Uri.TryCreate(source, UriKind.Absolute, out var uri))
+      if (Uri.IsWellFormedUriString(source, UriKind.Absolute) && Uri.TryCreate(source, UriKind.Absolute, out var uri) && new[] { Uri.UriSchemeHttp, Uri.UriSchemeHttps, Uri.UriSchemeFile }.Contains(uri.Scheme))
       {
         return WithResourceMapping(uri, target, fileMode);
       }
@@ -242,7 +242,14 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc />
     public TBuilderEntity WithResourceMapping(Uri source, string target, UnixFileModes fileMode = Unix.FileMode644)
     {
-      return source.IsFile ? WithResourceMapping(new FileResourceMapping(source.AbsolutePath, target, fileMode)) : WithResourceMapping(new UriResourceMapping(source, target, fileMode));
+      if (source.IsFile)
+      {
+        return WithResourceMapping(new FileResourceMapping(source.AbsolutePath, target, fileMode));
+      }
+      else
+      {
+        return WithResourceMapping(new UriResourceMapping(source, target, fileMode));
+      }
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -197,6 +197,11 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc />
     public TBuilderEntity WithResourceMapping(string source, string target, UnixFileModes fileMode = Unix.FileMode644)
     {
+      if (Uri.TryCreate(source, UriKind.Absolute, out var uri))
+      {
+        return WithResourceMapping(uri, target, fileMode);
+      }
+
       var fileAttributes = File.GetAttributes(source);
 
       if ((fileAttributes & FileAttributes.Directory) == FileAttributes.Directory)
@@ -232,6 +237,12 @@ namespace DotNet.Testcontainers.Builders
           return WithResourceMapping(resourceContent, target.ToString(), fileMode);
         }
       }
+    }
+
+    /// <inheritdoc />
+    public TBuilderEntity WithResourceMapping(Uri source, string target, UnixFileModes fileMode = Unix.FileMode644)
+    {
+      return source.IsFile ? WithResourceMapping(new FileResourceMapping(source.AbsolutePath, target, fileMode)) : WithResourceMapping(new UriResourceMapping(source, target, fileMode));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -224,7 +224,7 @@ namespace DotNet.Testcontainers.Builders
     /// <remarks>
     /// If the source corresponds to a file or the Uri scheme corresponds to a file,
     /// the content is copied to the target directory path. If the Uri scheme
-    /// corresponds to HTTP or HTTPS, the content is copied to the target file.
+    /// corresponds to HTTP or HTTPS, the content is copied to the target file path.
     ///
     /// If you prefer to copy a file to a specific target file path instead of a
     /// directory, use: <see cref="WithResourceMapping(FileInfo, FileInfo, UnixFileModes)" />.
@@ -272,12 +272,14 @@ namespace DotNet.Testcontainers.Builders
     /// <remarks>
     /// If the Uri scheme corresponds to a file, the content is copied to the target
     /// directory path. If the Uri scheme corresponds to HTTP or HTTPS, the content is
-    /// copied to the target file.
+    /// copied to the target file path.
+    ///
+    /// The Uri scheme must be either <c>http</c>, <c>https</c> or <c>file</c>.
     ///
     /// If you prefer to copy a file to a specific target file path instead of a
     /// directory, use: <see cref="WithResourceMapping(FileInfo, FileInfo, UnixFileModes)" />.
     /// </remarks>
-    /// <param name="source">The source URL of the file to be copied. Must be a <c>http</c>, <c>https</c> or <c>file</c> URL.</param>
+    /// <param name="source">The source URL of the file to be copied.</param>
     /// <param name="target">The target directory or file path to copy the file to.</param>
     /// <param name="fileMode">The POSIX file mode permission.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -219,10 +219,10 @@ namespace DotNet.Testcontainers.Builders
     TBuilderEntity WithResourceMapping(byte[] resourceContent, string filePath, UnixFileModes fileMode = Unix.FileMode644);
 
     /// <summary>
-    /// Copies a test host directory or file to the container before it starts.
+    /// Copies the contents of a URL or a test host directory or file to the container before it starts.
     /// </summary>
-    /// <param name="source">The source directory or file to be copied.</param>
-    /// <param name="target">The target directory path to copy the files to.</param>
+    /// <param name="source">The source URL, directory or file to be copied.</param>
+    /// <param name="target">The target directory path (if the source is a directory) or file path (if the source is a URL or file) to copy the file(s) to.</param>
     /// <param name="fileMode">The POSIX file mode permission.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
@@ -257,6 +257,15 @@ namespace DotNet.Testcontainers.Builders
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithResourceMapping(FileInfo source, FileInfo target, UnixFileModes fileMode = Unix.FileMode644);
+
+    /// <summary>
+    /// Copies a file at a given URL to the container before it starts.
+    /// </summary>
+    /// <param name="source">The source URL of the file to be copied. Must be a <c>file</c>, <c>http</c> or <c>https</c> URL.</param>
+    /// <param name="target">The target file path to copy the file to.</param>
+    /// <param name="fileMode">The POSIX file mode permission.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    TBuilderEntity WithResourceMapping(Uri source, string target, UnixFileModes fileMode = Unix.FileMode644);
 
     /// <summary>
     /// Assigns the mount configuration to manage data in the container.

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -219,10 +219,18 @@ namespace DotNet.Testcontainers.Builders
     TBuilderEntity WithResourceMapping(byte[] resourceContent, string filePath, UnixFileModes fileMode = Unix.FileMode644);
 
     /// <summary>
-    /// Copies the contents of a URL or a test host directory or file to the container before it starts.
+    /// Copies the contents of a URL, a test host directory or file to the container before it starts.
     /// </summary>
+    /// <remarks>
+    /// If the source corresponds to a file or the Uri scheme corresponds to a file,
+    /// the content is copied to the target directory path. If the Uri scheme
+    /// corresponds to HTTP or HTTPS, the content is copied to the target file.
+    ///
+    /// If you prefer to copy a file to a specific target file path instead of a
+    /// directory, use: <see cref="WithResourceMapping(FileInfo, FileInfo, UnixFileModes)" />.
+    /// </remarks>
     /// <param name="source">The source URL, directory or file to be copied.</param>
-    /// <param name="target">The target directory path (if the source is a directory) or file path (if the source is a URL or file) to copy the file(s) to.</param>
+    /// <param name="target">The target directory or file path to copy the file to.</param>
     /// <param name="fileMode">The POSIX file mode permission.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
@@ -259,10 +267,18 @@ namespace DotNet.Testcontainers.Builders
     TBuilderEntity WithResourceMapping(FileInfo source, FileInfo target, UnixFileModes fileMode = Unix.FileMode644);
 
     /// <summary>
-    /// Copies a file at a given URL to the container before it starts.
+    /// Copies a file from a URL to the container before it starts.
     /// </summary>
-    /// <param name="source">The source URL of the file to be copied. Must be a <c>file</c>, <c>http</c> or <c>https</c> URL.</param>
-    /// <param name="target">The target file path to copy the file to.</param>
+    /// <remarks>
+    /// If the Uri scheme corresponds to a file, the content is copied to the target
+    /// directory path. If the Uri scheme corresponds to HTTP or HTTPS, the content is
+    /// copied to the target file.
+    ///
+    /// If you prefer to copy a file to a specific target file path instead of a
+    /// directory, use: <see cref="WithResourceMapping(FileInfo, FileInfo, UnixFileModes)" />.
+    /// </remarks>
+    /// <param name="source">The source URL of the file to be copied. Must be a <c>http</c>, <c>https</c> or <c>file</c> URL.</param>
+    /// <param name="target">The target directory or file path to copy the file to.</param>
     /// <param name="fileMode">The POSIX file mode permission.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     TBuilderEntity WithResourceMapping(Uri source, string target, UnixFileModes fileMode = Unix.FileMode644);

--- a/src/Testcontainers/Configurations/Volumes/UriResourceMapping.cs
+++ b/src/Testcontainers/Configurations/Volumes/UriResourceMapping.cs
@@ -1,12 +1,12 @@
-using System;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace DotNet.Testcontainers.Configurations
 {
+  using System;
+  using System.Net.Http;
+  using System.Threading;
+  using System.Threading.Tasks;
+
   /// <inheritdoc cref="IResourceMapping" />
-  internal class UriResourceMapping : IResourceMapping
+  internal sealed class UriResourceMapping : IResourceMapping
   {
     private readonly Uri _uri;
 
@@ -48,7 +48,7 @@ namespace DotNet.Testcontainers.Configurations
     public Task DeleteAsync(CancellationToken ct = default) => Task.CompletedTask;
 
     /// <inheritdoc />
-    public virtual async Task<byte[]> GetAllBytesAsync(CancellationToken ct = default)
+    public async Task<byte[]> GetAllBytesAsync(CancellationToken ct = default)
     {
       using (var httpClient = new HttpClient())
       {

--- a/src/Testcontainers/Configurations/Volumes/UriResourceMapping.cs
+++ b/src/Testcontainers/Configurations/Volumes/UriResourceMapping.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DotNet.Testcontainers.Configurations
+{
+  /// <inheritdoc cref="IResourceMapping" />
+  internal class UriResourceMapping : IResourceMapping
+  {
+    private readonly Uri _uri;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UriResourceMapping" /> class.
+    /// </summary>
+    /// <param name="uri">The URL of the file to download.</param>
+    /// <param name="containerPath">The absolute path of the file to map in the container.</param>
+    /// <param name="fileMode">The POSIX file mode permission.</param>
+    public UriResourceMapping(Uri uri, string containerPath, UnixFileModes fileMode)
+    {
+      _uri = uri;
+      Type = MountType.Bind;
+      Source = uri.AbsoluteUri;
+      Target = containerPath;
+      FileMode = fileMode;
+      AccessMode = AccessMode.ReadOnly;
+    }
+
+    /// <inheritdoc />
+    public MountType Type { get; }
+
+    /// <inheritdoc />
+    public AccessMode AccessMode { get; }
+
+    /// <inheritdoc />
+    public string Source { get; }
+
+    /// <inheritdoc />
+    public string Target { get; }
+
+    /// <inheritdoc />
+    public UnixFileModes FileMode { get; }
+
+    /// <inheritdoc />
+    public Task CreateAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task DeleteAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public virtual async Task<byte[]> GetAllBytesAsync(CancellationToken ct = default)
+    {
+      using (var httpClient = new HttpClient())
+      {
+        return await httpClient.GetByteArrayAsync(_uri)
+          .ConfigureAwait(false);
+      }
+    }
+  }
+}

--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -35,14 +35,14 @@ public abstract class TarOutputMemoryStreamTest
     [UsedImplicitly]
     public sealed class FromResourceMapping : TarOutputMemoryStreamTest, IResourceMapping, IClassFixture<FromResourceMapping.HttpFixture>, IAsyncLifetime, IDisposable
     {
-        private readonly string _testUriHttp;
+        private readonly string _testHttpUri;
 
-        private readonly string _testUriFile;
+        private readonly string _testFileUri;
 
         public FromResourceMapping(FromResourceMapping.HttpFixture httpFixture)
         {
-            _testUriHttp = httpFixture.BaseAddress;
-            _testUriFile = new Uri(_testFile.FullName).ToString();
+            _testHttpUri = httpFixture.BaseAddress;
+            _testFileUri = new Uri(_testFile.FullName).ToString();
         }
 
         public MountType Type
@@ -120,8 +120,8 @@ public abstract class TarOutputMemoryStreamTest
                 .WithResourceMapping(_testFile, new FileInfo(targetFilePath1))
                 .WithResourceMapping(_testFile.FullName, targetDirectoryPath1)
                 .WithResourceMapping(_testFile.Directory.FullName, targetDirectoryPath2)
-                .WithResourceMapping(_testUriHttp, targetFilePath2)
-                .WithResourceMapping(_testUriFile, targetDirectoryPath3)
+                .WithResourceMapping(_testHttpUri, targetFilePath2)
+                .WithResourceMapping(_testFileUri, targetDirectoryPath3)
                 .Build();
 
             // When


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a new URL-based resource mapping, allowing to easily copying a file accessible over HTTP or HTTPS directly into a container before it starts, just like one could copy a local file.

## Why is it important?

The `UriResourceMapping` is straightforward to write and would not _need_ to be included in the Testcontainers library but I think having it built-in is a nice addition.