### PR TITLE
fix: Prevent .dockerignore entry from matching everything if it ends with globstart

### DIFF
--- a/src/Testcontainers/Images/IgnoreFile.cs
+++ b/src/Testcontainers/Images/IgnoreFile.cs
@@ -75,10 +75,10 @@ namespace DotNet.Testcontainers.Images
         {
           const string globstar = "**/";
 
-          if (line.Key.StartsWith(globstar))
+          if (line.Key.Contains(globstar))
           {
             lines.Add(line);
-            lines.Add(new KeyValuePair<string, bool>(line.Key.Substring(globstar.Length), line.Value));
+            lines.Add(new KeyValuePair<string, bool>(line.Key.Replace(globstar, string.Empty), line.Value));
           }
           else
           {

--- a/src/Testcontainers/Images/IgnoreFile.cs
+++ b/src/Testcontainers/Images/IgnoreFile.cs
@@ -73,14 +73,17 @@ namespace DotNet.Testcontainers.Images
         // Prepare exact and partial patterns.
         .Aggregate(new List<KeyValuePair<string, bool>>(), (lines, line) =>
         {
-          var key = line.Key;
-          var value = line.Value;
+          const string globstar = "**/";
 
-          lines.AddRange(key
-            .Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)
-            .Skip(1)
-            .Prepend(key)
-            .Select(ignorePattern => new KeyValuePair<string, bool>(ignorePattern, value)));
+          if (line.Key.StartsWith(globstar))
+          {
+            lines.Add(line);
+            lines.Add(new KeyValuePair<string, bool>(line.Key.Substring(globstar.Length), line.Value));
+          }
+          else
+          {
+            lines.Add(line);
+          }
 
           return lines;
         })

--- a/tests/Testcontainers.Tests/Fixtures/Images/IgnoreFileFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/IgnoreFileFixture.cs
@@ -40,12 +40,12 @@ namespace DotNet.Testcontainers.Tests.Fixtures
       Add(ignoreRecursiveFiles, ".git/logs", false);
       Add(ignoreRecursiveFiles, "src/lorem/lipsum/lipsum.config", false);
       Add(ignoreRecursiveFiles, "src/lorem/lipsum.config", false);
+      Add(ignoreRecursiveFiles, "src/lipsum.config", false);
       Add(ignoreRecursiveFiles, ".gitignore", true);
       Add(ignoreRecursiveFiles, ".git/HEAD", true);
       Add(ignoreRecursiveFiles, ".git/refs/heads/main", true);
       Add(ignoreRecursiveFiles, ".git/refs/heads/bugfix/gh-1119", true);
       Add(ignoreRecursiveFiles, "src/lorem/temp", true);
-      Add(ignoreRecursiveFiles, "src/lipsum.config", true);
       Add(ignoreRecursiveFiles, "lipsum.config", true);
       Add(ignoreSingleCharacterFiles, "temp", false);
       Add(ignoreSingleCharacterFiles, "temp1", false);

--- a/tests/Testcontainers.Tests/Fixtures/Images/IgnoreFileFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/IgnoreFileFixture.cs
@@ -13,7 +13,7 @@ namespace DotNet.Testcontainers.Tests.Fixtures
       var ignoreAllFilesAndDirectories = new IgnoreFile(new[] { "*", "!README*.md" }, logger);
       var ignoreNonRecursiveFiles = new IgnoreFile(new[] { "*/temp*" }, logger);
       var ignoreNonRecursiveNestedFiles = new IgnoreFile(new[] { "*/*/temp*" }, logger);
-      var ignoreRecursiveFiles = new IgnoreFile(new[] { "**/*.txt" }, logger);
+      var ignoreRecursiveFiles = new IgnoreFile(new[] { "**/*.txt", "**/.idea", "**/.vs", "**/.git", "!**/.gitignore", "!.git/HEAD", "!.git/refs/heads/**", "src/**/lipsum.config" }, logger);
       var ignoreSingleCharacterFiles = new IgnoreFile(new[] { "temp?" }, logger);
       var ignoreExceptionFiles = new IgnoreFile(new[] { "*.md", "!README*.md", "README-secret.md" }, logger);
       Add(ignoreFilesAndDirectories, "bin/Debug", false);
@@ -35,6 +35,18 @@ namespace DotNet.Testcontainers.Tests.Fixtures
       Add(ignoreRecursiveFiles, "lorem/lipsum.txt", false);
       Add(ignoreRecursiveFiles, "lorem/lipsum/lipsum.config", true);
       Add(ignoreRecursiveFiles, "lorem/lipsum.config", true);
+      Add(ignoreRecursiveFiles, "src/.idea/../v17/../lipsum.log", false);
+      Add(ignoreRecursiveFiles, "src/.vs/../v17/../lipsum.log", false);
+      Add(ignoreRecursiveFiles, ".git/logs", false);
+      Add(ignoreRecursiveFiles, "src/lorem/lipsum/lipsum.config", false);
+      Add(ignoreRecursiveFiles, "src/lorem/lipsum.config", false);
+      Add(ignoreRecursiveFiles, ".gitignore", true);
+      Add(ignoreRecursiveFiles, ".git/HEAD", true);
+      Add(ignoreRecursiveFiles, ".git/refs/heads/main", true);
+      Add(ignoreRecursiveFiles, ".git/refs/heads/bugfix/gh-1119", true);
+      Add(ignoreRecursiveFiles, "src/lorem/temp", true);
+      Add(ignoreRecursiveFiles, "src/lipsum.config", true);
+      Add(ignoreRecursiveFiles, "lipsum.config", true);
       Add(ignoreSingleCharacterFiles, "temp", false);
       Add(ignoreSingleCharacterFiles, "temp1", false);
       Add(ignoreSingleCharacterFiles, "temp12", true);


### PR DESCRIPTION
## What does this PR do?

The PR changes the `.dockerignore` partial (directory or file path) match implementation. The previous implementation contained a bug that resulted in creating a regular expression matching everything if a `.dockerignore` entry or line ended with `/**`, such as `!.git/refs/heads/**`.

## Why is it important?

Developers could encounter issues where the `.dockerignore` entry either ignored too many directories or files, or the negate pattern accepted too many directories or files that should have been ignored.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1119

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->