### PR TITLE
feat: Make the wait strategy timeout configurable

### DIFF
--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -104,6 +104,12 @@ namespace DotNet.Testcontainers.Configurations
       = EnvironmentConfiguration.Instance.GetHubImageNamePrefix() ?? PropertiesFileConfiguration.Instance.GetHubImageNamePrefix();
 
     /// <summary>
+    /// Gets or sets the maximum time for a wait strategy to execute before a <see cref="TimeoutException"/> is thrown.
+    /// Defaults to 5 minutes.
+    /// </summary>
+    public static TimeSpan WaitTimeout { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>
     /// Gets or sets the logger.
     /// </summary>
     [NotNull]

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -525,6 +525,19 @@ namespace DotNet.Testcontainers.Tests.Unit
         await Assert.ThrowsAnyAsync<Exception>(() => container.StartAsync())
           .ConfigureAwait(true);
       }
+
+      [Fact]
+      [UseWaitTimeout(seconds: 1)]
+      public async Task WaitStrategyTimeout()
+      {
+        await using var container = new ContainerBuilder()
+          .WithImage(CommonImages.Alpine)
+          .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntilFiveSecondsPassedFixture()))
+          .Build();
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() => container.StartAsync());
+        Assert.Equal("The alpine:3.17 container failed to complete readiness checks after waiting for 0.02 minutes (configurable with TestcontainersSettings.WaitTimeout).", exception.Message);
+      }
     }
   }
 }

--- a/tests/Testcontainers.Tests/Unit/UseWaitTimeoutAttribute.cs
+++ b/tests/Testcontainers.Tests/Unit/UseWaitTimeoutAttribute.cs
@@ -1,0 +1,29 @@
+namespace DotNet.Testcontainers.Tests.Unit
+{
+  using System;
+  using System.Reflection;
+  using DotNet.Testcontainers.Configurations;
+  using Xunit.Sdk;
+
+  class UseWaitTimeoutAttribute : BeforeAfterTestAttribute
+  {
+    private readonly TimeSpan _originalTimeout;
+    private readonly TimeSpan _timeout;
+
+    public UseWaitTimeoutAttribute(int seconds)
+    {
+      _originalTimeout = TestcontainersSettings.WaitTimeout;
+      _timeout = TimeSpan.FromSeconds(seconds);
+    }
+
+    public override void Before(MethodInfo methodUnderTest)
+    {
+      TestcontainersSettings.WaitTimeout = _timeout;
+    }
+
+    public override void After(MethodInfo methodUnderTest)
+    {
+      TestcontainersSettings.WaitTimeout = _originalTimeout;
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a new global (static) timeout setting for wait strategies: `TestcontainersSettings.WaitTimeout`.

## Why is it important?

Before this pull request there was no timeout (`Timeout.InfiniteTimeSpan` to be precise) so a buggy wait strategy could run forever. With this new timeout (defaulting to 5 minutes) tests will fail after this timeout instead of running forever.

## How to test this PR

A new test (`WaitStrategyTimeout`) was introduced to ensure that the new `TestcontainersSettings.WaitTimeout` property is observed and that the exception message is actionable.