### PR TITLE
chore: Remove PulsarContainer.CreateAuthenticationTokenAsync(TimeSpan) default arg

### DIFF
--- a/docs/modules/pulsar.md
+++ b/docs/modules/pulsar.md
@@ -92,10 +92,17 @@ If you need to use token authentication, use the following builder configuration
 PulsarContainer _pulsarContainer = PulsarBuilder().WithTokenAuthentication().Build();
 ```
 
-Start the container and get the token from the running instance by using:
+Start the container and obtain an authentication token with a specified expiration time
 
 ```csharp
 var authToken = await container.CreateAuthenticationTokenAsync(TimeSpan.FromHours(1))
+    .ConfigureAwait(false);
+```
+
+Alternatively, set the token to never expire
+
+```csharp
+var authToken = await container.CreateAuthenticationTokenAsync(Timeout.InfiniteTimeSpan)
     .ConfigureAwait(false);
 ```
 

--- a/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
+++ b/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
@@ -79,7 +79,7 @@ public abstract class PulsarContainerTest : IAsyncLifetime
 
         protected override async Task<IPulsarClient> CreateClientAsync(CancellationToken ct = default)
         {
-            var authToken = await _pulsarContainer.CreateAuthenticationTokenAsync(TimeSpan.FromHours(1), ct)
+            var authToken = await _pulsarContainer.CreateAuthenticationTokenAsync(Timeout.InfiniteTimeSpan, ct)
                 .ConfigureAwait(false);
 
             return PulsarClient.Builder().ServiceUrl(new Uri(_pulsarContainer.GetBrokerAddress())).Authentication(new TokenAuthentication(authToken)).Build();


### PR DESCRIPTION
## What does this PR do?

This update modifies the CreateAuthenticationTokenAsync to accept an expiry time, including an option for infinite expiration. In addition, the PulsarContainerTest and Pulsar documentation have been updated accordingly.

## Why is it important?

It’s essential for end users to have clarity about the lifespan of a token. By requiring them to set an expiry time, any uncertainty is eliminated. Additionally, we now offer support for tokens that never expire.

## How to test this PR

This is covered by the updated tests