### PR TITLE
feat: Include the container name in the reuse hash

### DIFF
--- a/docs/api/resource_reuse.md
+++ b/docs/api/resource_reuse.md
@@ -17,6 +17,9 @@ _ = new ContainerBuilder()
 
 The current implementation considers the following resource configurations and their corresponding builder APIs when calculating the hash value.
 
+> [!NOTE]  
+> Version 3.8.0 did not include the container configuration's name in the hash value.
+
 - [ContainerConfiguration](https://github.com/testcontainers/testcontainers-dotnet/blob/develop/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs)
     - Image
     - Entrypoint
@@ -26,6 +29,7 @@ The current implementation considers the following resource configurations and t
     - PortBindings
     - NetworkAliases
     - ExtraHosts
+    - Name
     - Labels
 - [NetworkConfiguration](https://github.com/testcontainers/testcontainers-dotnet/blob/develop/src/Testcontainers/Configurations/Networks/NetworkConfiguration.cs)
     - Name

--- a/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
@@ -155,7 +155,6 @@ namespace DotNet.Testcontainers.Configurations
     public Func<ImageInspectResponse, bool> ImagePullPolicy { get; }
 
     /// <inheritdoc />
-    [JsonIgnore]
     public string Name { get; }
 
     /// <inheritdoc />


### PR DESCRIPTION
## What does this PR do?

This pull request removes the `[JsonIgnore]` attribute from the `ContainerConfiguration.Name` property so that the container name becomes part of the reuse hash.

## Why is it important?

The rationale behind this change is explained in #1161.

> [!IMPORTANT]  
> Changing the parts used in the reuse hash will break existing reused containers but the best time to do it is now, while the reuse feature is still at the experimental stage.

## Related issues

Closes #1161

## How to test this PR

A new unit test (`ContainersWithDifferentNamesShouldHaveDifferentHashes`) has been added.