### PR TITLE
feat: Add Azure EventHubs module

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
         <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.101.7"/>
         <PackageVersion Include="AWSSDK.SQS" Version="3.7.100.71"/>
         <PackageVersion Include="Azure.Data.Tables" Version="12.8.0"/>
+        <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.11.3" />
         <PackageVersion Include="Azure.Storage.Blobs" Version="12.17.0"/>
         <PackageVersion Include="Azure.Storage.Queues" Version="12.15.0"/>
         <PackageVersion Include="ClickHouse.Client" Version="6.7.1"/>
@@ -62,6 +63,5 @@
         <PackageVersion Include="RavenDB.Client" Version="5.4.100"/>
         <PackageVersion Include="Selenium.WebDriver" Version="4.8.1"/>
         <PackageVersion Include="StackExchange.Redis" Version="2.6.90"/>
-        <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.11.3" />
     </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,5 +62,6 @@
         <PackageVersion Include="RavenDB.Client" Version="5.4.100"/>
         <PackageVersion Include="Selenium.WebDriver" Version="4.8.1"/>
         <PackageVersion Include="StackExchange.Redis" Version="2.6.90"/>
+        <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.11.3" />
     </ItemGroup>
 </Project>

--- a/Testcontainers.sln
+++ b/Testcontainers.sln
@@ -195,6 +195,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testcontainers.Tests", "tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testcontainers.WebDriver.Tests", "tests\Testcontainers.WebDriver.Tests\Testcontainers.WebDriver.Tests.csproj", "{EBA72C3B-57D5-43FF-A5B4-3D55B3B6D4C2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testcontainers.EventHubs", "src\Testcontainers.EventHubs\Testcontainers.EventHubs.csproj", "{0EF885E9-E973-47DC-AA9C-3A5E9175B0F3}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testcontainers.EventHubs.Tests", "tests\Testcontainers.EventHubs.Tests\Testcontainers.EventHubs.Tests.csproj", "{4A0C5523-CEB2-49C9-AE62-9187A01B016B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -568,6 +572,14 @@ Global
 		{EBA72C3B-57D5-43FF-A5B4-3D55B3B6D4C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EBA72C3B-57D5-43FF-A5B4-3D55B3B6D4C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EBA72C3B-57D5-43FF-A5B4-3D55B3B6D4C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0EF885E9-E973-47DC-AA9C-3A5E9175B0F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EF885E9-E973-47DC-AA9C-3A5E9175B0F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0EF885E9-E973-47DC-AA9C-3A5E9175B0F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0EF885E9-E973-47DC-AA9C-3A5E9175B0F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4A0C5523-CEB2-49C9-AE62-9187A01B016B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4A0C5523-CEB2-49C9-AE62-9187A01B016B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4A0C5523-CEB2-49C9-AE62-9187A01B016B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4A0C5523-CEB2-49C9-AE62-9187A01B016B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{5365F780-0E6C-41F0-B1B9-7DC34368F80C} = {673F23AE-7694-4BB9-ABD4-136D6C13634E}
@@ -661,5 +673,7 @@ Global
 		{1A1983E6-5297-435F-B467-E8E1F11277D6} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
 		{27CDB869-A150-4593-958F-6F26E5391E7C} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
 		{EBA72C3B-57D5-43FF-A5B4-3D55B3B6D4C2} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
+		{0EF885E9-E973-47DC-AA9C-3A5E9175B0F3} = {673F23AE-7694-4BB9-ABD4-136D6C13634E}
+		{4A0C5523-CEB2-49C9-AE62-9187A01B016B} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
 	EndGlobalSection
 EndGlobal

--- a/src/Testcontainers.EventHubs/.editorconfig
+++ b/src/Testcontainers.EventHubs/.editorconfig
@@ -1,0 +1,1 @@
+root = true

--- a/src/Testcontainers.EventHubs/Configuration/ConfigurationBuilder.cs
+++ b/src/Testcontainers.EventHubs/Configuration/ConfigurationBuilder.cs
@@ -1,0 +1,53 @@
+﻿namespace Testcontainers.EventHubs.Configuration
+{
+    public class ConfigurationBuilder
+    {
+        private const string DefaultNamespace = "emulatorns1";
+        
+        private readonly RootConfiguration _rootConfiguration = new RootConfiguration();
+            
+        private ConfigurationBuilder()
+        {
+            _rootConfiguration.UserConfig = new UserConfig
+            {
+                NamespaceConfig = new List<NamespaceConfig>()
+                {
+                    new NamespaceConfig
+                    {
+                        Type = "EventHub",
+                        Name = DefaultNamespace
+                    }
+                },
+                LoggingConfig = new LoggingConfig() { Type = "File" }
+            };
+        }
+
+        public static ConfigurationBuilder Create()
+        {
+            return new ConfigurationBuilder();
+        }
+        
+        public ConfigurationBuilder WithEventHub(string entityName, string partitionCount, IEnumerable<string> consumerGroups)
+        {
+            var namespaceConfig = _rootConfiguration.UserConfig.NamespaceConfig.FirstOrDefault(x => x.Name == DefaultNamespace);
+            if (namespaceConfig == null)
+            {
+                throw new InvalidOperationException($"Default Namespace '{DefaultNamespace}' not found.");
+            }
+
+            namespaceConfig.Entities.Add(new Entity
+            {
+                Name = entityName,
+                PartitionCount = partitionCount,
+                ConsumerGroups = consumerGroups.Select(consumerGroupName => new ConsumerGroup { Name = consumerGroupName }).ToList()
+            });
+
+            return this;
+        }
+
+        public string Build()
+        {
+            return JsonSerializer.Serialize(_rootConfiguration);
+        }
+    }
+}

--- a/src/Testcontainers.EventHubs/Configuration/ConsumerGroup.cs
+++ b/src/Testcontainers.EventHubs/Configuration/ConsumerGroup.cs
@@ -1,0 +1,7 @@
+﻿namespace Testcontainers.EventHubs.Configuration
+{
+    public record ConsumerGroup
+    {
+        public string Name { get; set; }
+    }
+}

--- a/src/Testcontainers.EventHubs/Configuration/Entity.cs
+++ b/src/Testcontainers.EventHubs/Configuration/Entity.cs
@@ -1,0 +1,9 @@
+﻿namespace Testcontainers.EventHubs.Configuration
+{
+    public record Entity
+    {
+        public string Name { get; set; }
+        public string PartitionCount { get; set; }
+        public List<ConsumerGroup> ConsumerGroups { get; set; } = [];
+    }
+}

--- a/src/Testcontainers.EventHubs/Configuration/LoggingConfig.cs
+++ b/src/Testcontainers.EventHubs/Configuration/LoggingConfig.cs
@@ -1,0 +1,7 @@
+﻿namespace Testcontainers.EventHubs.Configuration
+{
+    public record LoggingConfig
+    {
+        public string Type { get; set; }
+    }
+}

--- a/src/Testcontainers.EventHubs/Configuration/NamespaceConfig.cs
+++ b/src/Testcontainers.EventHubs/Configuration/NamespaceConfig.cs
@@ -1,0 +1,10 @@
+﻿namespace Testcontainers.EventHubs.Configuration
+{
+    public record NamespaceConfig
+    {
+        public string Type { get; set; }
+        public string Name { get; set; }
+        
+        public List<Entity> Entities { get; set; } = [];
+    }
+}

--- a/src/Testcontainers.EventHubs/Configuration/RootConfiguration.cs
+++ b/src/Testcontainers.EventHubs/Configuration/RootConfiguration.cs
@@ -1,0 +1,7 @@
+﻿namespace Testcontainers.EventHubs.Configuration
+{
+    public record RootConfiguration
+    {
+        public UserConfig UserConfig { get; set; }
+    }
+}

--- a/src/Testcontainers.EventHubs/Configuration/UserConfig.cs
+++ b/src/Testcontainers.EventHubs/Configuration/UserConfig.cs
@@ -1,0 +1,8 @@
+﻿namespace Testcontainers.EventHubs.Configuration
+{
+    public record UserConfig
+    {
+        public List<NamespaceConfig> NamespaceConfig { get; set; } = [];
+        public LoggingConfig LoggingConfig { get; set; }
+    }
+}

--- a/src/Testcontainers.EventHubs/EventHubsBuilder.cs
+++ b/src/Testcontainers.EventHubs/EventHubsBuilder.cs
@@ -1,0 +1,102 @@
+namespace Testcontainers.EventHubs;
+
+/// <inheritdoc cref="ContainerBuilder{TBuilderEntity, TContainerEntity, TConfigurationEntity}" />
+[PublicAPI]
+public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventHubsContainer, EventHubsConfiguration>
+{
+    public const string EventHubsImage = "mcr.microsoft.com/azure-messaging/eventhubs-emulator:latest";
+
+    public const ushort EventHubsPort = 5672;
+    
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventHubsBuilder" /> class.
+    /// </summary>
+    public EventHubsBuilder()
+        : this(new EventHubsConfiguration())
+    {
+        DockerResourceConfiguration = Init().DockerResourceConfiguration;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventHubsBuilder" /> class.
+    /// </summary>
+    /// <param name="resourceConfiguration">The Docker resource configuration.</param>
+    private EventHubsBuilder(EventHubsConfiguration resourceConfiguration)
+        : base(resourceConfiguration)
+    {
+        DockerResourceConfiguration = resourceConfiguration;
+    }
+
+    /// <inheritdoc />
+    protected override EventHubsConfiguration DockerResourceConfiguration { get; }
+    
+    /// <summary>
+    /// Sets the event hub configuration
+    /// </summary>
+    /// <param name="configurationBuilder"></param>
+    /// <returns></returns>
+    public EventHubsBuilder WithConfigurationBuilder(ConfigurationBuilder configurationBuilder)
+    {
+        var configBytes = Encoding.UTF8.GetBytes(configurationBuilder.Build());
+        
+        return WithResourceMapping(configBytes, "Eventhubs_Emulator/ConfigFiles/Config.json");
+    }
+    
+    /// <summary>
+    /// Sets the endpoint of the azurite blob service
+    /// </summary>
+    /// <param name="azuriteBlobEndpoint"></param>
+    /// <returns></returns>
+    public EventHubsBuilder WithAzuriteBlobEndpoint(string azuriteBlobEndpoint)
+    {
+        return WithEnvironment("BLOB_SERVER", azuriteBlobEndpoint);
+    }
+    
+    /// <summary>
+    /// Sets the endpoint of the azurite table service
+    /// </summary>
+    /// <param name="azuriteTableEndpoint"></param>
+    /// <returns></returns>
+    public EventHubsBuilder WithAzuriteTableEndpoint(string azuriteTableEndpoint)
+    {
+        return WithEnvironment("METADATA_SERVER", azuriteTableEndpoint);
+    }
+    
+    /// <inheritdoc />
+    public override EventHubsContainer Build()
+    {
+        Validate();
+        
+        var waitStrategy = Wait.ForUnixContainer().UntilMessageIsLogged("Emulator Service is Successfully Up!");
+        
+        var eventHubsBuilder = DockerResourceConfiguration.WaitStrategies.Count() > 1 ? this : WithWaitStrategy(waitStrategy);
+        return new EventHubsContainer(eventHubsBuilder.DockerResourceConfiguration);
+    }
+
+    /// <inheritdoc />
+    protected override EventHubsBuilder Init()
+    {
+        return base.Init()
+            .WithImage(EventHubsImage)
+            .WithEnvironment("ACCEPT_EULA", "Y")
+            .WithPortBinding(EventHubsPort, true);
+    }
+
+    /// <inheritdoc />
+    protected override EventHubsBuilder Clone(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
+    {
+        return Merge(DockerResourceConfiguration, new EventHubsConfiguration(resourceConfiguration));
+    }
+
+    /// <inheritdoc />
+    protected override EventHubsBuilder Clone(IContainerConfiguration resourceConfiguration)
+    {
+        return Merge(DockerResourceConfiguration, new EventHubsConfiguration(resourceConfiguration));
+    }
+
+    /// <inheritdoc />
+    protected override EventHubsBuilder Merge(EventHubsConfiguration oldValue, EventHubsConfiguration newValue)
+    {
+        return new EventHubsBuilder(new EventHubsConfiguration(oldValue, newValue));
+    }
+}

--- a/src/Testcontainers.EventHubs/EventHubsBuilder.cs
+++ b/src/Testcontainers.EventHubs/EventHubsBuilder.cs
@@ -1,3 +1,5 @@
+using DotNet.Testcontainers;
+
 namespace Testcontainers.EventHubs;
 
 /// <inheritdoc cref="ContainerBuilder{TBuilderEntity, TContainerEntity, TConfigurationEntity}" />
@@ -39,7 +41,8 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
     {
         var configBytes = Encoding.UTF8.GetBytes(configurationBuilder.Build());
         
-        return WithResourceMapping(configBytes, "Eventhubs_Emulator/ConfigFiles/Config.json");
+        return Merge(DockerResourceConfiguration, new EventHubsConfiguration(configurationBuilder: configurationBuilder))
+            .WithResourceMapping(configBytes, "Eventhubs_Emulator/ConfigFiles/Config.json");
     }
     
     /// <summary>
@@ -49,7 +52,8 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
     /// <returns></returns>
     public EventHubsBuilder WithAzuriteBlobEndpoint(string azuriteBlobEndpoint)
     {
-        return WithEnvironment("BLOB_SERVER", azuriteBlobEndpoint);
+        return Merge(DockerResourceConfiguration, new EventHubsConfiguration(azuriteBlobEndpoint: azuriteBlobEndpoint))
+            .WithEnvironment("BLOB_SERVER", azuriteBlobEndpoint);
     }
     
     /// <summary>
@@ -59,7 +63,8 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
     /// <returns></returns>
     public EventHubsBuilder WithAzuriteTableEndpoint(string azuriteTableEndpoint)
     {
-        return WithEnvironment("METADATA_SERVER", azuriteTableEndpoint);
+        return Merge(DockerResourceConfiguration, new EventHubsConfiguration(azuriteTableEndpoint: azuriteTableEndpoint))
+            .WithEnvironment("METADATA_SERVER", azuriteTableEndpoint);
     }
     
     /// <inheritdoc />
@@ -73,6 +78,26 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
         return new EventHubsContainer(eventHubsBuilder.DockerResourceConfiguration);
     }
 
+    /// <inheritdoc />
+    protected override void Validate()
+    {
+        base.Validate();
+
+        _ = Guard.Argument(DockerResourceConfiguration.ConfigurationBuilder,
+                nameof(DockerResourceConfiguration.ConfigurationBuilder))
+            .NotNull();
+
+        _ = Guard.Argument(DockerResourceConfiguration.AzuriteBlobEndpoint,
+                nameof(DockerResourceConfiguration.AzuriteBlobEndpoint))
+            .NotNull()
+            .NotEmpty();
+        
+        _ = Guard.Argument(DockerResourceConfiguration.AzuriteTableEndpoint,
+                nameof(DockerResourceConfiguration.AzuriteTableEndpoint))
+            .NotNull()
+            .NotEmpty();
+    }
+    
     /// <inheritdoc />
     protected override EventHubsBuilder Init()
     {

--- a/src/Testcontainers.EventHubs/EventHubsConfiguration.cs
+++ b/src/Testcontainers.EventHubs/EventHubsConfiguration.cs
@@ -7,8 +7,17 @@ public sealed class EventHubsConfiguration : ContainerConfiguration
     /// <summary>
     /// Initializes a new instance of the <see cref="EventHubsConfiguration" /> class.
     /// </summary>
-    public EventHubsConfiguration()
+    /// <param name="configurationBuilder">The configuration builder.</param>
+    /// <param name="azuriteBlobEndpoint">The Azurite blob endpoint.</param>
+    /// <param name="azuriteTableEndpoint">The Azurite table endpoint.</param>
+    public EventHubsConfiguration(
+        ConfigurationBuilder configurationBuilder = null,
+        string azuriteBlobEndpoint = null,
+        string azuriteTableEndpoint = null)
     {
+        ConfigurationBuilder = configurationBuilder;
+        AzuriteBlobEndpoint = azuriteBlobEndpoint;
+        AzuriteTableEndpoint = azuriteTableEndpoint;
     }
 
     /// <summary>
@@ -49,5 +58,23 @@ public sealed class EventHubsConfiguration : ContainerConfiguration
     public EventHubsConfiguration(EventHubsConfiguration oldValue, EventHubsConfiguration newValue)
         : base(oldValue, newValue)
     {
+        ConfigurationBuilder = BuildConfiguration.Combine(oldValue.ConfigurationBuilder, newValue.ConfigurationBuilder);
+        AzuriteBlobEndpoint = BuildConfiguration.Combine(oldValue.AzuriteBlobEndpoint, newValue.AzuriteBlobEndpoint);
+        AzuriteTableEndpoint = BuildConfiguration.Combine(oldValue.AzuriteTableEndpoint, newValue.AzuriteTableEndpoint);
     }
+    
+    /// <summary>
+    /// Gets the configuration builder
+    /// </summary>
+    public ConfigurationBuilder ConfigurationBuilder { get; }
+    
+    /// <summary>
+    /// Gets the Azurite blob endpoint
+    /// </summary>
+    public string AzuriteBlobEndpoint { get; }
+    
+    /// <summary>
+    /// Gets the Azurite table endpoint
+    /// </summary>
+    public string AzuriteTableEndpoint { get; }
 }

--- a/src/Testcontainers.EventHubs/EventHubsConfiguration.cs
+++ b/src/Testcontainers.EventHubs/EventHubsConfiguration.cs
@@ -1,0 +1,53 @@
+namespace Testcontainers.EventHubs;
+
+/// <inheritdoc cref="ContainerConfiguration" />
+[PublicAPI]
+public sealed class EventHubsConfiguration : ContainerConfiguration
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventHubsConfiguration" /> class.
+    /// </summary>
+    public EventHubsConfiguration()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventHubsConfiguration" /> class.
+    /// </summary>
+    /// <param name="resourceConfiguration">The Docker resource configuration.</param>
+    public EventHubsConfiguration(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
+        : base(resourceConfiguration)
+    {
+        // Passes the configuration upwards to the base implementations to create an updated immutable copy.
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventHubsConfiguration" /> class.
+    /// </summary>
+    /// <param name="resourceConfiguration">The Docker resource configuration.</param>
+    public EventHubsConfiguration(IContainerConfiguration resourceConfiguration)
+        : base(resourceConfiguration)
+    {
+        // Passes the configuration upwards to the base implementations to create an updated immutable copy.
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventHubsConfiguration" /> class.
+    /// </summary>
+    /// <param name="resourceConfiguration">The Docker resource configuration.</param>
+    public EventHubsConfiguration(EventHubsConfiguration resourceConfiguration)
+        : this(new EventHubsConfiguration(), resourceConfiguration)
+    {
+        // Passes the configuration upwards to the base implementations to create an updated immutable copy.
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventHubsConfiguration" /> class.
+    /// </summary>
+    /// <param name="oldValue">The old Docker resource configuration.</param>
+    /// <param name="newValue">The new Docker resource configuration.</param>
+    public EventHubsConfiguration(EventHubsConfiguration oldValue, EventHubsConfiguration newValue)
+        : base(oldValue, newValue)
+    {
+    }
+}

--- a/src/Testcontainers.EventHubs/EventHubsContainer.cs
+++ b/src/Testcontainers.EventHubs/EventHubsContainer.cs
@@ -1,0 +1,36 @@
+namespace Testcontainers.EventHubs;
+
+/// <inheritdoc cref="DockerContainer" />
+[PublicAPI]
+public sealed class EventHubsContainer : DockerContainer
+{
+    private const string SharedAccessKeyName = "RootManageSharedAccessKey";
+
+    private const string SharedAccessKey = "SAS_KEY_VALUE";
+
+    private const string UseDevelopmentEmulator = "true";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EventHubsContainer" /> class.
+    /// </summary>
+    /// <param name="configuration">The container configuration.</param>
+    public EventHubsContainer(EventHubsConfiguration configuration)
+        : base(configuration)
+    {
+    }
+
+    /// <summary>
+    /// Gets the event hub connection string.
+    /// </summary>
+    /// <returns>The event hub connection string.</returns>
+    public string GetConnectionString()
+    {
+        var properties = new Dictionary<string, string>();
+        properties.Add("Endpoint", new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(EventHubsBuilder.EventHubsPort)).ToString());
+        properties.Add("DefaultEndpointsProtocol", Uri.UriSchemeHttp);
+        properties.Add("SharedAccessKeyName", SharedAccessKeyName);
+        properties.Add("SharedAccessKey", SharedAccessKey);
+        properties.Add("UseDevelopmentEmulator", UseDevelopmentEmulator);
+        return string.Join(";", properties.Select(property => string.Join("=", property.Key, property.Value)));
+    }
+}

--- a/src/Testcontainers.EventHubs/Testcontainers.EventHubs.csproj
+++ b/src/Testcontainers.EventHubs/Testcontainers.EventHubs.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="JetBrains.Annotations" VersionOverride="2023.3.0" PrivateAssets="All"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="../Testcontainers/Testcontainers.csproj"/>
+    </ItemGroup>
+</Project>

--- a/src/Testcontainers.EventHubs/Usings.cs
+++ b/src/Testcontainers.EventHubs/Usings.cs
@@ -1,0 +1,11 @@
+global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Text;
+global using System.Text.Json;
+global using Docker.DotNet.Models;
+global using DotNet.Testcontainers.Builders;
+global using DotNet.Testcontainers.Configurations;
+global using DotNet.Testcontainers.Containers;
+global using JetBrains.Annotations;
+global using Testcontainers.EventHubs.Configuration;

--- a/tests/Testcontainers.EventHubs.Tests/.editorconfig
+++ b/tests/Testcontainers.EventHubs.Tests/.editorconfig
@@ -1,0 +1,1 @@
+root = true

--- a/tests/Testcontainers.EventHubs.Tests/EventHubsContainerTest.cs
+++ b/tests/Testcontainers.EventHubs.Tests/EventHubsContainerTest.cs
@@ -1,0 +1,71 @@
+namespace Testcontainers.EventHubs;
+
+public abstract class EventHubsContainerTest : IAsyncLifetime
+{
+    private readonly AzuriteContainer _azuriteContainer;
+
+    private EventHubsContainer _eventHubsContainer;
+
+    private readonly INetwork _network = new NetworkBuilder().WithName(NetworkName).Build();
+    
+    private const string NetworkName = "eh-network";
+    private const string AzuriteNetworkAlias = "azurite";
+    
+    private const string EventHubName = "testeventhub";
+    private const string EventHubConsumerGroupName = "testconsumergroup";
+    
+    private EventHubsContainerTest()
+    {
+        _azuriteContainer = new AzuriteBuilder()
+            .WithNetwork(_network)
+            .WithNetworkAliases(AzuriteNetworkAlias)
+            .Build();
+    }
+
+    public async Task InitializeAsync()
+    {
+        await _azuriteContainer.StartAsync();
+        
+        var configurationBuilder = ConfigurationBuilder
+            .Create()
+            .WithEventHub(EventHubName, "2", new[] { EventHubConsumerGroupName });
+
+        var builder = new EventHubsBuilder()
+            .WithNetwork(_network)
+            .WithConfigurationBuilder(configurationBuilder)
+            .WithAzuriteBlobEndpoint(AzuriteNetworkAlias)
+            .WithAzuriteTableEndpoint(AzuriteNetworkAlias);
+        
+        _eventHubsContainer = builder.Build();
+        
+        await _eventHubsContainer.StartAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _eventHubsContainer.DisposeAsync();
+        
+        await _azuriteContainer.DisposeAsync();
+    }
+
+    [Fact]
+    [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+    public async Task SendAndReceivesEvents()
+    {
+        // Give
+        var eventBody = Encoding.Default.GetBytes("test");
+        var producerClient = new EventHubProducerClient(_eventHubsContainer.GetConnectionString(), EventHubName);
+        
+        // When
+        var eventDataBatch = await producerClient.CreateBatchAsync();
+        eventDataBatch.TryAdd(new EventData(eventBody));
+        
+        var thrownExceptionSend = await Record.ExceptionAsync(() => producerClient.SendAsync(eventDataBatch));
+
+        // Then
+        Assert.Null(thrownExceptionSend);
+    }
+    
+    [UsedImplicitly]
+    public sealed class EventHubsDefaultConfiguration : EventHubsContainerTest;
+}

--- a/tests/Testcontainers.EventHubs.Tests/Testcontainers.EventHubs.Tests.csproj
+++ b/tests/Testcontainers.EventHubs.Tests/Testcontainers.EventHubs.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net8.0</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Azure.Messaging.EventHubs" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="xunit"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="../../src/Testcontainers.Azurite/Testcontainers.Azurite.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="..\..\src\Testcontainers.EventHubs\Testcontainers.EventHubs.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+      <PackageVersion Update="Azure.Messaging.EventHubs" Version="5.11.3" />
+    </ItemGroup>
+</Project>

--- a/tests/Testcontainers.EventHubs.Tests/Testcontainers.EventHubs.Tests.csproj
+++ b/tests/Testcontainers.EventHubs.Tests/Testcontainers.EventHubs.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Messaging.EventHubs" Version="5.11.3" />
+        <PackageReference Include="Azure.Messaging.EventHubs" />
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>

--- a/tests/Testcontainers.EventHubs.Tests/Testcontainers.EventHubs.Tests.csproj
+++ b/tests/Testcontainers.EventHubs.Tests/Testcontainers.EventHubs.Tests.csproj
@@ -5,7 +5,7 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Azure.Messaging.EventHubs" />
+        <PackageReference Include="Azure.Messaging.EventHubs" Version="5.11.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>

--- a/tests/Testcontainers.EventHubs.Tests/Usings.cs
+++ b/tests/Testcontainers.EventHubs.Tests/Usings.cs
@@ -1,0 +1,13 @@
+global using Azure.Messaging.EventHubs;
+global using Azure.Messaging.EventHubs.Producer;
+global using DotNet.Testcontainers.Builders;
+global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Networks;
+global using JetBrains.Annotations;
+global using System.Text;
+global using System.Threading.Tasks;
+global using Testcontainers.Azurite;
+global using Testcontainers.EventHubs.Configuration;
+global using Xunit;
+
+


### PR DESCRIPTION
## What does this PR do?

Microsoft released an emulator for EventHubs yesterday, see https://github.com/Azure/azure-service-bus/issues/223#issuecomment-2123141525

This PR included a module for the emulator.

## Info

You need to provide an Azurite (emulator) instance/endpoint to start the EventHub emulator. This can be done using the `EventHubsConfiguration`.

You need to specify the following configuration file when starting the emulator.

```json
{
  "UserConfig": {
    "NamespaceConfig": [
      {
        "Type": "EventHub",
        "Name": "emulatorNs1",
        "Entities": [
          {
            "Name": "eh1",
            "PartitionCount": "2",
            "ConsumerGroups": [
              {
                "Name": "cg1"
              }
            ]
          }
        ]
      }
    ], 
    "LoggingConfig": {
      "Type": "File"
    }
  }
}
```

It will be dynamically mapped and i have built a floating builder so that the user can set the configuration as easily as possible.
The namespace "emulatorNs1" is mandatory and it is the only one currently supported by the emulator.

```cs
var configurationBuilder = ConfigurationBuilder
    .Create()
    .WithEventHub(EventHubName, "2", new[] { EventHubConsumerGroupName });

var builder = new EventHubsBuilder()
    .WithNetwork(_network)
    .WithConfigurationBuilder(configurationBuilder)
    .WithAzuriteBlobEndpoint(AzuriteNetworkAlias)
    .WithAzuriteTableEndpoint(AzuriteNetworkAlias);

_eventHubsContainer = builder.Build();

await _eventHubsContainer.StartAsync();
```