### PR TITLE
chore: Remove obsolete members

### DIFF
--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -10,7 +10,6 @@ namespace DotNet.Testcontainers.Configurations
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Images;
   using JetBrains.Annotations;
-  using Microsoft.Extensions.Logging;
 
   /// <summary>
   /// This class represents the Testcontainers settings.
@@ -18,8 +17,6 @@ namespace DotNet.Testcontainers.Configurations
   [PublicAPI]
   public static class TestcontainersSettings
   {
-    private static readonly ManualResetEventSlim ManualResetEvent = new ManualResetEventSlim(true);
-
     [CanBeNull]
     private static readonly IDockerEndpointAuthenticationProvider DockerEndpointAuthProvider
       = new IDockerEndpointAuthenticationProvider[]
@@ -104,27 +101,11 @@ namespace DotNet.Testcontainers.Configurations
       = EnvironmentConfiguration.Instance.GetHubImageNamePrefix() ?? PropertiesFileConfiguration.Instance.GetHubImageNamePrefix();
 
     /// <summary>
-    /// Gets or sets the logger.
-    /// </summary>
-    [NotNull]
-    [Obsolete("Use the builder API WithLogger(ILogger) instead.")]
-    public static ILogger Logger { get; set; }
-      = ConsoleLogger.Instance;
-
-    /// <summary>
     /// Gets or sets the host operating system.
     /// </summary>
     [NotNull]
     public static IOperatingSystem OS { get; set; }
       = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? (IOperatingSystem)new Windows(DockerEndpointAuthConfig) : new Unix(DockerEndpointAuthConfig);
-
-    /// <summary>
-    /// Gets the wait handle that signals settings initialized.
-    /// </summary>
-    [NotNull]
-    [Obsolete("This property is no longer supported.")]
-    public static WaitHandle SettingsInitialized
-      => ManualResetEvent.WaitHandle;
 
     /// <inheritdoc cref="PortForwardingContainer.ExposeHostPortsAsync" />
     public static Task ExposeHostPortsAsync(ushort port, CancellationToken ct = default)

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -38,18 +38,6 @@ namespace DotNet.Testcontainers.Containers
       _configuration = configuration;
     }
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DockerContainer" /> class.
-    /// </summary>
-    /// <param name="configuration">The container configuration.</param>
-    /// <param name="logger">The logger.</param>
-    [Obsolete("Use the constructor DockerContainer(IContainerConfiguration) instead.")]
-    public DockerContainer(IContainerConfiguration configuration, ILogger logger)
-    {
-      _client = new TestcontainersClient(configuration.SessionId, configuration.DockerEndpointAuthConfig, logger);
-      _configuration = configuration;
-    }
-
     /// <inheritdoc />
     public event EventHandler Creating;
 

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -100,20 +100,6 @@ namespace DotNet.Testcontainers.Containers
     /// Starts and returns the default <see cref="ResourceReaper" /> instance.
     /// </summary>
     /// <param name="dockerEndpointAuthConfig">The Docker endpoint authentication configuration.</param>
-    /// <param name="isWindowsEngineEnabled">Determines whether the Windows engine is enabled or not.</param>
-    /// <param name="ct">The cancellation token to cancel the <see cref="ResourceReaper" /> initialization.</param>
-    /// <returns>Task that completes when the <see cref="ResourceReaper" /> has been started.</returns>
-    [PublicAPI]
-    [Obsolete("Use GetAndStartDefaultAsync(IDockerEndpointAuthenticationConfiguration, ILogger, bool, CancellationToken) instead.")]
-    public static Task<ResourceReaper> GetAndStartDefaultAsync(IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig, bool isWindowsEngineEnabled = false, CancellationToken ct = default)
-    {
-      return GetAndStartDefaultAsync(dockerEndpointAuthConfig, ConsoleLogger.Instance, isWindowsEngineEnabled, ct);
-    }
-
-    /// <summary>
-    /// Starts and returns the default <see cref="ResourceReaper" /> instance.
-    /// </summary>
-    /// <param name="dockerEndpointAuthConfig">The Docker endpoint authentication configuration.</param>
     /// <param name="logger">The logger.</param>
     /// <param name="isWindowsEngineEnabled">Determines whether the Windows engine is enabled or not.</param>
     /// <param name="ct">The cancellation token to cancel the <see cref="ResourceReaper" /> initialization.</param>

--- a/tests/Testcontainers.ResourceReaper.Tests/DefaultResourceReaperTest.cs
+++ b/tests/Testcontainers.ResourceReaper.Tests/DefaultResourceReaperTest.cs
@@ -11,7 +11,7 @@ namespace DotNet.Testcontainers.ResourceReaper.Tests
   {
     public async Task InitializeAsync()
     {
-      var resourceReaper = await ResourceReaper.GetAndStartDefaultAsync(TestcontainersSettings.OS.DockerEndpointAuthConfig)
+      var resourceReaper = await ResourceReaper.GetAndStartDefaultAsync(TestcontainersSettings.OS.DockerEndpointAuthConfig, ConsoleLogger.Instance)
         .ConfigureAwait(false);
 
       await resourceReaper.DisposeAsync()


### PR DESCRIPTION
## What does this PR do?

The PR removes a couple of obsolete members.

## Why is it important?

The members have been flagged as obsolete in the previous version(s) and are no longer recommended for use. Users were instructed to utilize the new or updated APIs. To maintain a clean implementation, it is necessary to remove the deprecated code.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
