### PR TITLE
feat: Add support for the target frameworks net6.0 and net8.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,16 +13,15 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": true
     },
-    "ghcr.io/devcontainers/features/dotnet:1": {
-      "version": "8.0.100",
+    "ghcr.io/devcontainers/features/dotnet:2.0.5": {
+      "version": "8.0.200",
       "installUsingApt": false
     }
   },
   "customizations": {
     "extensions": [
-      "formulahendry.dotnet-test-explorer",
       "ms-azuretools.vscode-docker",
-      "ms-dotnettools.csharp"
+      "ms-dotnettools.csdevkit"
     ],
     "settings": {
       "omnisharp.path": "latest" // https://github.com/OmniSharp/omnisharp-vscode/issues/5410#issuecomment-1284531542.

--- a/src/Templates/CSharp/Testcontainers.ModuleName/Testcontainers.ModuleName.csproj
+++ b/src/Templates/CSharp/Testcontainers.ModuleName/Testcontainers.ModuleName.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.ActiveMq/Testcontainers.ActiveMq.csproj
+++ b/src/Testcontainers.ActiveMq/Testcontainers.ActiveMq.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.ArangoDb/Testcontainers.ArangoDb.csproj
+++ b/src/Testcontainers.ArangoDb/Testcontainers.ArangoDb.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Azurite/Testcontainers.Azurite.csproj
+++ b/src/Testcontainers.Azurite/Testcontainers.Azurite.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.BigQuery/Testcontainers.BigQuery.csproj
+++ b/src/Testcontainers.BigQuery/Testcontainers.BigQuery.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Bigtable/Testcontainers.Bigtable.csproj
+++ b/src/Testcontainers.Bigtable/Testcontainers.Bigtable.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj
+++ b/src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.CockroachDb/Testcontainers.CockroachDb.csproj
+++ b/src/Testcontainers.CockroachDb/Testcontainers.CockroachDb.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Consul/Testcontainers.Consul.csproj
+++ b/src/Testcontainers.Consul/Testcontainers.Consul.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.CosmosDb/Testcontainers.CosmosDb.csproj
+++ b/src/Testcontainers.CosmosDb/Testcontainers.CosmosDb.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.CouchDb/Testcontainers.CouchDb.csproj
+++ b/src/Testcontainers.CouchDb/Testcontainers.CouchDb.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Couchbase/Testcontainers.Couchbase.csproj
+++ b/src/Testcontainers.Couchbase/Testcontainers.Couchbase.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj
+++ b/src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj
+++ b/src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj
+++ b/src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.FakeGcsServer/Testcontainers.FakeGcsServer.csproj
+++ b/src/Testcontainers.FakeGcsServer/Testcontainers.FakeGcsServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.FirebirdSql/Testcontainers.FirebirdSql.csproj
+++ b/src/Testcontainers.FirebirdSql/Testcontainers.FirebirdSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Firestore/Testcontainers.Firestore.csproj
+++ b/src/Testcontainers.Firestore/Testcontainers.Firestore.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.InfluxDb/Testcontainers.InfluxDb.csproj
+++ b/src/Testcontainers.InfluxDb/Testcontainers.InfluxDb.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.JanusGraph/Testcontainers.JanusGraph.csproj
+++ b/src/Testcontainers.JanusGraph/Testcontainers.JanusGraph.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.K3s/Testcontainers.K3s.csproj
+++ b/src/Testcontainers.K3s/Testcontainers.K3s.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Kafka/Testcontainers.Kafka.csproj
+++ b/src/Testcontainers.Kafka/Testcontainers.Kafka.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj
+++ b/src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Kusto/Testcontainers.Kusto.csproj
+++ b/src/Testcontainers.Kusto/Testcontainers.Kusto.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.LocalStack/Testcontainers.LocalStack.csproj
+++ b/src/Testcontainers.LocalStack/Testcontainers.LocalStack.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj
+++ b/src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Minio/Testcontainers.Minio.csproj
+++ b/src/Testcontainers.Minio/Testcontainers.Minio.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.MongoDb/Testcontainers.MongoDb.csproj
+++ b/src/Testcontainers.MongoDb/Testcontainers.MongoDb.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.MsSql/Testcontainers.MsSql.csproj
+++ b/src/Testcontainers.MsSql/Testcontainers.MsSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.MySql/Testcontainers.MySql.csproj
+++ b/src/Testcontainers.MySql/Testcontainers.MySql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Nats/Testcontainers.Nats.csproj
+++ b/src/Testcontainers.Nats/Testcontainers.Nats.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Neo4j/Testcontainers.Neo4j.csproj
+++ b/src/Testcontainers.Neo4j/Testcontainers.Neo4j.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Oracle/Testcontainers.Oracle.csproj
+++ b/src/Testcontainers.Oracle/Testcontainers.Oracle.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Papercut/Testcontainers.Papercut.csproj
+++ b/src/Testcontainers.Papercut/Testcontainers.Papercut.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj
+++ b/src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.PubSub/Testcontainers.PubSub.csproj
+++ b/src/Testcontainers.PubSub/Testcontainers.PubSub.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.RabbitMq/Testcontainers.RabbitMq.csproj
+++ b/src/Testcontainers.RabbitMq/Testcontainers.RabbitMq.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.RavenDb/Testcontainers.RavenDb.csproj
+++ b/src/Testcontainers.RavenDb/Testcontainers.RavenDb.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Redis/Testcontainers.Redis.csproj
+++ b/src/Testcontainers.Redis/Testcontainers.Redis.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.Redpanda/Testcontainers.Redpanda.csproj
+++ b/src/Testcontainers.Redpanda/Testcontainers.Redpanda.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.SqlEdge/Testcontainers.SqlEdge.csproj
+++ b/src/Testcontainers.SqlEdge/Testcontainers.SqlEdge.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers.WebDriver/Testcontainers.WebDriver.csproj
+++ b/src/Testcontainers.WebDriver/Testcontainers.WebDriver.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -279,7 +279,7 @@ namespace DotNet.Testcontainers.Containers
       {
         if (!TryGetEndpoint(out var host, out var port))
         {
-          await Task.Delay(TimeSpan.FromSeconds(RetryTimeoutInSeconds), default)
+          await Task.Delay(TimeSpan.FromSeconds(RetryTimeoutInSeconds), default(CancellationToken))
             .ConfigureAwait(false);
 
           continue;
@@ -291,8 +291,13 @@ namespace DotNet.Testcontainers.Containers
 
           try
           {
+#if NET6_0_OR_GREATER
+            await tcpClient.ConnectAsync(host, port, ct)
+              .ConfigureAwait(false);
+#else
             await tcpClient.ConnectAsync(host, port)
               .ConfigureAwait(false);
+#endif
 
             var stream = tcpClient.GetStream();
 
@@ -384,14 +389,14 @@ namespace DotNet.Testcontainers.Containers
           {
             _resourceReaperContainer.Logger.CanNotConnectToResourceReaper(SessionId, host, port, e);
 
-            await Task.Delay(TimeSpan.FromSeconds(RetryTimeoutInSeconds), default)
+            await Task.Delay(TimeSpan.FromSeconds(RetryTimeoutInSeconds), default(CancellationToken))
               .ConfigureAwait(false);
           }
           catch (Exception e)
           {
             _resourceReaperContainer.Logger.LostConnectionToResourceReaper(SessionId, host, port, e);
 
-            await Task.Delay(TimeSpan.FromSeconds(RetryTimeoutInSeconds), default)
+            await Task.Delay(TimeSpan.FromSeconds(RetryTimeoutInSeconds), default(CancellationToken))
               .ConfigureAwait(false);
           }
         }

--- a/src/Testcontainers/Containers/ResourceReaperException.cs
+++ b/src/Testcontainers/Containers/ResourceReaperException.cs
@@ -1,18 +1,12 @@
 namespace DotNet.Testcontainers.Containers
 {
   using System;
-  using System.Runtime.Serialization;
 
   [Serializable]
   public sealed class ResourceReaperException : Exception
   {
     public ResourceReaperException(string message)
       : base(message)
-    {
-    }
-
-    private ResourceReaperException(SerializationInfo info, StreamingContext context)
-      : base(info, context)
     {
     }
   }

--- a/src/Testcontainers/Testcontainers.csproj
+++ b/src/Testcontainers/Testcontainers.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <Configurations>Debug;Release</Configurations>
     <RootNamespace>DotNet.Testcontainers</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
## What does this PR do?

Add support for the target frameworks `net6.0` and `net8.0`.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
