### PR TITLE
fix: Prevent a `NullReferenceException` when pulling uncached base images to build an image

### DIFF
--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -339,7 +339,7 @@ namespace DotNet.Testcontainers.Clients
         var cachedImages = await Image.GetAllAsync(filters, ct)
           .ConfigureAwait(false);
 
-        var repositoryTags = new HashSet<string>(cachedImages.SelectMany(image => image.RepoTags));
+        var repositoryTags = new HashSet<string>(cachedImages.SelectMany(image => image.RepoTags ?? Array.Empty<string>()));
 
         var uncachedImages = baseImages.Where(baseImage => !repositoryTags.Contains(baseImage.FullName));
 


### PR DESCRIPTION
## What does this PR do?

Fix a possible null reference exception when the `RepoTags` property of the `ImagesListResponse` is null.

## Why is it important?

Repeated crashes in tests when the docker instance in not empty makes it unusable 

## Related issues
- Closes #1125

## How to test this PR

Unfortunately I could not find a public reproducible way, only with some company internal images. 
However the fix is minimal and self explaining, just adding a null check.
