### PR TITLE
feat: Improve parsing of Docker image tag version `MatchVersion(Predicate<Version>)`

### DIFF
--- a/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
@@ -99,12 +99,18 @@ namespace DotNet.Testcontainers.Tests.Unit
       Assert.False(result);
     }
 
-    [Fact]
-    public void MatchVersion_ReturnsTrue_WhenVersionMatchesPredicate()
+    [Theory]
+    [InlineData("foo:2", 2, 0, -1, -1)]
+    [InlineData("foo:2-variant", 2, 0, -1, -1)]
+    [InlineData("foo:2.3", 2, 3, -1, -1)]
+    [InlineData("foo:2.3-variant", 2, 3, -1, -1)]
+    [InlineData("foo:2.3.4", 2, 3, 4, -1)]
+    [InlineData("foo:2.3.4-variant", 2, 3, 4, -1)]
+    public void MatchVersion_ReturnsTrue_WhenVersionMatchesPredicate(string image, int major, int minor, int build, int revision)
     {
       // Given
-      Predicate<Version> predicate = v => v.Major == 1 && v.Minor == 0 && v.Build == 0;
-      IImage dockerImage = new DockerImage("foo:1.0.0");
+      Predicate<Version> predicate = v => v.Major == major && v.Minor == minor && v.Build == build && v.Revision == revision;
+      IImage dockerImage = new DockerImage(image);
 
       // When
       var result = dockerImage.MatchVersion(predicate);


### PR DESCRIPTION
## What does this PR do?

This pull request handles major-only version number, e.g. `2` without any dot that `Version.TryParse` doesn't parse. Matching a version was recently introduced in #1213 but did not account for major-only versions which are quite common in Docker image tags.

## Why is it important?

Verifying a version on the major part of the tag version is sometimes enough.

## Related issues

Relates #1213

## How to test this PR

The `MatchVersion_ReturnsTrue_WhenVersionMatchesPredicate` test was updated from a `Fact` to a `Theory` handling many different version number inputs.
