### PR TITLE
feat: MsSql => Turning `WithDatabase` into a public method

### DIFF
--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -104,7 +104,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// </remarks>
     /// <param name="database">The MsSql database.</param>
     /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
-    private MsSqlBuilder WithDatabase(string database)
+    public MsSqlBuilder WithDatabase(string database)
     {
         return Merge(DockerResourceConfiguration, new MsSqlConfiguration(database: database))
             .WithEnvironment("SQLCMDDBNAME", database);


### PR DESCRIPTION
## What does this PR do?

Turning `MsSqlBuilder.WithDatabase` into a public method.

## Why is it important?

This is important to set up the default database.

**Note**: This method is already public on `Testcontainers.PostgreSql` for example.

Without this method as public, I needed to implement the `IAsyncLifetime`, and use the following trick:

```
public async Task InitializeAsync()
{
     await _dbContainer.StartAsync().ConfigureAwait(false);
     await _dbContainer.ExecScriptAsync("CREATE DATABASE [MyDatabase]");
     await _dbContainer.ExecScriptAsync("ALTER LOGIN myuser WITH DEFAULT DATABASE = [MyDatabase]");
}
```

## Related issues

N/A

## How to test this PR

Just run the existing tests (specially `Testcontainers.MsSql.Tests`) and verify that nothing is broken.
