### PR TITLE
feat: Detect CSharp, FSharp and Visual Basic projects

### DIFF
--- a/.cake-scripts/version.cake
+++ b/.cake-scripts/version.cake
@@ -1,4 +1,4 @@
-#addin nuget:?package=Cake.Git&version=2.0.0
+#addin nuget:?package=Cake.Git&version=3.0.0
 
 internal sealed class BuildInformation
 {

--- a/build.cake
+++ b/build.cake
@@ -1,8 +1,8 @@
-#tool nuget:?package=dotnet-sonarscanner&version=5.15.0
+#tool nuget:?package=dotnet-sonarscanner&version=7.1.1
 
-#addin nuget:?package=Cake.Sonar&version=1.1.32
+#addin nuget:?package=Cake.Sonar&version=1.1.33
 
-#addin nuget:?package=Cake.Git&version=3.0.0
+#addin nuget:?package=Cake.Git&version=4.0.0
 
 #load ".cake-scripts/parameters.cake"
 

--- a/build.cake
+++ b/build.cake
@@ -1,8 +1,8 @@
 #tool nuget:?package=dotnet-sonarscanner&version=7.1.1
 
-#addin nuget:?package=Cake.Sonar&version=1.1.33
+#addin nuget:?package=Cake.Sonar&version=1.1.32
 
-#addin nuget:?package=Cake.Git&version=4.0.0
+#addin nuget:?package=Cake.Git&version=3.0.0
 
 #load ".cake-scripts/parameters.cake"
 

--- a/src/Testcontainers/Images/DockerImage.cs
+++ b/src/Testcontainers/Images/DockerImage.cs
@@ -127,13 +127,18 @@ namespace DotNet.Testcontainers.Images
     public bool MatchVersion(Predicate<Version> predicate)
     {
       var versionMatch = Regex.Match(Tag, @"^(\d+)(\.\d+)?(\.\d+)?", RegexOptions.None, TimeSpan.FromSeconds(1));
+
       if (!versionMatch.Success)
+      {
         return false;
+      }
 
       if (Version.TryParse(versionMatch.Value, out var version))
+      {
         return predicate(version);
+      }
 
-      // If the regex matches and Version.TryParse fails then it means it's a major version only (i.e. without any . in the version)
+      // If the Regex matches and Version.TryParse(string?, out Version?) fails then it means it is a major version only (i.e. without any dot separator)
       return predicate(new Version(int.Parse(versionMatch.Groups[1].Value, NumberStyles.None), 0));
     }
 

--- a/tests/Testcontainers.Tests/Unit/Builders/CommonDirectoryPathTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Builders/CommonDirectoryPathTest.cs
@@ -1,6 +1,7 @@
 namespace DotNet.Testcontainers.Tests.Unit
 {
   using System.IO;
+  using DotNet.Testcontainers.Commons;
   using DotNet.Testcontainers.Builders;
   using Xunit;
 
@@ -8,12 +9,16 @@ namespace DotNet.Testcontainers.Tests.Unit
   {
     public static TheoryData<CommonDirectoryPath> CommonDirectoryPaths()
     {
+      using var fsprojFileStream = File.Create(Path.Combine(TestSession.TempDirectoryPath, "Testcontainers.fsproj"));
+      using var vbprojFileStream = File.Create(Path.Combine(TestSession.TempDirectoryPath, "Testcontainers.vbproj"));
       var theoryData = new TheoryData<CommonDirectoryPath>();
       theoryData.Add(CommonDirectoryPath.GetBinDirectory());
       theoryData.Add(CommonDirectoryPath.GetGitDirectory());
       theoryData.Add(CommonDirectoryPath.GetProjectDirectory());
       theoryData.Add(CommonDirectoryPath.GetSolutionDirectory());
       theoryData.Add(CommonDirectoryPath.GetCallerFileDirectory());
+      theoryData.Add(CommonDirectoryPath.GetProjectDirectory(fsprojFileStream.Name));
+      theoryData.Add(CommonDirectoryPath.GetProjectDirectory(vbprojFileStream.Name));
       return theoryData;
     }
 
@@ -28,7 +33,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     public void CommonDirectoryPathNotExists()
     {
       var callerFilePath = Path.GetPathRoot(Directory.GetCurrentDirectory());
-      Assert.Throws<DirectoryNotFoundException>(() => CommonDirectoryPath.GetGitDirectory(callerFilePath));
+      Assert.Throws<DirectoryNotFoundException>(() => CommonDirectoryPath.GetGitDirectory(callerFilePath!));
     }
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
@@ -23,9 +23,9 @@ namespace DotNet.Testcontainers.Tests.Unit
     static DockerEndpointAuthenticationProviderTest()
     {
       _ = Directory.CreateDirectory(CertificatesDirectoryPath);
-      _ = File.Create(Path.Combine(CertificatesDirectoryPath, "ca.pem"));
-      _ = File.Create(Path.Combine(CertificatesDirectoryPath, "cert.pem"));
-      _ = File.Create(Path.Combine(CertificatesDirectoryPath, "key.pem"));
+      using var fileStream1 = File.Create(Path.Combine(CertificatesDirectoryPath, "ca.pem"));
+      using var fileStream2 = File.Create(Path.Combine(CertificatesDirectoryPath, "cert.pem"));
+      using var fileStream3 = File.Create(Path.Combine(CertificatesDirectoryPath, "key.pem"));
     }
 
     [Theory]


### PR DESCRIPTION
## What does this PR do?

The PR extends the `GetProjectDirectory(string)` method. In addition to detecting C# project files, the method now also detects F# and Visual Basic project files.

## Why is it important?

Developers using F# or Visual Basic were not able to use this method.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1217

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
