### PR TITLE
fix: Add default file permission (755 for image build)

### DIFF
--- a/docs/api/create_docker_image.md
+++ b/docs/api/create_docker_image.md
@@ -101,3 +101,14 @@ _ = new ImageFromDockerfileBuilder()
 !!!tip
 
     Testcontainers for .NET detects your Docker host configuration. You do **not** have to set the Docker daemon socket.
+
+## Known issues
+
+- When building an image using Testcontainers for .NET and switching the user's context (`USER` statement) in a Dockerfile, the user won't automatically become the [owner](https://github.com/testcontainers/testcontainers-dotnet/issues/1171#issuecomment-2099197840) of the working directory, which seems to be the case when building the image from the CLI. If the running process requires write access to the working directory, it is necessary to set the permissions explicitly (the base image in this example already contains the user `app`):
+
+   ```Dockerfile
+   FROM mcr.microsoft.com/dotnet/sdk:8.0
+   WORKDIR /app
+   RUN chown app:app .
+   USER app
+   ```

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -4,6 +4,7 @@ namespace DotNet.Testcontainers.Images
   using System.Collections.Generic;
   using System.IO;
   using System.Linq;
+  using System.Runtime.InteropServices;
   using System.Text;
   using System.Text.RegularExpressions;
   using System.Threading;
@@ -148,7 +149,12 @@ namespace DotNet.Testcontainers.Images
               using (var inputStream = new FileStream(absoluteFilePath, FileMode.Open, FileAccess.Read))
               {
                 var entry = TarEntry.CreateTarEntry(relativeFilePath);
-                entry.Size = inputStream.Length;
+                entry.TarHeader.Size = inputStream.Length;
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                  entry.TarHeader.Mode = (int)Unix.FileMode755;
+                }
 
                 await tarOutputStream.PutNextEntryAsync(entry, ct)
                   .ConfigureAwait(false);


### PR DESCRIPTION
## What does this PR do?

Applies the default file permission (755) in the tarball that is later sent to the Docker daemon to build the image.

## Why is it important?

Without setting the default permissions on Windows test hosts, the relevant `ENTRYPOINT` and `CMD` commands may not be able to access (read) files from the working directory (if the user context changes).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1171

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
