### PR TITLE
chore: Use new sshd:1.2.0 image

### DIFF
--- a/src/Testcontainers/Containers/PortForwarding.cs
+++ b/src/Testcontainers/Containers/PortForwarding.cs
@@ -61,18 +61,9 @@ namespace DotNet.Testcontainers.Containers
     [PublicAPI]
     private sealed class PortForwardingBuilder : ContainerBuilder<PortForwardingBuilder, PortForwardingContainer, PortForwardingConfiguration>
     {
-      public const string SshdImage = "testcontainers/sshd:1.1.0";
+      public const string SshdImage = "testcontainers/sshd:1.2.0";
 
       public const ushort SshdPort = 22;
-
-      private const string Command = "echo \"$USERNAME:$PASSWORD\" | chpasswd && /usr/sbin/sshd -D"
-                                     + " -o AddressFamily=inet"
-                                     + " -o AllowAgentForwarding=yes"
-                                     + " -o AllowTcpForwarding=yes"
-                                     + " -o GatewayPorts=yes"
-                                     + " -o HostkeyAlgorithms=+ssh-rsa"
-                                     + " -o KexAlgorithms=+diffie-hellman-group1-sha1"
-                                     + " -o PermitRootLogin=yes";
 
       /// <summary>
       /// Initializes a new instance of the <see cref="PortForwardingConfiguration" /> class.
@@ -114,8 +105,6 @@ namespace DotNet.Testcontainers.Containers
         return base.Init()
           .WithImage(SshdImage)
           .WithPortBinding(SshdPort, true)
-          .WithEntrypoint("/bin/sh", "-c")
-          .WithCommand(Command)
           .WithUsername("root")
           .WithPassword("root")
           .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(SshdPort));


### PR DESCRIPTION
## What does this PR do?

It uses the newest testcontainers/sshd:1.2.0 docker image, which includes the CMD in the image instead of in the code.

Please see https://github.com/testcontainers/sshd-docker/pull/7 for more details.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Avoid code duplication across testcontainers projects.

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

## Related issues

- Caused by https://github.com/testcontainers/sshd-docker/pull/7
- Relates (java) https://github.com/testcontainers/testcontainers-java/pull/8574
- Relates (node) https://github.com/testcontainers/testcontainers-node/pull/758
- Relates (go) https://github.com/testcontainers/testcontainers-go/pull/2471/commits/8f8a7c2a05854614ea20f040fe98aa26d9698d4f

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->


<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
