### PR TITLE
feat: Log Docker daemon labels if present

### DIFF
--- a/src/Testcontainers/Clients/DockerApiClient.cs
+++ b/src/Testcontainers/Clients/DockerApiClient.cs
@@ -107,8 +107,19 @@ namespace DotNet.Testcontainers.Clients
         runtimeInfo.AppendLine(dockerInfo.OperatingSystem);
 
         runtimeInfo.Append("  Total Memory: ");
-        runtimeInfo.AppendFormat(CultureInfo.InvariantCulture, "{0:F} {1}", dockerInfo.MemTotal / Math.Pow(1024, byteUnits.Length), byteUnits[byteUnits.Length - 1]);
+        runtimeInfo.AppendLine(String.Format(CultureInfo.InvariantCulture, "{0:F} {1}", dockerInfo.MemTotal / Math.Pow(1024, byteUnits.Length), byteUnits[byteUnits.Length - 1]));
 
+        var labels = dockerInfo.Labels;
+        if (labels != null && labels.Count > 0)
+        {
+          runtimeInfo.AppendLine("  Labels: ");
+
+          foreach (var label in labels)
+          {
+            runtimeInfo.Append("    ");
+            runtimeInfo.AppendLine(label);
+          }
+        }
         Logger.LogInformation("{RuntimeInfo}", runtimeInfo);
       }
       catch(Exception e)


### PR DESCRIPTION
Docker Engine can be configured to have labels.

Configure Docker Desktop: DD settings > Docker daemon

```
{
  "builder": {
    "gc": {
      "defaultKeepStorage": "20GB",
      "enabled": true
    }
  },
  "experimental": false,
  "labels": [
    "who=eddumelendez",
    "from=world"
  ]
}
```

should provide

```
Connected to Docker:
  Host: unix:///var/run/docker.sock
  Server Version: 27.1.1
  Kernel Version: 6.10.2-linuxkit
  API Version: 1.46
  Operating System: Docker Desktop
  Total Memory: 9.71 GB
  Labels: 
    from=world
    who=eddumelendez
```