### PR TITLE
fix(MySql): Create an empty `/var/lib/mysql-files` directory to prevent older versions from failing to start

### DIFF
--- a/src/Testcontainers.MySql/MySqlBuilder.cs
+++ b/src/Testcontainers.MySql/MySqlBuilder.cs
@@ -90,7 +90,7 @@ public sealed class MySqlBuilder : ContainerBuilder<MySqlBuilder, MySqlContainer
             .WithDatabase(DefaultDatabase)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
-            .WithStartupCallback((container, ct) => Task.WhenAll(container.WriteConfigurationFileAsync(ct), container.CreateMySqlFilesDirectory(ct)));
+            .WithStartupCallback((container, ct) => Task.WhenAll(container.CreateMySqlFilesDirectoryAsync(ct), container.WriteConfigurationFileAsync(ct)));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.MySql/MySqlBuilder.cs
+++ b/src/Testcontainers.MySql/MySqlBuilder.cs
@@ -90,7 +90,7 @@ public sealed class MySqlBuilder : ContainerBuilder<MySqlBuilder, MySqlContainer
             .WithDatabase(DefaultDatabase)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
-            .WithStartupCallback((container, ct) => container.WriteConfigurationFileAsync(ct));
+            .WithStartupCallback((container, ct) => Task.WhenAll(container.WriteConfigurationFileAsync(ct), container.CreateMySqlFilesDirectory(ct)));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.MySql/MySqlContainer.cs
+++ b/src/Testcontainers.MySql/MySqlContainer.cs
@@ -49,6 +49,20 @@ public sealed class MySqlContainer : DockerContainer, IDatabaseContainer
     }
 
     /// <summary>
+    /// Creates an empty <c>/var/lib/mysql-files</c> directory.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <remarks>
+    /// This directory does not exist in the mysql 8.0.28 and earlier
+    /// Docker images and is required for the container to start properly.
+    /// </remarks>
+    /// <returns>Task that completes when the directory has been created.</returns>
+    internal Task CreateMySqlFilesDirectory(CancellationToken ct = default)
+    {
+        return ExecAsync(new[] { "mkdir", "/var/lib/mysql-files" }, ct);
+    }
+
+    /// <summary>
     /// Write an unobfuscated MySql configuration file that configures the client
     /// login path. This prevents warnings in the <see cref="ExecScriptAsync" />
     /// result about using a password on the command line.

--- a/src/Testcontainers.MySql/MySqlContainer.cs
+++ b/src/Testcontainers.MySql/MySqlContainer.cs
@@ -51,13 +51,13 @@ public sealed class MySqlContainer : DockerContainer, IDatabaseContainer
     /// <summary>
     /// Creates an empty <c>/var/lib/mysql-files</c> directory.
     /// </summary>
-    /// <param name="ct">Cancellation token.</param>
     /// <remarks>
-    /// This directory does not exist in the mysql 8.0.28 and earlier
-    /// Docker images and is required for the container to start properly.
+    /// The directory does not exist in the MySql 8.0.28 and earlier Docker images, and
+    /// it is required for the module to start properly.
     /// </remarks>
+    /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that completes when the directory has been created.</returns>
-    internal Task CreateMySqlFilesDirectory(CancellationToken ct = default)
+    internal Task CreateMySqlFilesDirectoryAsync(CancellationToken ct = default)
     {
         return ExecAsync(new[] { "mkdir", "/var/lib/mysql-files" }, ct);
     }

--- a/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
+++ b/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
@@ -59,6 +59,16 @@ public abstract class MySqlContainerTest : IAsyncLifetime
     }
 
     [UsedImplicitly]
+    public sealed class MySqlOldConfiguration : MySqlContainerTest
+    {
+        // https://github.com/testcontainers/testcontainers-dotnet/issues/1142
+        public MySqlOldConfiguration()
+            : base(new MySqlBuilder().WithImage("mysql:8.0.28").Build())
+        {
+        }
+    }
+
+    [UsedImplicitly]
     public sealed class MySqlRootConfiguration : MySqlContainerTest
     {
         public MySqlRootConfiguration()

--- a/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
+++ b/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
@@ -59,20 +59,20 @@ public abstract class MySqlContainerTest : IAsyncLifetime
     }
 
     [UsedImplicitly]
-    public sealed class MySqlOldConfiguration : MySqlContainerTest
+    public sealed class MySqlRootConfiguration : MySqlContainerTest
     {
-        // https://github.com/testcontainers/testcontainers-dotnet/issues/1142
-        public MySqlOldConfiguration()
-            : base(new MySqlBuilder().WithImage("mysql:8.0.28").Build())
+        public MySqlRootConfiguration()
+            : base(new MySqlBuilder().WithUsername("root").Build())
         {
         }
     }
 
     [UsedImplicitly]
-    public sealed class MySqlRootConfiguration : MySqlContainerTest
+    public sealed class GitHubIssue1142 : MySqlContainerTest
     {
-        public MySqlRootConfiguration()
-            : base(new MySqlBuilder().WithUsername("root").Build())
+        // https://github.com/testcontainers/testcontainers-dotnet/issues/1142.
+        public GitHubIssue1142()
+            : base(new MySqlBuilder().WithImage("mysql:8.0.28").Build())
         {
         }
     }


### PR DESCRIPTION
## What does this PR do?

This pull request creates an empty `/var/lib/mysql-files` directory for MySql containers. This directory is required for MySql containers to properly start. The `/var/lib/mysql-files` directory exists for `mysql:8.0.29` images onwards but does not exist for `mysql:8.0.28` and earlier images.

## Why is it important?

This fixes a regression introduced in Testcontainers.MySql 3.8.0

## Related issues

Fixes #1142