### PR TITLE
feat: Add remote container registry identity token support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include="BouncyCastle.Cryptography" Version="2.2.1"/>
+        <PackageVersion Include="BouncyCastle.Cryptography" Version="2.3.0"/>
         <PackageVersion Include="Docker.DotNet.X509" Version="3.125.15"/>
         <PackageVersion Include="Docker.DotNet" Version="3.125.15"/>
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0"/>
@@ -15,8 +15,8 @@
         <!-- Unit and integration test dependencies: -->
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageVersion Include="coverlet.collector" Version="6.0.0"/>
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6"/>
-        <PackageVersion Include="xunit" Version="2.6.6"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7"/>
+        <PackageVersion Include="xunit" Version="2.7.0"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->
         <PackageVersion Include="Apache.NMS.ActiveMQ" Version="2.1.0"/>
         <PackageVersion Include="ArangoDBNetStandard" Version="2.0.1"/>

--- a/examples/Flyway/Directory.Packages.props
+++ b/examples/Flyway/Directory.Packages.props
@@ -7,8 +7,8 @@
         <!-- Unit and integration test dependencies: -->
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageVersion Include="Testcontainers.PostgreSql" Version="3.7.0"/>
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6"/>
-        <PackageVersion Include="xunit" Version="2.6.5"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7"/>
+        <PackageVersion Include="xunit" Version="2.7.0"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->
         <PackageVersion Include="Npgsql" Version="6.0.10"/>
     </ItemGroup>

--- a/examples/WeatherForecast/Directory.Packages.props
+++ b/examples/WeatherForecast/Directory.Packages.props
@@ -11,8 +11,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.1"/>
     <PackageVersion Include="Testcontainers.SqlEdge" Version="3.7.0"/>
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6"/>
-    <PackageVersion Include="xunit" Version="2.6.5"/>
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7"/>
+    <PackageVersion Include="xunit" Version="2.7.0"/>
     <!-- Third-party client dependencies to connect and interact with the containers: -->
     <PackageVersion Include="Selenium.WebDriver.ChromeDriver" Version="106.0.5249.6100"/>
     <PackageVersion Include="Selenium.WebDriver" Version="4.9.1"/>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "8.0.200",
     "rollForward": "latestPatch"
   }
 }

--- a/src/Testcontainers/Builders/Base64Provider.cs
+++ b/src/Testcontainers/Builders/Base64Provider.cs
@@ -67,6 +67,17 @@ namespace DotNet.Testcontainers.Builders
         return null;
       }
 
+      if (authProperty.Value.TryGetProperty("identitytoken", out var identityToken) && JsonValueKind.String.Equals(identityToken.ValueKind))
+      {
+        var identityTokenValue = identityToken.GetString();
+
+        if (!string.IsNullOrEmpty(identityTokenValue))
+        {
+          _logger.DockerRegistryCredentialFound(hostname);
+          return new DockerRegistryAuthenticationConfiguration(authProperty.Name, null, null, identityToken.GetString());
+        }
+      }
+
       if (!authProperty.Value.TryGetProperty("auth", out var auth))
       {
         return null;

--- a/src/Testcontainers/Builders/Base64Provider.cs
+++ b/src/Testcontainers/Builders/Base64Provider.cs
@@ -74,7 +74,7 @@ namespace DotNet.Testcontainers.Builders
         if (!string.IsNullOrEmpty(identityTokenValue))
         {
           _logger.DockerRegistryCredentialFound(hostname);
-          return new DockerRegistryAuthenticationConfiguration(authProperty.Name, null, null, identityToken.GetString());
+          return new DockerRegistryAuthenticationConfiguration(authProperty.Name, null, null, identityTokenValue);
         }
       }
 

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
@@ -93,6 +93,9 @@ namespace DotNet.Testcontainers.Tests.Unit
       [InlineData("{\"auths\":{\"" + DockerRegistry + "\":{\"auth\":{}}}}", true, "The \"auth\" property value kind for https://index.docker.io/v1/ is invalid: Object")]
       [InlineData("{\"auths\":{\"" + DockerRegistry + "\":{\"auth\":\"Not_Base64_encoded\"}}}", true, "The \"auth\" property value for https://index.docker.io/v1/ is not a valid Base64 string")]
       [InlineData("{\"auths\":{\"" + DockerRegistry + "\":{\"auth\":\"dXNlcm5hbWU=\"}}}", true, "The \"auth\" property value for https://index.docker.io/v1/ should contain one colon separating the username and the password (basic authentication)")]
+      [InlineData("{\"auths\":{\"" + DockerRegistry + "\":{\"identitytoken\":null}}}", true, null)]
+      [InlineData("{\"auths\":{\"" + DockerRegistry + "\":{\"identitytoken\":\"\"}}}", true, null)]
+      [InlineData("{\"auths\":{\"" + DockerRegistry + "\":{\"identitytoken\":{}}}}", true, null)]
       public void ShouldGetNull(string jsonDocument, bool isApplicable, string logMessage)
       {
         // Given
@@ -118,7 +121,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       [Theory]
       [InlineData("{\"auths\":{\"" + DockerRegistry + "\":{\"auth\":\"dXNlcm5hbWU6cGFzc3dvcmQ=\"}}}", "username", "password", null)]
-      [InlineData("{\"auths\":{\"" + DockerRegistry + "\":{\"identitytoken\":\"identitytoken\"}}}", "username", "password", "identitytoken")]
+      [InlineData("{\"auths\":{\"" + DockerRegistry + "\":{\"identitytoken\":\"identitytoken\"}}}", null, null, "identitytoken")]
       public void ShouldGetAuthConfig(string jsonDocument, string expectedUsername, string expectedPassword, string expectedIdentityToken)
       {
         // Given
@@ -261,7 +264,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     private sealed class WarnLogger : ILogger
     {
-      private readonly List<Tuple<LogLevel, string>> _logMessages = new List<Tuple<LogLevel, string>>();
+      private readonly IList<Tuple<LogLevel, string>> _logMessages = new List<Tuple<LogLevel, string>>();
 
       public IEnumerable<Tuple<LogLevel, string>> LogMessages => _logMessages;
 

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
@@ -116,11 +116,12 @@ namespace DotNet.Testcontainers.Tests.Unit
         }
       }
 
-      [Fact]
-      public void ShouldGetAuthConfig()
+      [Theory]
+      [InlineData("{\"auths\":{\"" + DockerRegistry + "\":{\"auth\":\"dXNlcm5hbWU6cGFzc3dvcmQ=\"}}}", "username", "password", null)]
+      [InlineData("{\"auths\":{\"" + DockerRegistry + "\":{\"identitytoken\":\"identitytoken\"}}}", "username", "password", "identitytoken")]
+      public void ShouldGetAuthConfig(string jsonDocument, string expectedUsername, string expectedPassword, string expectedIdentityToken)
       {
         // Given
-        const string jsonDocument = "{\"auths\":{\"" + DockerRegistry + "\":{\"auth\":\"dXNlcm5hbWU6cGFzc3dvcmQ=\"}}}";
         var jsonElement = JsonDocument.Parse(jsonDocument).RootElement;
 
         // When
@@ -131,8 +132,9 @@ namespace DotNet.Testcontainers.Tests.Unit
         Assert.True(authenticationProvider.IsApplicable(DockerRegistry));
         Assert.NotNull(authConfig);
         Assert.Equal(DockerRegistry, authConfig.RegistryEndpoint);
-        Assert.Equal("username", authConfig.Username);
-        Assert.Equal("password", authConfig.Password);
+        Assert.Equal(expectedUsername, authConfig.Username);
+        Assert.Equal(expectedPassword, authConfig.Password);
+        Assert.Equal(expectedIdentityToken, authConfig.IdentityToken);
       }
     }
 


### PR DESCRIPTION
## What does this PR do?

The PR adds support of the `identitytoken` token to the Base64 authentication provider. If an `auths` node key contains the `identitytoken` node, Testcontainers will use it to authenticate against the private container registry.

## Why is it important?

According to the Microsoft [docs](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli#az-acr-login-with---expose-token), this is a common way to authenticate against the Azure Container Registry and is necessary in some cases. For example, this is a simple mechanism to authenticate against ACR in a CI environment (apart from the Docker login tasks for Azure DevOps or GitHub).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #841

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups

- Include additional documentation regarding private container registry authentication.