### PR TITLE
fix: Get sqlcmd utility file path from container instead of const file path

### DIFF
--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -134,11 +134,17 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
         /// <inheritdoc />
         public async Task<bool> UntilAsync(IContainer container)
         {
-            var hasMsSql18Tools = await container.ExecAsync(new[] { "[", "-f" , "/opt/mssql-tools18/bin/sqlcmd", "]" })
+            var msSqlContainer = container as MsSqlContainer;
+            if (msSqlContainer == null)
+            {
+                throw new InvalidOperationException("The container is not a MsSqlContainer.");
+            }
+            
+            var sqlCmdPath = await msSqlContainer.GetSqlCmdPathAsync()
                 .ConfigureAwait(false);
      
             string[] command = [ 
-                hasMsSql18Tools.ExitCode == 0 ? "/opt/mssql-tools18/bin/sqlcmd" : "/opt/mssql-tools/bin/sqlcmd",
+                sqlCmdPath,
                 "-C",
                 "-Q",
                 "SELECT 1;",

--- a/src/Testcontainers.MsSql/MsSqlContainer.cs
+++ b/src/Testcontainers.MsSql/MsSqlContainer.cs
@@ -4,6 +4,10 @@ namespace Testcontainers.MsSql;
 [PublicAPI]
 public sealed class MsSqlContainer : DockerContainer, IDatabaseContainer
 {
+    private static readonly string[] FindSqlCmdFilePath = { "/bin/sh", "-c", "find /opt/mssql-tools*/bin/sqlcmd -type f -print -quit" };
+
+    private readonly Lazy<Task<string>> _lazySqlCmdFilePath;
+
     private readonly MsSqlConfiguration _configuration;
 
     /// <summary>
@@ -13,6 +17,7 @@ public sealed class MsSqlContainer : DockerContainer, IDatabaseContainer
     public MsSqlContainer(MsSqlConfiguration configuration)
         : base(configuration)
     {
+        _lazySqlCmdFilePath = new Lazy<Task<string>>(FindSqlCmdFilePathAsync);
         _configuration = configuration;
     }
 
@@ -32,6 +37,19 @@ public sealed class MsSqlContainer : DockerContainer, IDatabaseContainer
     }
 
     /// <summary>
+    /// Gets the <c>sqlcmd</c> utility file path.
+    /// </summary>
+    /// <remarks>
+    /// The file path represents the path from the container, not from the Docker or test host.
+    /// </remarks>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the <c>sqlcmd</c> utility file path has been found.</returns>
+    public Task<string> GetSqlCmdFilePathAsync(CancellationToken ct = default)
+    {
+        return _lazySqlCmdFilePath.Value;
+    }
+
+    /// <summary>
     /// Executes the SQL script in the MsSql container.
     /// </summary>
     /// <param name="scriptContent">The content of the SQL script to execute.</param>
@@ -41,10 +59,26 @@ public sealed class MsSqlContainer : DockerContainer, IDatabaseContainer
     {
         var scriptFilePath = string.Join("/", string.Empty, "tmp", Guid.NewGuid().ToString("D"), Path.GetRandomFileName());
 
+        var sqlCmdFilePath = await GetSqlCmdFilePathAsync(ct)
+            .ConfigureAwait(false);
+
         await CopyAsync(Encoding.Default.GetBytes(scriptContent), scriptFilePath, Unix.FileMode644, ct)
             .ConfigureAwait(false);
 
-        return await ExecAsync(new[] { "/opt/mssql-tools/bin/sqlcmd", "-b", "-r", "1", "-U", _configuration.Username, "-P", _configuration.Password, "-i", scriptFilePath }, ct)
+        return await ExecAsync(new[] { sqlCmdFilePath, "-C", "-b", "-r", "1", "-U", _configuration.Username, "-P", _configuration.Password, "-i", scriptFilePath }, ct)
             .ConfigureAwait(false);
+    }
+
+    private async Task<string> FindSqlCmdFilePathAsync()
+    {
+        var findSqlCmdFilePathExecResult = await ExecAsync(FindSqlCmdFilePath)
+            .ConfigureAwait(false);
+
+        if (findSqlCmdFilePathExecResult.ExitCode == 0)
+        {
+            return findSqlCmdFilePathExecResult.Stdout.Trim();
+        }
+
+        throw new NotSupportedException("The sqlcmd binary could not be found.");
     }
 }

--- a/src/Testcontainers.MsSql/MsSqlContainer.cs
+++ b/src/Testcontainers.MsSql/MsSqlContainer.cs
@@ -44,7 +44,25 @@ public sealed class MsSqlContainer : DockerContainer, IDatabaseContainer
         await CopyAsync(Encoding.Default.GetBytes(scriptContent), scriptFilePath, Unix.FileMode644, ct)
             .ConfigureAwait(false);
 
-        return await ExecAsync(new[] { "/opt/mssql-tools/bin/sqlcmd", "-b", "-r", "1", "-U", _configuration.Username, "-P", _configuration.Password, "-i", scriptFilePath }, ct)
+        var hasMsSql18Tools = await ExecAsync(new[] { "[", "-f" , "/opt/mssql-tools18/bin/sqlcmd", "]" }, ct)
+            .ConfigureAwait(false);
+
+        var command = new[]
+        {
+            hasMsSql18Tools.ExitCode == 0 ? "/opt/mssql-tools18/bin/sqlcmd" : "/opt/mssql-tools/bin/sqlcmd",
+            "-C",
+            "-b",
+            "-r",
+            "1",
+            "-U",
+            _configuration.Username,
+            "-P",
+            _configuration.Password,
+            "-i",
+            scriptFilePath,
+        };
+        
+        return await ExecAsync(command, ct)
             .ConfigureAwait(false);
     }
 }

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -1,9 +1,16 @@
+using JetBrains.Annotations;
+
 namespace Testcontainers.MsSql;
 
-public sealed class MsSqlContainerTest : IAsyncLifetime
+public abstract class MsSqlContainerTest : IAsyncLifetime
 {
-    private readonly MsSqlContainer _msSqlContainer = new MsSqlBuilder().Build();
+    private readonly MsSqlContainer _msSqlContainer;
 
+    private MsSqlContainerTest(MsSqlContainer msSqlContainer)
+    {
+        _msSqlContainer = msSqlContainer;
+    }
+    
     public Task InitializeAsync()
     {
         return _msSqlContainer.StartAsync();
@@ -42,5 +49,23 @@ public sealed class MsSqlContainerTest : IAsyncLifetime
         // Then
         Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
         Assert.Empty(execResult.Stderr);
+    }
+    
+    [UsedImplicitly]
+    public sealed class MsSqlDefaultConfiguration : MsSqlContainerTest
+    {
+        public MsSqlDefaultConfiguration()
+            : base(new MsSqlBuilder().Build())
+        {
+        }
+    }
+
+    [UsedImplicitly]
+    public sealed class MsSqlWithMsSqlTools18Configuration : MsSqlContainerTest
+    {
+        public MsSqlWithMsSqlTools18Configuration()
+            : base(new MsSqlBuilder().WithImage("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04").Build())
+        {
+        }
     }
 }

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -1,16 +1,14 @@
-using JetBrains.Annotations;
-
 namespace Testcontainers.MsSql;
 
 public abstract class MsSqlContainerTest : IAsyncLifetime
 {
     private readonly MsSqlContainer _msSqlContainer;
 
-    private MsSqlContainerTest(MsSqlContainer msSqlContainer)
+    public MsSqlContainerTest(MsSqlContainer msSqlContainer)
     {
         _msSqlContainer = msSqlContainer;
     }
-    
+
     public Task InitializeAsync()
     {
         return _msSqlContainer.StartAsync();
@@ -50,7 +48,7 @@ public abstract class MsSqlContainerTest : IAsyncLifetime
         Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
         Assert.Empty(execResult.Stderr);
     }
-    
+
     [UsedImplicitly]
     public sealed class MsSqlDefaultConfiguration : MsSqlContainerTest
     {
@@ -61,9 +59,9 @@ public abstract class MsSqlContainerTest : IAsyncLifetime
     }
 
     [UsedImplicitly]
-    public sealed class MsSqlWithMsSqlTools18Configuration : MsSqlContainerTest
+    public sealed class MsSqlTools18Configuration : MsSqlContainerTest
     {
-        public MsSqlWithMsSqlTools18Configuration()
+        public MsSqlTools18Configuration()
             : base(new MsSqlBuilder().WithImage("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04").Build())
         {
         }

--- a/tests/Testcontainers.MsSql.Tests/Usings.cs
+++ b/tests/Testcontainers.MsSql.Tests/Usings.cs
@@ -2,5 +2,6 @@ global using System.Data;
 global using System.Data.Common;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using JetBrains.Annotations;
 global using Microsoft.Data.SqlClient;
 global using Xunit;


### PR DESCRIPTION
## What does this PR do?

It adds a check on the mssql-tools path which changed during 2022-CU14 update.

## Why is it important?

Because from the 2022-CU14 version, Microsoft changed the path to the mssql tools, breaking CI for many folks who have been using the 2022-latest image tag.

## Related issues

- Closes #1220

## Follow-ups

I'm not a fan of duplicating the logic between WaitUntil and the MsSqlContainer :'(