### PR TITLE
Update Azurite image to 3.31.0 for API version 2024-08-04

### DIFF
--- a/src/Testcontainers.Azurite/AzuriteBuilder.cs
+++ b/src/Testcontainers.Azurite/AzuriteBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.Azurite;
 [PublicAPI]
 public sealed class AzuriteBuilder : ContainerBuilder<AzuriteBuilder, AzuriteContainer, AzuriteConfiguration>
 {
-    public const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.28.0";
+    public const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.31.0";
 
     public const ushort BlobPort = 10000;
 


### PR DESCRIPTION
## What does this PR do?

Update default image to [latest available image](https://mcr.microsoft.com/v2/azure-storage/azurite/tags/list).  [Release notes](https://github.com/Azure/Azurite/blob/8f3b809a8f3319e3730c002d8796e94e33d0deb0/ChangeLog.md#202406-version-3310).

## Why is it important?
Support latest Azure.Storage.* SDK packages by default, without a `WithImage(...)` override.

## Related issues
- Relates #1027 
- Relates #1056

## How to test this PR
* Update Azure.Storage.* NuGet dependencies to 12.20.0 or later.
* Run [tests](https://github.com/testcontainers/testcontainers-dotnet/blob/develop/tests/Testcontainers.Azurite.Tests/AzuriteContainerTest.cs)

## Follow-ups
Maybe we can come up with an automated process (How configurable is Dependabot?) to read [available image list](https://mcr.microsoft.com/v2/azure-storage/azurite/tags/list) and create a PR to update.  I think using the latest tag is problematic because users would have to clear the image locally to get the next version. 
