### PR TITLE
feat: Add custom configuration for retries, interval and timeout

### DIFF
--- a/docs/api/resource_reuse.md
+++ b/docs/api/resource_reuse.md
@@ -17,8 +17,9 @@ _ = new ContainerBuilder()
 
 The current implementation considers the following resource configurations and their corresponding builder APIs when calculating the hash value.
 
-> [!NOTE]  
-> Version 3.8.0 did not include the container configuration's name in the hash value.
+!!!note
+
+    Version 3.8.0 did not include the container configuration's name in the hash value.
 
 - [ContainerConfiguration](https://github.com/testcontainers/testcontainers-dotnet/blob/develop/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs)
     - Image

--- a/docs/custom_configuration/index.md
+++ b/docs/custom_configuration/index.md
@@ -16,6 +16,11 @@ Testcontainers supports various configurations to set up your test environment. 
 | `ryuk.container.privileged` | `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED` | Runs Ryuk (resource reaper) in privileged mode.                                                                           | `false`                     |
 | `ryuk.container.image`      | `TESTCONTAINERS_RYUK_CONTAINER_IMAGE`      | The Ryuk (resource reaper) Docker image.                                                                                  | `testcontainers/ryuk:0.5.1` |
 | `hub.image.name.prefix`     | `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX`     | The name to use for substituting the Docker Hub registry part of the image name.                                          | -                           |
+<!-- | `wait.strategy.retries`     | `TESTCONTAINERS_WAIT_STRATEGY_RETRIES`     | The wait strategy retry count.                                                                                            | `infinite`                  |
+| `wait.strategy.interval`    | `TESTCONTAINERS_WAIT_STRATEGY_INTERVAL`    | The wait strategy interval<sup>1</sup>.                                                                                   | `00:00:01`                  |
+| `wait.strategy.timeout`     | `TESTCONTAINERS_WAIT_STRATEGY_TIMEOUT`     | The wait strategy timeout<sup>1</sup>.                                                                                    | `01:00:00`                  |
+
+1) The value represent the string representation of a [TimeSpan](https://learn.microsoft.com/en-us/dotnet/api/system.timespan), for example, `00:00:01` for 1 second. -->
 
 ## Configure remote container runtime
 

--- a/src/Testcontainers/Builders/DockerDesktopEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/DockerDesktopEndpointAuthenticationProvider.cs
@@ -101,5 +101,23 @@ namespace DotNet.Testcontainers.Builders
     {
       return null;
     }
+
+    /// <inheritdoc />
+    public ushort GetWaitStrategyRetries()
+    {
+      return ushort.MinValue;
+    }
+
+    /// <inheritdoc />
+    public TimeSpan GetWaitStrategyInterval()
+    {
+      return TimeSpan.Zero;
+    }
+
+    /// <inheritdoc />
+    public TimeSpan GetWaitStrategyTimeout()
+    {
+      return TimeSpan.Zero;
+    }
   }
 }

--- a/src/Testcontainers/Builders/DockerDesktopEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/DockerDesktopEndpointAuthenticationProvider.cs
@@ -103,21 +103,21 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    public ushort GetWaitStrategyRetries()
+    public ushort? GetWaitStrategyRetries()
     {
-      return ushort.MinValue;
+      return null;
     }
 
     /// <inheritdoc />
-    public TimeSpan GetWaitStrategyInterval()
+    public TimeSpan? GetWaitStrategyInterval()
     {
-      return TimeSpan.Zero;
+      return null;
     }
 
     /// <inheritdoc />
-    public TimeSpan GetWaitStrategyTimeout()
+    public TimeSpan? GetWaitStrategyTimeout()
     {
-      return TimeSpan.Zero;
+      return null;
     }
   }
 }

--- a/src/Testcontainers/Builders/TestcontainersEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/TestcontainersEndpointAuthenticationProvider.cs
@@ -130,21 +130,21 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    public ushort GetWaitStrategyRetries()
+    public ushort? GetWaitStrategyRetries()
     {
-      return ushort.MinValue;
+      return _customConfiguration.GetWaitStrategyRetries();
     }
 
     /// <inheritdoc />
-    public TimeSpan GetWaitStrategyInterval()
+    public TimeSpan? GetWaitStrategyInterval()
     {
-      return TimeSpan.Zero;
+      return _customConfiguration.GetWaitStrategyInterval();
     }
 
     /// <inheritdoc />
-    public TimeSpan GetWaitStrategyTimeout()
+    public TimeSpan? GetWaitStrategyTimeout()
     {
-      return TimeSpan.Zero;
+      return _customConfiguration.GetWaitStrategyTimeout();
     }
 
     private sealed class TestcontainersConfiguration : PropertiesFileConfiguration

--- a/src/Testcontainers/Builders/TestcontainersEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/TestcontainersEndpointAuthenticationProvider.cs
@@ -129,6 +129,24 @@ namespace DotNet.Testcontainers.Builders
       return _customConfiguration.GetHubImageNamePrefix();
     }
 
+    /// <inheritdoc />
+    public ushort GetWaitStrategyRetries()
+    {
+      return ushort.MinValue;
+    }
+
+    /// <inheritdoc />
+    public TimeSpan GetWaitStrategyInterval()
+    {
+      return TimeSpan.Zero;
+    }
+
+    /// <inheritdoc />
+    public TimeSpan GetWaitStrategyTimeout()
+    {
+      return TimeSpan.Zero;
+    }
+
     private sealed class TestcontainersConfiguration : PropertiesFileConfiguration
     {
       public TestcontainersConfiguration()

--- a/src/Testcontainers/Configurations/CustomConfiguration.cs
+++ b/src/Testcontainers/Configurations/CustomConfiguration.cs
@@ -102,24 +102,26 @@ namespace DotNet.Testcontainers.Configurations
       return GetPropertyValue<string>(propertyName);
     }
 
-    protected virtual ushort GetWaitStrategyRetries(string propertyName)
+    protected virtual ushort? GetWaitStrategyRetries(string propertyName)
     {
-      return GetPropertyValue<ushort>(propertyName);
+      return GetPropertyValue<ushort?>(propertyName);
     }
 
-    protected virtual TimeSpan GetWaitStrategyInterval(string propertyName)
+    protected virtual TimeSpan? GetWaitStrategyInterval(string propertyName)
     {
-      return _properties.TryGetValue(propertyName, out var propertyValue) && TimeSpan.TryParse(propertyValue, out var result) && result > TimeSpan.Zero ? result : TimeSpan.FromSeconds(1);
+      return _properties.TryGetValue(propertyName, out var propertyValue) && TimeSpan.TryParse(propertyValue, out var result) && result > TimeSpan.Zero ? result : (TimeSpan?)null;
     }
 
-    protected virtual TimeSpan GetWaitStrategyTimeout(string propertyName)
+    protected virtual TimeSpan? GetWaitStrategyTimeout(string propertyName)
     {
-      return _properties.TryGetValue(propertyName, out var propertyValue) && TimeSpan.TryParse(propertyValue, out var result) && result > TimeSpan.Zero ? result : TimeSpan.FromHours(1);
+      return _properties.TryGetValue(propertyName, out var propertyValue) && TimeSpan.TryParse(propertyValue, out var result) && result > TimeSpan.Zero ? result : (TimeSpan?)null;
     }
 
     private T GetPropertyValue<T>(string propertyName)
     {
-      switch (Type.GetTypeCode(typeof(T)))
+      var type = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
+      switch (Type.GetTypeCode(type))
       {
         case TypeCode.Boolean:
         {
@@ -128,7 +130,7 @@ namespace DotNet.Testcontainers.Configurations
 
         case TypeCode.UInt16:
         {
-          return (T)(object)(_properties.TryGetValue(propertyName, out var propertyValue) && ushort.TryParse(propertyValue, out var result) ? result : ushort.MinValue);
+          return (T)(object)(_properties.TryGetValue(propertyName, out var propertyValue) && ushort.TryParse(propertyValue, out var result) ? result : (ushort?)null);
         }
 
         case TypeCode.String:

--- a/src/Testcontainers/Configurations/CustomConfiguration.cs
+++ b/src/Testcontainers/Configurations/CustomConfiguration.cs
@@ -102,6 +102,21 @@ namespace DotNet.Testcontainers.Configurations
       return GetPropertyValue<string>(propertyName);
     }
 
+    protected virtual ushort GetWaitStrategyRetries(string propertyName)
+    {
+      return GetPropertyValue<ushort>(propertyName);
+    }
+
+    protected virtual TimeSpan GetWaitStrategyInterval(string propertyName)
+    {
+      return _properties.TryGetValue(propertyName, out var propertyValue) && TimeSpan.TryParse(propertyValue, out var result) && result > TimeSpan.Zero ? result : TimeSpan.FromSeconds(1);
+    }
+
+    protected virtual TimeSpan GetWaitStrategyTimeout(string propertyName)
+    {
+      return _properties.TryGetValue(propertyName, out var propertyValue) && TimeSpan.TryParse(propertyValue, out var result) && result > TimeSpan.Zero ? result : TimeSpan.FromHours(1);
+    }
+
     private T GetPropertyValue<T>(string propertyName)
     {
       switch (Type.GetTypeCode(typeof(T)))
@@ -109,6 +124,11 @@ namespace DotNet.Testcontainers.Configurations
         case TypeCode.Boolean:
         {
           return (T)(object)(_properties.TryGetValue(propertyName, out var propertyValue) && ("1".Equals(propertyValue, StringComparison.Ordinal) || (bool.TryParse(propertyValue, out var result) && result)));
+        }
+
+        case TypeCode.UInt16:
+        {
+          return (T)(object)(_properties.TryGetValue(propertyName, out var propertyValue) && ushort.TryParse(propertyValue, out var result) ? result : ushort.MinValue);
         }
 
         case TypeCode.String:

--- a/src/Testcontainers/Configurations/EnvironmentConfiguration.cs
+++ b/src/Testcontainers/Configurations/EnvironmentConfiguration.cs
@@ -34,6 +34,12 @@ namespace DotNet.Testcontainers.Configurations
 
     private const string HubImageNamePrefix = "TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX";
 
+    private const string WaitStrategyRetries = "TESTCONTAINERS_WAIT_STRATEGY_RETRIES";
+
+    private const string WaitStrategyInterval = "TESTCONTAINERS_WAIT_STRATEGY_INTERVAL";
+
+    private const string WaitStrategyTimeout = "TESTCONTAINERS_WAIT_STRATEGY_TIMEOUT";
+
     static EnvironmentConfiguration()
     {
     }
@@ -56,6 +62,9 @@ namespace DotNet.Testcontainers.Configurations
           RyukContainerPrivileged,
           RyukContainerImage,
           HubImageNamePrefix,
+          WaitStrategyRetries,
+          WaitStrategyInterval,
+          WaitStrategyTimeout,
         }
         .ToDictionary(key => key, Environment.GetEnvironmentVariable))
     {
@@ -137,6 +146,24 @@ namespace DotNet.Testcontainers.Configurations
     public string GetHubImageNamePrefix()
     {
       return GetHubImageNamePrefix(HubImageNamePrefix);
+    }
+
+    /// <inheritdoc />
+    public ushort GetWaitStrategyRetries()
+    {
+      return GetWaitStrategyRetries(WaitStrategyRetries);
+    }
+
+    /// <inheritdoc />
+    public TimeSpan GetWaitStrategyInterval()
+    {
+      return GetWaitStrategyInterval(WaitStrategyInterval);
+    }
+
+    /// <inheritdoc />
+    public TimeSpan GetWaitStrategyTimeout()
+    {
+      return GetWaitStrategyTimeout(WaitStrategyTimeout);
     }
   }
 }

--- a/src/Testcontainers/Configurations/EnvironmentConfiguration.cs
+++ b/src/Testcontainers/Configurations/EnvironmentConfiguration.cs
@@ -149,19 +149,19 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public ushort GetWaitStrategyRetries()
+    public ushort? GetWaitStrategyRetries()
     {
       return GetWaitStrategyRetries(WaitStrategyRetries);
     }
 
     /// <inheritdoc />
-    public TimeSpan GetWaitStrategyInterval()
+    public TimeSpan? GetWaitStrategyInterval()
     {
       return GetWaitStrategyInterval(WaitStrategyInterval);
     }
 
     /// <inheritdoc />
-    public TimeSpan GetWaitStrategyTimeout()
+    public TimeSpan? GetWaitStrategyTimeout()
     {
       return GetWaitStrategyTimeout(WaitStrategyTimeout);
     }

--- a/src/Testcontainers/Configurations/ICustomConfiguration.cs
+++ b/src/Testcontainers/Configurations/ICustomConfiguration.cs
@@ -103,21 +103,27 @@ namespace DotNet.Testcontainers.Configurations
     string GetHubImageNamePrefix();
 
     /// <summary>
-    ///
+    /// Gets the wait strategy retries custom configuration.
     /// </summary>
-    /// <returns></returns>
-    ushort GetWaitStrategyRetries();
+    /// <returns>The wait strategy retries custom configuration.</returns>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
+    [CanBeNull]
+    ushort? GetWaitStrategyRetries();
 
     /// <summary>
-    ///
+    /// Gets the wait strategy interval custom configuration.
     /// </summary>
-    /// <returns></returns>
-    TimeSpan GetWaitStrategyInterval();
+    /// <returns>The wait strategy interval custom configuration.</returns>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
+    [CanBeNull]
+    TimeSpan? GetWaitStrategyInterval();
 
     /// <summary>
-    ///
+    /// Gets the wait strategy timeout custom configuration.
     /// </summary>
-    /// <returns></returns>
-    TimeSpan GetWaitStrategyTimeout();
+    /// <returns>The wait strategy timeout custom configuration.</returns>
+    /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
+    [CanBeNull]
+    TimeSpan? GetWaitStrategyTimeout();
   }
 }

--- a/src/Testcontainers/Configurations/ICustomConfiguration.cs
+++ b/src/Testcontainers/Configurations/ICustomConfiguration.cs
@@ -101,5 +101,23 @@ namespace DotNet.Testcontainers.Configurations
     /// <remarks>https://dotnet.testcontainers.org/custom_configuration/.</remarks>
     [CanBeNull]
     string GetHubImageNamePrefix();
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
+    ushort GetWaitStrategyRetries();
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
+    TimeSpan GetWaitStrategyInterval();
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <returns></returns>
+    TimeSpan GetWaitStrategyTimeout();
   }
 }

--- a/src/Testcontainers/Configurations/PropertiesFileConfiguration.cs
+++ b/src/Testcontainers/Configurations/PropertiesFileConfiguration.cs
@@ -139,5 +139,26 @@ namespace DotNet.Testcontainers.Configurations
       const string propertyName = "hub.image.name.prefix";
       return GetHubImageNamePrefix(propertyName);
     }
+
+    /// <inheritdoc />
+    public ushort GetWaitStrategyRetries()
+    {
+      const string propertyName = "wait.strategy.retries";
+      return GetWaitStrategyRetries(propertyName);
+    }
+
+    /// <inheritdoc />
+    public TimeSpan GetWaitStrategyInterval()
+    {
+      const string propertyName = "wait.strategy.interval";
+      return GetWaitStrategyInterval(propertyName);
+    }
+
+    /// <inheritdoc />
+    public TimeSpan GetWaitStrategyTimeout()
+    {
+      const string propertyName = "wait.strategy.timeout";
+      return GetWaitStrategyTimeout(propertyName);
+    }
   }
 }

--- a/src/Testcontainers/Configurations/PropertiesFileConfiguration.cs
+++ b/src/Testcontainers/Configurations/PropertiesFileConfiguration.cs
@@ -141,21 +141,21 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public ushort GetWaitStrategyRetries()
+    public ushort? GetWaitStrategyRetries()
     {
       const string propertyName = "wait.strategy.retries";
       return GetWaitStrategyRetries(propertyName);
     }
 
     /// <inheritdoc />
-    public TimeSpan GetWaitStrategyInterval()
+    public TimeSpan? GetWaitStrategyInterval()
     {
       const string propertyName = "wait.strategy.interval";
       return GetWaitStrategyInterval(propertyName);
     }
 
     /// <inheritdoc />
-    public TimeSpan GetWaitStrategyTimeout()
+    public TimeSpan? GetWaitStrategyTimeout()
     {
       const string propertyName = "wait.strategy.timeout";
       return GetWaitStrategyTimeout(propertyName);

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -101,6 +101,42 @@ namespace DotNet.Testcontainers.Configurations
       = EnvironmentConfiguration.Instance.GetHubImageNamePrefix() ?? PropertiesFileConfiguration.Instance.GetHubImageNamePrefix();
 
     /// <summary>
+    /// Gets or sets the wait strategy retry count.
+    /// </summary>
+    /// <remarks>
+    /// This property represents the default value and applies to all wait strategies.
+    /// Wait strategies can be configured individually using the wait strategy option callback:
+    /// https://dotnet.testcontainers.org/api/wait_strategies/.
+    /// </remarks>
+    [CanBeNull]
+    public static ushort? WaitStrategyRetries { get; set; }
+      = EnvironmentConfiguration.Instance.GetWaitStrategyRetries() ?? PropertiesFileConfiguration.Instance.GetWaitStrategyRetries();
+
+    /// <summary>
+    /// Gets or sets the wait strategy interval.
+    /// </summary>
+    /// <remarks>
+    /// This property represents the default value and applies to all wait strategies.
+    /// Wait strategies can be configured individually using the wait strategy option callback:
+    /// https://dotnet.testcontainers.org/api/wait_strategies/.
+    /// </remarks>
+    [CanBeNull]
+    public static TimeSpan? WaitStrategyInterval { get; set; }
+      = EnvironmentConfiguration.Instance.GetWaitStrategyInterval() ?? PropertiesFileConfiguration.Instance.GetWaitStrategyInterval();
+
+    /// <summary>
+    /// Gets or sets the wait strategy timeout.
+    /// </summary>
+    /// <remarks>
+    /// This property represents the default value and applies to all wait strategies.
+    /// Wait strategies can be configured individually using the wait strategy option callback:
+    /// https://dotnet.testcontainers.org/api/wait_strategies/.
+    /// </remarks>
+    [CanBeNull]
+    public static TimeSpan? WaitStrategyTimeout { get; set; }
+      = EnvironmentConfiguration.Instance.GetWaitStrategyTimeout() ?? PropertiesFileConfiguration.Instance.GetWaitStrategyTimeout();
+
+    /// <summary>
     /// Gets or sets the host operating system.
     /// </summary>
     [NotNull]

--- a/src/Testcontainers/Configurations/WaitStrategies/RetryLimitExceededException.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/RetryLimitExceededException.cs
@@ -1,0 +1,21 @@
+﻿namespace DotNet.Testcontainers.Configurations
+{
+  using System;
+
+  public sealed class RetryLimitExceededException : Exception
+  {
+    public RetryLimitExceededException()
+    {
+    }
+
+    public RetryLimitExceededException(string message)
+      : base(message)
+    {
+    }
+
+    public RetryLimitExceededException(string message, Exception inner)
+      : base(message, inner)
+    {
+    }
+  }
+}

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
@@ -44,8 +44,8 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Gets the number of retries.
     /// </summary>
-    public int Retries { get; private set; }
-      = -1;
+    public ushort Retries { get; private set; }
+      = ushort.MinValue;
 
     /// <summary>
     /// Gets the interval between retries.

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
@@ -45,19 +45,19 @@ namespace DotNet.Testcontainers.Configurations
     /// Gets the number of retries.
     /// </summary>
     public ushort Retries { get; private set; }
-      = ushort.MinValue;
+      = TestcontainersSettings.WaitStrategyRetries ?? 0;
 
     /// <summary>
     /// Gets the interval between retries.
     /// </summary>
     public TimeSpan Interval { get; private set; }
-      = TimeSpan.FromSeconds(1);
+      = TestcontainersSettings.WaitStrategyInterval ?? TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// Gets the timeout.
     /// </summary>
     public TimeSpan Timeout { get; private set; }
-      = TimeSpan.FromHours(1);
+      = TestcontainersSettings.WaitStrategyTimeout ?? TimeSpan.FromHours(1);
 
     /// <inheritdoc />
     public IWaitStrategy WithRetries(ushort retries)

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
@@ -114,10 +114,10 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="retries">The number of retries to run for the condition to become false.</param>
     /// <param name="ct">The optional cancellation token to cancel the waiting operation.</param>
     /// <exception cref="TimeoutException">Thrown when the timeout expires.</exception>
-    /// <exception cref="ArgumentException">Thrown when the number of retries is exceeded.</exception>
+    /// <exception cref="RetryLimitExceededException">Thrown when the number of retries is exceeded.</exception>
     /// <returns>A task that represents the asynchronous block operation.</returns>
     [PublicAPI]
-    public static async Task WaitWhileAsync(Func<Task<bool>> wait, TimeSpan interval, TimeSpan timeout, int retries = -1, CancellationToken ct = default)
+    public static async Task WaitWhileAsync(Func<Task<bool>> wait, TimeSpan interval, TimeSpan timeout, int retries = 0, CancellationToken ct = default)
     {
       ushort actualRetries = 0;
 
@@ -134,7 +134,7 @@ namespace DotNet.Testcontainers.Configurations
           }
 
           _ = Guard.Argument(retries, nameof(retries))
-            .ThrowIf(_ => retries > 0 && ++actualRetries > retries, _ => throw new ArgumentException(MaximumRetryExceededException));
+            .ThrowIf(_ => retries > 0 && ++actualRetries > retries, _ => throw new RetryLimitExceededException(MaximumRetryExceededException));
 
           await Task.Delay(interval, ct)
             .ConfigureAwait(false);
@@ -170,10 +170,10 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="retries">The number of retries to run for the condition to become true.</param>
     /// <param name="ct">The optional cancellation token to cancel the waiting operation.</param>
     /// <exception cref="TimeoutException">Thrown when the timeout expires.</exception>
-    /// <exception cref="ArgumentException">Thrown when the number of retries is exceeded.</exception>
+    /// <exception cref="RetryLimitExceededException">Thrown when the number of retries is exceeded.</exception>
     /// <returns>A task that represents the asynchronous block operation.</returns>
     [PublicAPI]
-    public static async Task WaitUntilAsync(Func<Task<bool>> wait, TimeSpan interval, TimeSpan timeout, int retries = -1, CancellationToken ct = default)
+    public static async Task WaitUntilAsync(Func<Task<bool>> wait, TimeSpan interval, TimeSpan timeout, int retries = 0, CancellationToken ct = default)
     {
       ushort actualRetries = 0;
 
@@ -190,7 +190,7 @@ namespace DotNet.Testcontainers.Configurations
           }
 
           _ = Guard.Argument(retries, nameof(retries))
-            .ThrowIf(_ => retries > 0 && ++actualRetries > retries, _ => throw new ArgumentException(MaximumRetryExceededException));
+            .ThrowIf(_ => retries > 0 && ++actualRetries > retries, _ => throw new RetryLimitExceededException(MaximumRetryExceededException));
 
           await Task.Delay(interval, ct)
             .ConfigureAwait(false);

--- a/tests/Testcontainers.Platform.Linux.Tests/WaitStrategyTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/WaitStrategyTest.cs
@@ -1,0 +1,45 @@
+﻿namespace Testcontainers.Tests;
+
+public sealed class WaitStrategyTest
+{
+    [Fact]
+    public Task WithTimeout()
+    {
+        return Assert.ThrowsAsync<TimeoutException>(() => new ContainerBuilder()
+            .WithImage(CommonImages.Alpine)
+            .WithEntrypoint(CommonCommands.SleepInfinity)
+            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(FailingWaitStrategy.Instance, o => o.WithTimeout(TimeSpan.FromSeconds(1))))
+            .Build()
+            .StartAsync());
+    }
+
+    [Fact]
+    public Task WithRetries()
+    {
+        return Assert.ThrowsAsync<RetryLimitExceededException>(() => new ContainerBuilder()
+            .WithImage(CommonImages.Alpine)
+            .WithEntrypoint(CommonCommands.SleepInfinity)
+            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(FailingWaitStrategy.Instance, o => o.WithRetries(1)))
+            .Build()
+            .StartAsync());
+    }
+
+    private sealed class FailingWaitStrategy : IWaitUntil
+    {
+        static FailingWaitStrategy()
+        {
+        }
+
+        private FailingWaitStrategy()
+        {
+        }
+
+        public static IWaitUntil Instance { get; }
+            = new FailingWaitStrategy();
+
+        public Task<bool> UntilAsync(IContainer container)
+        {
+            return Task.FromResult(false);
+        }
+    }
+}

--- a/tests/Testcontainers.Tests/Unit/Configurations/CustomConfigurationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/CustomConfigurationTest.cs
@@ -27,6 +27,9 @@ namespace DotNet.Testcontainers.Tests.Unit
         EnvironmentVariables.Add("TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED");
         EnvironmentVariables.Add("TESTCONTAINERS_RYUK_CONTAINER_IMAGE");
         EnvironmentVariables.Add("TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX");
+        EnvironmentVariables.Add("TESTCONTAINERS_WAIT_STRATEGY_RETRIES");
+        EnvironmentVariables.Add("TESTCONTAINERS_WAIT_STRATEGY_INTERVAL");
+        EnvironmentVariables.Add("TESTCONTAINERS_WAIT_STRATEGY_TIMEOUT");
       }
 
       [Theory]
@@ -175,6 +178,41 @@ namespace DotNet.Testcontainers.Tests.Unit
         SetEnvironmentVariable(propertyName, propertyValue);
         ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
         Assert.Equal(expected, customConfiguration.GetHubImageNamePrefix());
+      }
+
+      [Theory]
+      [InlineData("", "", 0)]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_RETRIES", "", 0)]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_RETRIES", "1", 1)]
+      public void GetWaitStrategyRetriesCustomConfiguration(string propertyName, string propertyValue, ushort expected)
+      {
+        SetEnvironmentVariable(propertyName, propertyValue);
+        ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
+        Assert.Equal(expected, customConfiguration.GetWaitStrategyRetries());
+      }
+
+      [Theory]
+      [InlineData("", "", "00:00:01")]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_INTERVAL", "", "00:00:01")]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_INTERVAL", "-00:00:00.001", "00:00:01")]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_INTERVAL", "00:00:01", "00:00:01")]
+      public void GetWaitStrategyIntervalCustomConfiguration(string propertyName, string propertyValue, string expected)
+      {
+        SetEnvironmentVariable(propertyName, propertyValue);
+        ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
+        Assert.Equal(expected, customConfiguration.GetWaitStrategyInterval().ToString());
+      }
+
+      [Theory]
+      [InlineData("", "", "01:00:00")]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_TIMEOUT", "", "01:00:00")]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_TIMEOUT", "-00:00:00.001", "01:00:00")]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_TIMEOUT", "00:00:01", "00:00:01")]
+      public void GetWaitStrategyTimeoutCustomConfiguration(string propertyName, string propertyValue, string expected)
+      {
+        SetEnvironmentVariable(propertyName, propertyValue);
+        ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
+        Assert.Equal(expected, customConfiguration.GetWaitStrategyTimeout().ToString());
       }
 
       public void Dispose()
@@ -330,6 +368,38 @@ namespace DotNet.Testcontainers.Tests.Unit
       {
         ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
         Assert.Equal(expected, customConfiguration.GetHubImageNamePrefix());
+      }
+
+      [Theory]
+      [InlineData("", 0)]
+      [InlineData("wait.strategy.retries=", 0)]
+      [InlineData("wait.strategy.retries=1", 1)]
+      public void GetWaitStrategyRetriesCustomConfiguration(string configuration, ushort expected)
+      {
+        ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
+        Assert.Equal(expected, customConfiguration.GetWaitStrategyRetries());
+      }
+
+      [Theory]
+      [InlineData("", "00:00:01")]
+      [InlineData("wait.strategy.interval=", "00:00:01")]
+      [InlineData("wait.strategy.interval=-00:00:00.001", "00:00:01")]
+      [InlineData("wait.strategy.interval=00:00:01", "00:00:01")]
+      public void GetWaitStrategyIntervalCustomConfiguration(string configuration, string expected)
+      {
+        ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
+        Assert.Equal(expected, customConfiguration.GetWaitStrategyInterval().ToString());
+      }
+
+      [Theory]
+      [InlineData("", "01:00:00")]
+      [InlineData("wait.strategy.timeout=", "01:00:00")]
+      [InlineData("wait.strategy.timeout=-00:00:00.001", "01:00:00")]
+      [InlineData("wait.strategy.timeout=00:00:01", "00:00:01")]
+      public void GetWaitStrategyTimeoutCustomConfiguration(string configuration, string expected)
+      {
+        ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
+        Assert.Equal(expected, customConfiguration.GetWaitStrategyTimeout().ToString());
       }
     }
   }

--- a/tests/Testcontainers.Tests/Unit/Configurations/CustomConfigurationTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/CustomConfigurationTest.cs
@@ -181,10 +181,10 @@ namespace DotNet.Testcontainers.Tests.Unit
       }
 
       [Theory]
-      [InlineData("", "", 0)]
-      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_RETRIES", "", 0)]
+      [InlineData("", "", null)]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_RETRIES", "", null)]
       [InlineData("TESTCONTAINERS_WAIT_STRATEGY_RETRIES", "1", 1)]
-      public void GetWaitStrategyRetriesCustomConfiguration(string propertyName, string propertyValue, ushort expected)
+      public void GetWaitStrategyRetriesCustomConfiguration(string propertyName, string propertyValue, int? expected)
       {
         SetEnvironmentVariable(propertyName, propertyValue);
         ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
@@ -192,27 +192,27 @@ namespace DotNet.Testcontainers.Tests.Unit
       }
 
       [Theory]
-      [InlineData("", "", "00:00:01")]
-      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_INTERVAL", "", "00:00:01")]
-      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_INTERVAL", "-00:00:00.001", "00:00:01")]
+      [InlineData("", "", null)]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_INTERVAL", "", null)]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_INTERVAL", "-00:00:00.001", null)]
       [InlineData("TESTCONTAINERS_WAIT_STRATEGY_INTERVAL", "00:00:01", "00:00:01")]
       public void GetWaitStrategyIntervalCustomConfiguration(string propertyName, string propertyValue, string expected)
       {
         SetEnvironmentVariable(propertyName, propertyValue);
         ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
-        Assert.Equal(expected, customConfiguration.GetWaitStrategyInterval().ToString());
+        Assert.Equal(expected, customConfiguration.GetWaitStrategyInterval()?.ToString());
       }
 
       [Theory]
-      [InlineData("", "", "01:00:00")]
-      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_TIMEOUT", "", "01:00:00")]
-      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_TIMEOUT", "-00:00:00.001", "01:00:00")]
+      [InlineData("", "", null)]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_TIMEOUT", "", null)]
+      [InlineData("TESTCONTAINERS_WAIT_STRATEGY_TIMEOUT", "-00:00:00.001", null)]
       [InlineData("TESTCONTAINERS_WAIT_STRATEGY_TIMEOUT", "00:00:01", "00:00:01")]
       public void GetWaitStrategyTimeoutCustomConfiguration(string propertyName, string propertyValue, string expected)
       {
         SetEnvironmentVariable(propertyName, propertyValue);
         ICustomConfiguration customConfiguration = new EnvironmentConfiguration();
-        Assert.Equal(expected, customConfiguration.GetWaitStrategyTimeout().ToString());
+        Assert.Equal(expected, customConfiguration.GetWaitStrategyTimeout()?.ToString());
       }
 
       public void Dispose()
@@ -371,35 +371,35 @@ namespace DotNet.Testcontainers.Tests.Unit
       }
 
       [Theory]
-      [InlineData("", 0)]
-      [InlineData("wait.strategy.retries=", 0)]
+      [InlineData("", null)]
+      [InlineData("wait.strategy.retries=", null)]
       [InlineData("wait.strategy.retries=1", 1)]
-      public void GetWaitStrategyRetriesCustomConfiguration(string configuration, ushort expected)
+      public void GetWaitStrategyRetriesCustomConfiguration(string configuration, int? expected)
       {
         ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
         Assert.Equal(expected, customConfiguration.GetWaitStrategyRetries());
       }
 
       [Theory]
-      [InlineData("", "00:00:01")]
-      [InlineData("wait.strategy.interval=", "00:00:01")]
-      [InlineData("wait.strategy.interval=-00:00:00.001", "00:00:01")]
+      [InlineData("", null)]
+      [InlineData("wait.strategy.interval=", null)]
+      [InlineData("wait.strategy.interval=-00:00:00.001", null)]
       [InlineData("wait.strategy.interval=00:00:01", "00:00:01")]
       public void GetWaitStrategyIntervalCustomConfiguration(string configuration, string expected)
       {
         ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
-        Assert.Equal(expected, customConfiguration.GetWaitStrategyInterval().ToString());
+        Assert.Equal(expected, customConfiguration.GetWaitStrategyInterval()?.ToString());
       }
 
       [Theory]
-      [InlineData("", "01:00:00")]
-      [InlineData("wait.strategy.timeout=", "01:00:00")]
-      [InlineData("wait.strategy.timeout=-00:00:00.001", "01:00:00")]
+      [InlineData("", null)]
+      [InlineData("wait.strategy.timeout=", null)]
+      [InlineData("wait.strategy.timeout=-00:00:00.001", null)]
       [InlineData("wait.strategy.timeout=00:00:01", "00:00:01")]
       public void GetWaitStrategyTimeoutCustomConfiguration(string configuration, string expected)
       {
         ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { configuration });
-        Assert.Equal(expected, customConfiguration.GetWaitStrategyTimeout().ToString());
+        Assert.Equal(expected, customConfiguration.GetWaitStrategyTimeout()?.ToString());
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

The pull request extends the ICustomConfiguration interface and adds getters for the recently added wait strategy options.

## Why is it important?

This allows developers to globally override the default configurations instead of configuring each wait strategy individually.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #1168
- Relates #1145

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
