### PR TITLE
docs: Add reading file from a container

### DIFF
--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -55,6 +55,18 @@ _ = new ContainerBuilder()
   .WithResourceMapping(Encoding.Default.GetBytes("{}"), "/app/appsettings.json");
 ```
 
+## Reading files from the container
+
+The `IContainer` interface offers a `ReadFileAsync(string, CancellationToken)` method to read files from the container. The implementation returns the read bytes. Either process the read bytes in-memory or persist them to the disk.
+
+```csharp title="Reading a file"
+var readBytes = await container.ReadFileAsync("/app/appsettings.json")
+  .ConfigureAwait(false);
+
+await File.WriteAllBytesAsync("appsettings.json", readBytes)
+  .ConfigureAwait(false);
+```
+
 ## Examples
 
 An NGINX container that binds the HTTP port to a random host port and hosts static content. The example connects to the web server and checks the HTTP status code.


### PR DESCRIPTION
## What does this PR do?

Add documentation about reading files from a container.

## Why is it important?

The API is not documented, and it is not obvious to developers how they can read files from a container.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
