### PR TITLE
fix: Trim relative path indicators from Dockerfile path

### DIFF
--- a/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
@@ -3,6 +3,7 @@ namespace DotNet.Testcontainers.Builders
   using System;
   using System.Collections.Generic;
   using System.IO;
+  using System.Text.RegularExpressions;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Images;
@@ -65,7 +66,8 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc />
     public ImageFromDockerfileBuilder WithDockerfile(string dockerfile)
     {
-      return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(dockerfile: dockerfile));
+      var dockerfileFilePath = Regex.Replace(dockerfile, "^\\.(\\/|\\\\)", string.Empty, RegexOptions.None, TimeSpan.FromSeconds(1));
+      return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(dockerfile: dockerfileFilePath));
     }
 
     /// <inheritdoc />

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -100,8 +100,11 @@ namespace DotNet.Testcontainers.Tests.Unit
       Assert.Equal($"Directory '{Path.GetFullPath(dockerfileDirectory)}' does not exist.", exception.Message);
     }
 
-    [Fact]
-    public async Task BuildsDockerImage()
+    [Theory]
+    [InlineData("Dockerfile")]
+    [InlineData("./Dockerfile")]
+    [InlineData(".\\Dockerfile")]
+    public async Task BuildsDockerImage(string dockerfile)
     {
       // Given
       IImage tag1 = new DockerImage("localhost/testcontainers", Guid.NewGuid().ToString("D"), string.Empty);
@@ -110,7 +113,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
         .WithName(tag1)
-        .WithDockerfile("Dockerfile")
+        .WithDockerfile(dockerfile)
         .WithDockerfileDirectory("Assets/")
         .WithDeleteIfExists(true)
         .WithCreateParameterModifier(parameterModifier => parameterModifier.Tags.Add(tag2.FullName))


### PR DESCRIPTION
## What does this PR do?

The pull request removes the relative path indicators from the Dockerfile path in the `WithDockerfile(string)` image builder API.

## Why is it important?

This change is necessary to prevent issues when a developer passes a relative path to the API, such as `./Dockerfile`. If the Dockerfile path starts with a relative path indicator, the `.dockerignore` negate pattern that makes sure the Dockerfile is always included in the tarball might not work correct. This can result in the Dockerfile not being included. Building the image fails with the following or a similar error:

> Cannot locate specified Dockerfile: ./Dockerfile

Trimming the relative path indicators prevents a follow-up issue. If the path contains relative path indicators, setting the [`ImageBuildParameters.Dockerfile`](https://github.com/testcontainers/testcontainers-dotnet/blob/develop/src/Testcontainers/Clients/DockerImageOperations.cs#L101) property causes the build to fail as well.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1143

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
