### PR TITLE
feat: Add wait strategy options

### DIFF
--- a/docs/api/wait_strategies.md
+++ b/docs/api/wait_strategies.md
@@ -11,6 +11,15 @@ _ = Wait.ForUnixContainer()
   .AddCustomWaitStrategy(new MyCustomWaitStrategy());
 ```
 
+<!-- In some cases, it might be necessary to configure the behavior of a wait strategy further, being able to cancel the readiness check. The API provides a callback that allows setting additional configurations such as `Retries`, `Interval`, and `Timeout`.
+
+```csharp title="Cancel the readiness check after one minute"
+_ = Wait.ForUnixContainer()
+  .UntilMessageIsLogged("Server started", o => o.WithTimeout(TimeSpan.FromMinutes(1)));
+```
+
+Besides configuring the wait strategy, cancelling a container start can always be done utilizing a [CancellationToken](create_docker_container.md#canceling-a-container-start). -->
+
 ## Wait until an HTTP(S) endpoint is available
 
 You can choose to wait for an HTTP(S) endpoint to return a particular HTTP response status code or to match a predicate. The default configuration tries to access the HTTP endpoint running inside the container. Chose `ForPort(ushort)` or `ForPath(string)` to adjust the endpoint or `UsingTls()` to switch to HTTPS. When using `UsingTls()` port 443 is used as a default. If your container exposes a different HTTPS port, make sure that the correct waiting port is configured accordingly.

--- a/src/Testcontainers.Couchbase/CouchbaseBuilder.cs
+++ b/src/Testcontainers.Couchbase/CouchbaseBuilder.cs
@@ -183,7 +183,7 @@ public sealed class CouchbaseBuilder : ContainerBuilder<CouchbaseBuilder, Couchb
     /// <param name="ct">Cancellation token.</param>
     private async Task ConfigureCouchbaseAsync(IContainer container, CancellationToken ct = default)
     {
-        await WaitStrategy.WaitUntilAsync(() => WaitUntilNodeIsReady.UntilAsync(container), TimeSpan.FromSeconds(2), TimeSpan.FromMinutes(5), ct)
+        await WaitStrategy.WaitUntilAsync(() => WaitUntilNodeIsReady.UntilAsync(container), TimeSpan.FromSeconds(2), TimeSpan.FromMinutes(5), -1, ct)
             .ConfigureAwait(false);
 
         using (var httpClient = new HttpClient(new RetryHandler()))
@@ -269,7 +269,7 @@ public sealed class CouchbaseBuilder : ContainerBuilder<CouchbaseBuilder, Couchb
             .Build()
             .Last();
 
-        await WaitStrategy.WaitUntilAsync(() => waitUntilBucketIsCreated.UntilAsync(container), TimeSpan.FromSeconds(2), TimeSpan.FromMinutes(5), ct)
+        await WaitStrategy.WaitUntilAsync(() => waitUntilBucketIsCreated.UntilAsync(container), TimeSpan.FromSeconds(2), TimeSpan.FromMinutes(5), -1, ct)
             .ConfigureAwait(false);
     }
 

--- a/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
@@ -60,7 +60,7 @@ namespace DotNet.Testcontainers.Configurations
       IEnumerable<string> networkAliases = null,
       IEnumerable<string> extraHosts = null,
       IOutputConsumer outputConsumer = null,
-      IEnumerable<IWaitUntil> waitStrategies = null,
+      IEnumerable<WaitStrategy> waitStrategies = null,
       Func<IContainer, CancellationToken, Task> startupCallback = null,
       bool? autoRemove = null,
       bool? privileged = null)
@@ -133,7 +133,7 @@ namespace DotNet.Testcontainers.Configurations
       NetworkAliases = BuildConfiguration.Combine(oldValue.NetworkAliases, newValue.NetworkAliases);
       ExtraHosts = BuildConfiguration.Combine(oldValue.ExtraHosts, newValue.ExtraHosts);
       OutputConsumer = BuildConfiguration.Combine(oldValue.OutputConsumer, newValue.OutputConsumer);
-      WaitStrategies = BuildConfiguration.Combine<IEnumerable<IWaitUntil>>(oldValue.WaitStrategies, newValue.WaitStrategies);
+      WaitStrategies = BuildConfiguration.Combine<IEnumerable<WaitStrategy>>(oldValue.WaitStrategies, newValue.WaitStrategies);
       StartupCallback = BuildConfiguration.Combine(oldValue.StartupCallback, newValue.StartupCallback);
       AutoRemove = (oldValue.AutoRemove.HasValue && oldValue.AutoRemove.Value) || (newValue.AutoRemove.HasValue && newValue.AutoRemove.Value);
       Privileged = (oldValue.Privileged.HasValue && oldValue.Privileged.Value) || (newValue.Privileged.HasValue && newValue.Privileged.Value);
@@ -212,7 +212,7 @@ namespace DotNet.Testcontainers.Configurations
 
     /// <inheritdoc />
     [JsonIgnore]
-    public IEnumerable<IWaitUntil> WaitStrategies { get; }
+    public IEnumerable<WaitStrategy> WaitStrategies { get; }
 
     /// <inheritdoc />
     [JsonIgnore]

--- a/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
@@ -119,7 +119,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Gets the wait strategies.
     /// </summary>
-    IEnumerable<IWaitUntil> WaitStrategies { get; }
+    IEnumerable<WaitStrategy> WaitStrategies { get; }
 
     /// <summary>
     /// Gets the startup callback.

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
@@ -63,7 +63,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     [PublicAPI]
-    IWaitForContainerOS UntilPortIsAvailable(ushort port, Action<IWaitStrategy> waitStrategyModifier = null);
+    IWaitForContainerOS UntilPortIsAvailable(int port, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <summary>
     /// Waits until the file exists.

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
@@ -14,20 +14,12 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Adds a custom wait strategy to the wait strategies collection.
     /// </summary>
-    /// <param name="waitStrategy">The wait strategy until the container is ready.</param>
+    /// <param name="waitUntil">The wait strategy until the container is ready.</param>
+    /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     /// <remarks>Already contains <see cref="UntilContainerIsRunning" /> as default wait strategy.</remarks>
     [PublicAPI]
-    IWaitForContainerOS AddCustomWaitStrategy(IWaitUntil waitStrategy);
-
-    /// <summary>
-    /// Waits until the command is completed successfully.
-    /// </summary>
-    /// <param name="command">The command to be executed.</param>
-    /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
-    /// <remarks>Invokes the operating system command shell. Expects the exit code to be 0.</remarks>
-    [PublicAPI]
-    IWaitForContainerOS UntilCommandIsCompleted(string command);
+    IWaitForContainerOS AddCustomWaitStrategy(IWaitUntil waitUntil, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <summary>
     /// Waits until the command is completed successfully.
@@ -42,70 +34,101 @@ namespace DotNet.Testcontainers.Configurations
     IWaitForContainerOS UntilCommandIsCompleted(params string[] command);
 
     /// <summary>
+    /// Waits until the command is completed successfully.
+    /// </summary>
+    /// <param name="command">The command to be executed.</param>
+    /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
+    /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
+    /// <remarks>Invokes the operating system command shell. Expects the exit code to be 0.</remarks>
+    [PublicAPI]
+    IWaitForContainerOS UntilCommandIsCompleted(string command, Action<IWaitStrategy> waitStrategyModifier = null);
+
+    /// <summary>
+    /// Waits until the command is completed successfully.
+    /// </summary>
+    /// <param name="command">The command to be executed.</param>
+    /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
+    /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
+    /// <remarks>
+    /// Does not invoke the operating system command shell.
+    /// Normal shell processing does not happen. Expects the exit code to be 0.
+    /// </remarks>
+    [PublicAPI]
+    IWaitForContainerOS UntilCommandIsCompleted(IEnumerable<string> command, Action<IWaitStrategy> waitStrategyModifier = null);
+
+    /// <summary>
     /// Waits until the port is available.
     /// </summary>
     /// <param name="port">The port to be checked.</param>
+    /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     [PublicAPI]
-    IWaitForContainerOS UntilPortIsAvailable(int port);
+    IWaitForContainerOS UntilPortIsAvailable(ushort port, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <summary>
     /// Waits until the file exists.
     /// </summary>
     /// <param name="filePath">The file path to be checked.</param>
     /// <param name="fileSystem">The file system to be checked.</param>
+    /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     [PublicAPI]
-    IWaitForContainerOS UntilFileExists(string filePath, FileSystem fileSystem = FileSystem.Host);
+    IWaitForContainerOS UntilFileExists(string filePath, FileSystem fileSystem = FileSystem.Host, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <summary>
     /// Waits until the message is logged.
     /// </summary>
     /// <param name="pattern">The regular expression that matches the log message.</param>
+    /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     [PublicAPI]
-    IWaitForContainerOS UntilMessageIsLogged(string pattern);
+    IWaitForContainerOS UntilMessageIsLogged(string pattern, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <summary>
     /// Waits until the message is logged.
     /// </summary>
     /// <param name="pattern">The regular expression that matches the log message.</param>
+    /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     [PublicAPI]
-    IWaitForContainerOS UntilMessageIsLogged(Regex pattern);
+    IWaitForContainerOS UntilMessageIsLogged(Regex pattern, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <summary>
     /// Waits until the operation is completed successfully.
     /// </summary>
     /// <param name="operation">The operation to be executed.</param>
     /// <param name="maxCallCount">The number of attempts before an exception is thrown.</param>
+    /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     /// <exception cref="TimeoutException">Thrown when number of failed operations exceeded <paramref name="maxCallCount" />.</exception>
     [PublicAPI]
-    IWaitForContainerOS UntilOperationIsSucceeded(Func<bool> operation, int maxCallCount);
+    [Obsolete("Use one of the other wait strategies in combination with the `Action<IWaitStrategy>` argument, and set the number of retries.")]
+    IWaitForContainerOS UntilOperationIsSucceeded(Func<bool> operation, int maxCallCount, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <summary>
     /// Waits until the http request is completed successfully.
     /// </summary>
     /// <param name="request">The http request to be executed.</param>
+    /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     [PublicAPI]
-    IWaitForContainerOS UntilHttpRequestIsSucceeded(Func<HttpWaitStrategy, HttpWaitStrategy> request);
+    IWaitForContainerOS UntilHttpRequestIsSucceeded(Func<HttpWaitStrategy, HttpWaitStrategy> request, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <summary>
     /// Waits until the container is healthy.
     /// </summary>
     /// <param name="failingStreak">The number of attempts before an exception is thrown.</param>
+    /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
     /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
     /// <exception cref="TimeoutException">Thrown when number of failed operations exceeded <paramref name="failingStreak" />.</exception>
     [PublicAPI]
-    IWaitForContainerOS UntilContainerIsHealthy(long failingStreak = 3);
+    IWaitForContainerOS UntilContainerIsHealthy(long failingStreak = 3, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <summary>
     /// Returns a collection with all configured wait strategies.
     /// </summary>
     /// <returns>Returns a list with all configured wait strategies.</returns>
     [PublicAPI]
-    IEnumerable<IWaitUntil> Build();
+    IEnumerable<WaitStrategy> Build();
   }
 }

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitStrategy.cs
@@ -1,0 +1,33 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Represents a wait strategy configuration.
+  /// </summary>
+  [PublicAPI]
+  public interface IWaitStrategy
+  {
+    /// <summary>
+    /// Sets the number of retries for the wait strategy.
+    /// </summary>
+    /// <param name="retries">The number of retries.</param>
+    /// <returns>The updated instance of the wait strategy.</returns>
+    IWaitStrategy WithRetries(ushort retries);
+
+    /// <summary>
+    /// Sets the interval between retries for the wait strategy.
+    /// </summary>
+    /// <param name="interval">The interval between retries.</param>
+    /// <returns>The updated instance of the wait strategy.</returns>
+    IWaitStrategy WithInterval(TimeSpan interval);
+
+    /// <summary>
+    /// Sets the timeout for the wait strategy.
+    /// </summary>
+    /// <param name="timeout">The timeout duration.</param>
+    /// <returns>The updated instance of the wait strategy.</returns>
+    IWaitStrategy WithTimeout(TimeSpan timeout);
+  }
+}

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
@@ -7,77 +7,87 @@ namespace DotNet.Testcontainers.Configurations
   /// <inheritdoc cref="IWaitForContainerOS" />
   internal abstract class WaitForContainerOS : IWaitForContainerOS
   {
-    private readonly ICollection<IWaitUntil> _waitStrategies = new List<IWaitUntil>();
+    private readonly ICollection<WaitStrategy> _waitStrategies = new List<WaitStrategy>();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WaitForContainerOS" /> class.
     /// </summary>
     protected WaitForContainerOS()
     {
-      _waitStrategies.Add(new UntilContainerIsRunning());
+      _waitStrategies.Add(new WaitStrategy(new UntilContainerIsRunning()));
     }
-
-    /// <inheritdoc />
-    public abstract IWaitForContainerOS UntilCommandIsCompleted(string command);
 
     /// <inheritdoc />
     public abstract IWaitForContainerOS UntilCommandIsCompleted(params string[] command);
 
     /// <inheritdoc />
-    public abstract IWaitForContainerOS UntilPortIsAvailable(int port);
+    public abstract IWaitForContainerOS UntilCommandIsCompleted(string command, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS AddCustomWaitStrategy(IWaitUntil waitStrategy)
+    public abstract IWaitForContainerOS UntilCommandIsCompleted(IEnumerable<string> command, Action<IWaitStrategy> waitStrategyModifier = null);
+
+    /// <inheritdoc />
+    public abstract IWaitForContainerOS UntilPortIsAvailable(ushort port, Action<IWaitStrategy> waitStrategyModifier = null);
+
+    /// <inheritdoc />
+    public virtual IWaitForContainerOS AddCustomWaitStrategy(IWaitUntil waitUntil, Action<IWaitStrategy> waitStrategyModifier = null)
     {
+      var waitStrategy = new WaitStrategy(waitUntil);
+
+      if (waitStrategyModifier != null)
+      {
+        waitStrategyModifier(waitStrategy);
+      }
+
       _waitStrategies.Add(waitStrategy);
       return this;
     }
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS UntilFileExists(string filePath, FileSystem fileSystem = FileSystem.Host)
+    public virtual IWaitForContainerOS UntilFileExists(string filePath, FileSystem fileSystem = FileSystem.Host, Action<IWaitStrategy> waitStrategyModifier = null)
     {
       switch (fileSystem)
       {
         case FileSystem.Container:
-          return AddCustomWaitStrategy(new UntilFileExistsInContainer(filePath));
+          return AddCustomWaitStrategy(new UntilFileExistsInContainer(filePath), waitStrategyModifier);
         case FileSystem.Host:
         default:
-          return AddCustomWaitStrategy(new UntilFileExistsOnHost(filePath));
+          return AddCustomWaitStrategy(new UntilFileExistsOnHost(filePath), waitStrategyModifier);
       }
     }
 
     /// <inheritdoc />
-    public IWaitForContainerOS UntilMessageIsLogged(string pattern)
+    public IWaitForContainerOS UntilMessageIsLogged(string pattern, Action<IWaitStrategy> waitStrategyModifier = null)
     {
-      return AddCustomWaitStrategy(new UntilMessageIsLogged(pattern));
+      return AddCustomWaitStrategy(new UntilMessageIsLogged(pattern), waitStrategyModifier);
     }
 
     /// <inheritdoc />
-    public IWaitForContainerOS UntilMessageIsLogged(Regex pattern)
+    public IWaitForContainerOS UntilMessageIsLogged(Regex pattern, Action<IWaitStrategy> waitStrategyModifier = null)
     {
-      return AddCustomWaitStrategy(new UntilMessageIsLogged(pattern));
+      return AddCustomWaitStrategy(new UntilMessageIsLogged(pattern), waitStrategyModifier);
     }
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS UntilOperationIsSucceeded(Func<bool> operation, int maxCallCount)
+    public virtual IWaitForContainerOS UntilOperationIsSucceeded(Func<bool> operation, int maxCallCount, Action<IWaitStrategy> waitStrategyModifier = null)
     {
-      return AddCustomWaitStrategy(new UntilOperationIsSucceeded(operation, maxCallCount));
+      return AddCustomWaitStrategy(new UntilOperationIsSucceeded(operation, maxCallCount), waitStrategyModifier);
     }
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS UntilHttpRequestIsSucceeded(Func<HttpWaitStrategy, HttpWaitStrategy> request)
+    public virtual IWaitForContainerOS UntilHttpRequestIsSucceeded(Func<HttpWaitStrategy, HttpWaitStrategy> request, Action<IWaitStrategy> waitStrategyModifier = null)
     {
-      return AddCustomWaitStrategy(request.Invoke(new HttpWaitStrategy()));
+      return AddCustomWaitStrategy(request.Invoke(new HttpWaitStrategy()), waitStrategyModifier);
     }
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS UntilContainerIsHealthy(long failingStreak = 3)
+    public virtual IWaitForContainerOS UntilContainerIsHealthy(long failingStreak = 3, Action<IWaitStrategy> waitStrategyModifier = null)
     {
-      return AddCustomWaitStrategy(new UntilContainerIsHealthy(failingStreak));
+      return AddCustomWaitStrategy(new UntilContainerIsHealthy(failingStreak), waitStrategyModifier);
     }
 
     /// <inheritdoc />
-    public IEnumerable<IWaitUntil> Build()
+    public IEnumerable<WaitStrategy> Build()
     {
       return _waitStrategies;
     }

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
@@ -27,7 +27,7 @@ namespace DotNet.Testcontainers.Configurations
     public abstract IWaitForContainerOS UntilCommandIsCompleted(IEnumerable<string> command, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <inheritdoc />
-    public abstract IWaitForContainerOS UntilPortIsAvailable(ushort port, Action<IWaitStrategy> waitStrategyModifier = null);
+    public abstract IWaitForContainerOS UntilPortIsAvailable(int port, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <inheritdoc />
     public virtual IWaitForContainerOS AddCustomWaitStrategy(IWaitUntil waitUntil, Action<IWaitStrategy> waitStrategyModifier = null)

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerUnix.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerUnix.cs
@@ -1,14 +1,12 @@
 namespace DotNet.Testcontainers.Configurations
 {
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+
   /// <inheritdoc cref="IWaitForContainerOS" />
   internal sealed class WaitForContainerUnix : WaitForContainerOS
   {
-    /// <inheritdoc />
-    public override IWaitForContainerOS UntilCommandIsCompleted(string command)
-    {
-      return AddCustomWaitStrategy(new UntilUnixCommandIsCompleted(command));
-    }
-
     /// <inheritdoc />
     public override IWaitForContainerOS UntilCommandIsCompleted(params string[] command)
     {
@@ -16,9 +14,21 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public override IWaitForContainerOS UntilPortIsAvailable(int port)
+    public override IWaitForContainerOS UntilCommandIsCompleted(string command, Action<IWaitStrategy> waitStrategyModifier = null)
     {
-      return AddCustomWaitStrategy(new UntilUnixPortIsAvailable(port));
+      return AddCustomWaitStrategy(new UntilUnixCommandIsCompleted(command), waitStrategyModifier);
+    }
+
+    /// <inheritdoc />
+    public override IWaitForContainerOS UntilCommandIsCompleted(IEnumerable<string> command, Action<IWaitStrategy> waitStrategyModifier = null)
+    {
+      return AddCustomWaitStrategy(new UntilUnixCommandIsCompleted(command.ToArray()), waitStrategyModifier);
+    }
+
+    /// <inheritdoc />
+    public override IWaitForContainerOS UntilPortIsAvailable(ushort port, Action<IWaitStrategy> waitStrategyModifier = null)
+    {
+      return AddCustomWaitStrategy(new UntilUnixPortIsAvailable(port), waitStrategyModifier);
     }
   }
 }

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerUnix.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerUnix.cs
@@ -26,7 +26,7 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public override IWaitForContainerOS UntilPortIsAvailable(ushort port, Action<IWaitStrategy> waitStrategyModifier = null)
+    public override IWaitForContainerOS UntilPortIsAvailable(int port, Action<IWaitStrategy> waitStrategyModifier = null)
     {
       return AddCustomWaitStrategy(new UntilUnixPortIsAvailable(port), waitStrategyModifier);
     }

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerWindows.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerWindows.cs
@@ -1,14 +1,12 @@
 namespace DotNet.Testcontainers.Configurations
 {
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+
   /// <inheritdoc cref="IWaitForContainerOS" />
   internal sealed class WaitForContainerWindows : WaitForContainerOS
   {
-    /// <inheritdoc />
-    public override IWaitForContainerOS UntilCommandIsCompleted(string command)
-    {
-      return AddCustomWaitStrategy(new UntilWindowsCommandIsCompleted(command));
-    }
-
     /// <inheritdoc />
     public override IWaitForContainerOS UntilCommandIsCompleted(params string[] command)
     {
@@ -16,9 +14,21 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public override IWaitForContainerOS UntilPortIsAvailable(int port)
+    public override IWaitForContainerOS UntilCommandIsCompleted(string command, Action<IWaitStrategy> waitStrategyModifier = null)
     {
-      return AddCustomWaitStrategy(new UntilWindowsPortIsAvailable(port));
+      return AddCustomWaitStrategy(new UntilWindowsCommandIsCompleted(command), waitStrategyModifier);
+    }
+
+    /// <inheritdoc />
+    public override IWaitForContainerOS UntilCommandIsCompleted(IEnumerable<string> command, Action<IWaitStrategy> waitStrategyModifier = null)
+    {
+      return AddCustomWaitStrategy(new UntilWindowsCommandIsCompleted(command.ToArray()), waitStrategyModifier);
+    }
+
+    /// <inheritdoc />
+    public override IWaitForContainerOS UntilPortIsAvailable(ushort port, Action<IWaitStrategy> waitStrategyModifier = null)
+    {
+      return AddCustomWaitStrategy(new UntilWindowsPortIsAvailable(port), waitStrategyModifier);
     }
   }
 }

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerWindows.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerWindows.cs
@@ -26,7 +26,7 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public override IWaitForContainerOS UntilPortIsAvailable(ushort port, Action<IWaitStrategy> waitStrategyModifier = null)
+    public override IWaitForContainerOS UntilPortIsAvailable(int port, Action<IWaitStrategy> waitStrategyModifier = null)
     {
       return AddCustomWaitStrategy(new UntilWindowsPortIsAvailable(port), waitStrategyModifier);
     }

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
@@ -3,22 +3,124 @@ namespace DotNet.Testcontainers.Configurations
   using System;
   using System.Threading;
   using System.Threading.Tasks;
+  using DotNet.Testcontainers.Containers;
   using JetBrains.Annotations;
 
-  public static class WaitStrategy
+  /// <inheritdoc cref="IWaitStrategy" />
+  [PublicAPI]
+  public class WaitStrategy : IWaitStrategy
   {
+    private const string MaximumRetryExceededException = "The maximum number of retries has been exceeded.";
+
+    private IWaitWhile _waitWhile;
+
+    private IWaitUntil _waitUntil;
+
     /// <summary>
-    /// Blocks while condition is true or timeout occurs.
+    /// Initializes a new instance of the <see cref="WaitStrategy" /> class.
     /// </summary>
-    /// <param name="wait">Function to block execution.</param>
-    /// <param name="frequency">The frequency in milliseconds to check the condition.</param>
-    /// <param name="timeout">Timeout in milliseconds.</param>
-    /// <param name="ct">Propagates notification that operations should be canceled.</param>
-    /// <exception cref="TimeoutException">Thrown as soon as the timeout expires.</exception>
+    public WaitStrategy()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WaitStrategy" /> class.
+    /// </summary>
+    /// <param name="waitWhile">The wait while condition to be used in the strategy.</param>
+    public WaitStrategy(IWaitWhile waitWhile)
+    {
+      _ = WithStrategy(waitWhile);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WaitStrategy" /> class.
+    /// </summary>
+    /// <param name="waitUntil">The wait until condition to be used in the strategy.</param>
+    public WaitStrategy(IWaitUntil waitUntil)
+    {
+      _ = WithStrategy(waitUntil);
+    }
+
+    /// <summary>
+    /// Gets the number of retries.
+    /// </summary>
+    public int Retries { get; private set; }
+      = -1;
+
+    /// <summary>
+    /// Gets the interval between retries.
+    /// </summary>
+    public TimeSpan Interval { get; private set; }
+      = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Gets the timeout.
+    /// </summary>
+    public TimeSpan Timeout { get; private set; }
+      = TimeSpan.FromHours(1);
+
+    /// <inheritdoc />
+    public IWaitStrategy WithRetries(ushort retries)
+    {
+      Retries = retries;
+      return this;
+    }
+
+    /// <inheritdoc />
+    public IWaitStrategy WithInterval(TimeSpan interval)
+    {
+      Interval = interval;
+      return this;
+    }
+
+    /// <inheritdoc />
+    public IWaitStrategy WithTimeout(TimeSpan timeout)
+    {
+      Timeout = timeout;
+      return this;
+    }
+
+    /// <summary>
+    /// Executes the wait strategy while the container satisfies the condition.
+    /// </summary>
+    /// <param name="container">The container to check the condition for.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation, returning false if the container satisfies the condition; otherwise, true.</returns>
+    public virtual Task<bool> WhileAsync(IContainer container, CancellationToken ct = default)
+    {
+      return _waitWhile.WhileAsync(container);
+    }
+
+    /// <summary>
+    /// Executes the wait strategy until the container satisfies the condition.
+    /// </summary>
+    /// <param name="container">The container to check the condition for.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task representing the asynchronous operation, returning true if the container satisfies the condition; otherwise, false.</returns>
+    public virtual Task<bool> UntilAsync(IContainer container, CancellationToken ct = default)
+    {
+      return _waitUntil.UntilAsync(container);
+    }
+
+    /// <summary>
+    /// Waits asynchronously until the specified condition returns false or until a timeout occurs.
+    /// </summary>
+    /// <remarks>
+    /// Zero or a negative value for <paramref name="retries" /> will run the readiness check infinitely until it becomes false.
+    /// </remarks>
+    /// <param name="wait">A function that represents the asynchronous condition to wait for.</param>
+    /// <param name="interval">The time interval between consecutive evaluations of the condition.</param>
+    /// <param name="timeout">The maximum duration to wait for the condition to become false.</param>
+    /// <param name="retries">The number of retries to run for the condition to become false.</param>
+    /// <param name="ct">The optional cancellation token to cancel the waiting operation.</param>
+    /// <exception cref="TimeoutException">Thrown when the timeout expires.</exception>
+    /// <exception cref="ArgumentException">Thrown when the number of retries is exceeded.</exception>
     /// <returns>A task that represents the asynchronous block operation.</returns>
     [PublicAPI]
-    public static async Task WaitWhileAsync(Func<Task<bool>> wait, TimeSpan frequency, TimeSpan timeout, CancellationToken ct = default)
+    public static async Task WaitWhileAsync(Func<Task<bool>> wait, TimeSpan interval, TimeSpan timeout, int retries = -1, CancellationToken ct = default)
     {
+      ushort actualRetries = 0;
+
       async Task WhileAsync()
       {
         while (!ct.IsCancellationRequested)
@@ -31,7 +133,10 @@ namespace DotNet.Testcontainers.Configurations
             break;
           }
 
-          await Task.Delay(frequency, ct)
+          _ = Guard.Argument(retries, nameof(retries))
+            .ThrowIf(_ => retries > 0 && ++actualRetries > retries, _ => throw new ArgumentException(MaximumRetryExceededException));
+
+          await Task.Delay(interval, ct)
             .ConfigureAwait(false);
         }
       }
@@ -54,17 +159,24 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <summary>
-    /// Blocks until condition is true or timeout occurs.
+    /// Waits asynchronously until the specified condition returns true or until a timeout occurs.
     /// </summary>
-    /// <param name="wait">Function to block execution.</param>
-    /// <param name="frequency">The frequency in milliseconds to check the condition.</param>
-    /// <param name="timeout">The timeout in milliseconds.</param>
-    /// <param name="ct">Propagates notification that operations should be canceled.</param>
-    /// <exception cref="TimeoutException">Thrown as soon as the timeout expires.</exception>
+    /// <remarks>
+    /// Zero or a negative value for <paramref name="retries" /> will run the readiness check infinitely until it becomes true.
+    /// </remarks>
+    /// <param name="wait">A function that represents the asynchronous condition to wait for.</param>
+    /// <param name="interval">The time interval between consecutive evaluations of the condition.</param>
+    /// <param name="timeout">The maximum duration to wait for the condition to become true.</param>
+    /// <param name="retries">The number of retries to run for the condition to become true.</param>
+    /// <param name="ct">The optional cancellation token to cancel the waiting operation.</param>
+    /// <exception cref="TimeoutException">Thrown when the timeout expires.</exception>
+    /// <exception cref="ArgumentException">Thrown when the number of retries is exceeded.</exception>
     /// <returns>A task that represents the asynchronous block operation.</returns>
     [PublicAPI]
-    public static async Task WaitUntilAsync(Func<Task<bool>> wait, TimeSpan frequency, TimeSpan timeout, CancellationToken ct = default)
+    public static async Task WaitUntilAsync(Func<Task<bool>> wait, TimeSpan interval, TimeSpan timeout, int retries = -1, CancellationToken ct = default)
     {
+      ushort actualRetries = 0;
+
       async Task UntilAsync()
       {
         while (!ct.IsCancellationRequested)
@@ -77,7 +189,10 @@ namespace DotNet.Testcontainers.Configurations
             break;
           }
 
-          await Task.Delay(frequency, ct)
+          _ = Guard.Argument(retries, nameof(retries))
+            .ThrowIf(_ => retries > 0 && ++actualRetries > retries, _ => throw new ArgumentException(MaximumRetryExceededException));
+
+          await Task.Delay(interval, ct)
             .ConfigureAwait(false);
         }
       }
@@ -97,6 +212,28 @@ namespace DotNet.Testcontainers.Configurations
       // Rethrows exceptions.
       await waitTask
         .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sets the wait while condition.
+    /// </summary>
+    /// <param name="waitWhile">The wait while condition to be used in the strategy.</param>
+    /// <returns>The updated instance of the wait strategy.</returns>
+    private WaitStrategy WithStrategy(IWaitWhile waitWhile)
+    {
+      _waitWhile = waitWhile;
+      return this;
+    }
+
+    /// <summary>
+    /// Sets the wait until condition.
+    /// </summary>
+    /// <param name="waitUntil">The wait until condition to be used in the strategy.</param>
+    /// <returns>The updated instance of the wait strategy.</returns>
+    private WaitStrategy WithStrategy(IWaitUntil waitUntil)
+    {
+      _waitUntil = waitUntil;
+      return this;
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

The pull request extends the `IWaitForContainerOS` interface and adds an optional argument to the members, allowing the configuration of individual wait strategies. These changes enable configuration of the maximum number of retries, the interval (time) between each retry, and a timeout after the readiness check is canceled.

In addition to this newly added approach, developers can cancel the container start, as is common in .NET, utilizing a [cancellation token](https://dotnet.testcontainers.org/api/create_docker_container/#canceling-a-container-start).

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #827

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


## Follow-ups

- Support custom configurations (default values) for `Retries`, `Interval`, `Timeout`
- #1145