### PR TITLE
fix: Allow specifying the protocol (TCP, UDP, SCTP) to resolve the public assigned host port

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run Tests
         # run: dotnet cake --target=Tests --test-filter=${{ startsWith(matrix.os, 'ubuntu') && 'FullyQualifiedName~Testcontainers' || 'DockerPlatform=Windows' }}
-        run: dotnet cake --target=Tests --test-filter=FullyQualifiedName~RandomUdpPortBinding
+        run: dotnet cake --target=Tests --test-filter='FullyQualifiedName~RandomUdpPortBinding'
 
       # The Test Reporter GH Action is not compatible with the recent
       # actions/upload-artifact@v4 updates: https://github.com/dorny/test-reporter/issues/363.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -76,7 +76,8 @@ jobs:
         run: dotnet cake --target=Build
 
       - name: Run Tests
-        run: dotnet cake --target=Tests --test-filter=${{ startsWith(matrix.os, 'ubuntu') && 'FullyQualifiedName~Testcontainers' || 'DockerPlatform=Windows' }}
+        # run: dotnet cake --target=Tests --test-filter=${{ startsWith(matrix.os, 'ubuntu') && 'FullyQualifiedName~Testcontainers' || 'DockerPlatform=Windows' }}
+        run: dotnet cake --target=Tests --test-filter=FullyQualifiedName~RandomUdpPortBinding
 
       # The Test Reporter GH Action is not compatible with the recent
       # actions/upload-artifact@v4 updates: https://github.com/dorny/test-reporter/issues/363.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -76,8 +76,7 @@ jobs:
         run: dotnet cake --target=Build
 
       - name: Run Tests
-        # run: dotnet cake --target=Tests --test-filter=${{ startsWith(matrix.os, 'ubuntu') && 'FullyQualifiedName~Testcontainers' || 'DockerPlatform=Windows' }}
-        run: dotnet cake --target=Tests --test-filter='FullyQualifiedName~RandomUdpPortBinding'
+        run: dotnet cake --target=Tests --test-filter=${{ startsWith(matrix.os, 'ubuntu') && 'FullyQualifiedName~Testcontainers' || 'DockerPlatform=Windows' }}
 
       # The Test Reporter GH Action is not compatible with the recent
       # actions/upload-artifact@v4 updates: https://github.com/dorny/test-reporter/issues/363.

--- a/src/Testcontainers/Clients/ContainerConfigurationConverter.cs
+++ b/src/Testcontainers/Clients/ContainerConfigurationConverter.cs
@@ -48,7 +48,7 @@ namespace DotNet.Testcontainers.Clients
 
     public IDictionary<string, EndpointSettings> Networks { get; }
 
-    private static string GetQualifiedPort(string containerPort)
+    public static string GetQualifiedPort(string containerPort)
     {
       return Array.Exists(new[] { UdpPortSuffix, TcpPortSuffix, SctpPortSuffix }, portSuffix => containerPort.EndsWith(portSuffix, StringComparison.OrdinalIgnoreCase)) ? containerPort.ToLowerInvariant() : containerPort + TcpPortSuffix;
     }

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -236,7 +236,9 @@ namespace DotNet.Testcontainers.Containers
     {
       ThrowIfResourceNotFound();
 
-      if (_container.NetworkSettings.Ports.TryGetValue($"{containerPort}/tcp", out var portBindings) && ushort.TryParse(portBindings[0].HostPort, out var publicPort))
+      containerPort = ContainerConfigurationConverter.GetQualifiedPort(containerPort);
+
+      if (_container.NetworkSettings.Ports.TryGetValue(containerPort, out var portBindings) && ushort.TryParse(portBindings[0].HostPort, out var publicPort))
       {
         return publicPort;
       }

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -236,15 +236,15 @@ namespace DotNet.Testcontainers.Containers
     {
       ThrowIfResourceNotFound();
 
-      containerPort = ContainerConfigurationConverter.GetQualifiedPort(containerPort);
+      var qualifiedContainerPort = ContainerConfigurationConverter.GetQualifiedPort(containerPort);
 
-      if (_container.NetworkSettings.Ports.TryGetValue(containerPort, out var portBindings) && ushort.TryParse(portBindings[0].HostPort, out var publicPort))
+      if (_container.NetworkSettings.Ports.TryGetValue(qualifiedContainerPort, out var portBindings) && ushort.TryParse(portBindings[0].HostPort, out var publicPort))
       {
         return publicPort;
       }
       else
       {
-        throw new InvalidOperationException($"Exposed port {containerPort} is not mapped.");
+        throw new InvalidOperationException($"Exposed port {qualifiedContainerPort} is not mapped.");
       }
     }
 

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -132,6 +132,9 @@ namespace DotNet.Testcontainers.Containers
     /// <summary>
     /// Resolves the public assigned host port.
     /// </summary>
+    /// <remarks>
+    /// Resolves the public assigned host port for the TCP protocol. To resolve a specific protocol, use <see cref="GetMappedPublicPort(string)" />.
+    /// </remarks>
     /// <param name="containerPort">The container port.</param>
     /// <returns>Returns the public assigned host port.</returns>
     /// <exception cref="InvalidOperationException">Container has not been created.</exception>
@@ -140,6 +143,9 @@ namespace DotNet.Testcontainers.Containers
     /// <summary>
     /// Resolves the public assigned host port.
     /// </summary>
+    /// <remarks>
+    /// Append /tcp|udp|sctp to <paramref name="containerPort" /> to resolve the public assigned host port for a specific protocol e.g. "53/udp".
+    /// </remarks>
     /// <param name="containerPort">The container port.</param>
     /// <returns>Returns the public assigned host port.</returns>
     /// <exception cref="InvalidOperationException">Container has not been created.</exception>

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -219,6 +219,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         // Simple Python-based echo server with UDP
         // https://github.com/vhiribarren/docker-echo-server
         await using var container = new ContainerBuilder()
+          // .WithImage("docker-hub.artifactory.mocca.yunextraffic.cloud/vhiribarren/echo-server")
           .WithImage("vhiribarren/echo-server")
           .WithPortBinding(containerUdpQualifiedPort, true)
           .Build();
@@ -233,13 +234,16 @@ namespace DotNet.Testcontainers.Tests.Unit
 
         var message = Guid.NewGuid().ToString("D");
         var response = CallUdpEchoServer("127.0.0.1", localMappedPort, message);
-        // Assert.Equal(message, response);
+        // var response = CallUdpEchoServer("172.19.212.239", localMappedPort, message);
+        // response will look like this: "UDP: fb15aa0b4d19 received: <message> from ('<IP>', <Port>)
+        Assert.Contains(message, response);
       }
 
       private string CallUdpEchoServer(string serverIP, int serverPort, string message)
       {
         // Create a UDP client
-        UdpClient client = new UdpClient(serverPort);
+        // UdpClient client = new UdpClient(0, AddressFamily.InterNetwork);
+        UdpClient client = new UdpClient();
 
         try
         {

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -232,7 +232,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         Assert.NotEqual(containerUdpPort, localMappedPort);
 
         var message = Guid.NewGuid().ToString("D");
-        var response = CallUdpEchoServer(container.Hostname, localMappedPort, message);
+        var response = CallUdpEchoServer("127.0.0.1", localMappedPort, message);
         Assert.Equal(message, response);
       }
 

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -229,65 +229,6 @@ namespace DotNet.Testcontainers.Tests.Unit
         Assert.NotEqual(containerPort, container.GetMappedPublicPort("161/udp"));
       }
 
-      [Fact(Skip = "UDP server doesn't work")]
-      public async Task RandomUdpPortBindingUdpServer()
-      {
-        // Given
-        const string containerUdpQualifiedPort = "4001/udp";
-        const ushort containerUdpPort = 4001;
-
-        // Simple Python-based echo server with UDP
-        // https://github.com/vhiribarren/docker-echo-server
-        await using var container = new ContainerBuilder()
-          // .WithImage("docker-hub.artifactory.mocca.yunextraffic.cloud/vhiribarren/echo-server")
-          .WithImage("vhiribarren/echo-server")
-          .WithPortBinding(containerUdpQualifiedPort, true)
-          .Build();
-
-        // When
-        await container.StartAsync()
-          .ConfigureAwait(true);
-
-        // Then
-        var localMappedPort = container.GetMappedPublicPort(containerUdpQualifiedPort);
-        Assert.NotEqual(containerUdpPort, localMappedPort);
-
-        var message = Guid.NewGuid().ToString("D");
-        var response = CallUdpEchoServer("127.0.0.1", localMappedPort, message);
-        // var response = CallUdpEchoServer("172.19.212.239", localMappedPort, message);
-        // response will look like this: "UDP: fb15aa0b4d19 received: <message> from ('<IP>', <Port>)
-        Assert.Contains(message, response);
-      }
-
-      private string CallUdpEchoServer(string serverIP, int serverPort, string message)
-      {
-        // Create a UDP client
-        // UdpClient client = new UdpClient(0, AddressFamily.InterNetwork);
-        UdpClient client = new UdpClient();
-
-        try
-        {
-          // Connect to the server
-          client.Connect(serverIP, serverPort);
-
-          // Send data to the server
-          byte[] sendData = Encoding.ASCII.GetBytes(message);
-          client.Send(sendData, sendData.Length);
-
-          // Receive the response from the server
-          IPEndPoint remoteEndPoint = new IPEndPoint(IPAddress.Any, 0);
-          byte[] receiveData = client.Receive(ref remoteEndPoint);
-          string receivedMessage = Encoding.ASCII.GetString(receiveData);
-
-          return receivedMessage;
-        }
-        finally
-        {
-          // Close the client
-          client.Close();
-        }
-      }
-
       [Fact]
       public async Task BindMountAndCommand()
       {

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -213,6 +213,26 @@ namespace DotNet.Testcontainers.Tests.Unit
       public async Task RandomUdpPortBinding()
       {
         // Given
+        const ushort containerPort = 161;
+
+        await using var container = new ContainerBuilder()
+          .WithImage(CommonImages.Alpine)
+          .WithEntrypoint(CommonCommands.SleepInfinity)
+          .WithPortBinding("161/udp", true)
+          .Build();
+
+        // When
+        await container.StartAsync()
+          .ConfigureAwait(true);
+
+        // Then
+        Assert.NotEqual(containerPort, container.GetMappedPublicPort("161/udp"));
+      }
+
+      [Fact(Skip = "UDP server doesn't work")]
+      public async Task RandomUdpPortBindingUdpServer()
+      {
+        // Given
         const string containerUdpQualifiedPort = "4001/udp";
         const ushort containerUdpPort = 4001;
 
@@ -266,7 +286,6 @@ namespace DotNet.Testcontainers.Tests.Unit
           // Close the client
           client.Close();
         }
-        return string.Empty;
       }
 
       [Fact]

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -233,7 +233,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 
         var message = Guid.NewGuid().ToString("D");
         var response = CallUdpEchoServer("127.0.0.1", localMappedPort, message);
-        Assert.Equal(message, response);
+        // Assert.Equal(message, response);
       }
 
       private string CallUdpEchoServer(string serverIP, int serverPort, string message)

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -171,7 +171,29 @@ namespace DotNet.Testcontainers.Tests.Unit
       }
 
       [Fact]
-      public async Task RandomPortBinding()
+      public async Task RandomUdpPortBinding()
+      {
+        // Given
+        const ushort containerPort = 53;
+
+        const string qualifiedContainerPort = "53/udp";
+
+        await using var container = new ContainerBuilder()
+          .WithImage(CommonImages.Alpine)
+          .WithEntrypoint(CommonCommands.SleepInfinity)
+          .WithPortBinding(qualifiedContainerPort, true)
+          .Build();
+
+        // When
+        await container.StartAsync()
+          .ConfigureAwait(true);
+
+        // Then
+        Assert.NotEqual(containerPort, container.GetMappedPublicPort(qualifiedContainerPort));
+      }
+
+      [Fact]
+      public async Task RandomTcpPortBinding()
       {
         // Given
         const ushort containerPort = 80;
@@ -207,26 +229,6 @@ namespace DotNet.Testcontainers.Tests.Unit
 
         // Then
         Assert.Throws<InvalidOperationException>(() => container.GetMappedPublicPort(443));
-      }
-
-      [Fact]
-      public async Task RandomUdpPortBinding()
-      {
-        // Given
-        const ushort containerPort = 161;
-
-        await using var container = new ContainerBuilder()
-          .WithImage(CommonImages.Alpine)
-          .WithEntrypoint(CommonCommands.SleepInfinity)
-          .WithPortBinding("161/udp", true)
-          .Build();
-
-        // When
-        await container.StartAsync()
-          .ConfigureAwait(true);
-
-        // Then
-        Assert.NotEqual(containerPort, container.GetMappedPublicPort("161/udp"));
       }
 
       [Fact]


### PR DESCRIPTION
## What does this PR do?

This PR fixes #1218 by allowing protocol qualifiers to be specified in `public ushort GetMappedPublicPort(string containerPort)`.

## Why is it important?

UDP port mapping is for example needed for SNMP protocol

## Related issues
- Closes #1218
- Relates #1216

## How to test this PR

Added unit test `RandomUdpPortBinding`
