### PR TITLE
chore: Change global.json roll-forward policy from `latestPatch` to `latestMinor`

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "8.0.200",
-    "rollForward": "latestPatch"
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
## What does this PR do?

This pull request changes the [roll forward policy](https://andrewlock.net/exploring-the-new-rollforward-and-allowprerelease-settings-in-global-json/) from `latestPatch` to `latestMinor`.

## Why is it important?

Contributors can work on Testcontainers with the latest dotnet SDK. Note that it's impossible to compile the projects with the latest SDK (version 8.0.303) and the `latestPatch` policy.

```
dotnet --version
The command could not be loaded, possibly because:
  * You intended to execute a .NET application:
      The application '--version' does not exist.
  * You intended to execute a .NET SDK command:
      A compatible .NET SDK was not found.

Requested SDK version: 8.0.200
global.json file: /Users/0xced/Projects/testcontainers-dotnet/global.json

Installed SDKs:
6.0.424 [/usr/local/share/dotnet/sdk]
8.0.303 [/usr/local/share/dotnet/sdk]

Install the [8.0.200] .NET SDK or update [~/testcontainers-dotnet/global.json] to match an installed SDK.

Learn about SDK resolution:
https://aka.ms/dotnet/sdk-not-found
```

## Related issues

None