### PR TITLE
feat: Align `IImage` properties with Docker DSL

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <PackageId>$(AssemblyName)</PackageId>
-    <Version>3.11.0</Version>
+    <Version>4.0.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Product>Testcontainers</Product>

--- a/src/Testcontainers.Pulsar/PulsarContainer.cs
+++ b/src/Testcontainers.Pulsar/PulsarContainer.cs
@@ -56,7 +56,7 @@ public sealed class PulsarContainer : DockerContainer
             "--secret-key",
             PulsarBuilder.SecretKeyFilePath,
             "--subject",
-            PulsarBuilder.Username
+            PulsarBuilder.Username,
         };
 
         if (!Timeout.InfiniteTimeSpan.Equals(expiryTime))

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -80,7 +80,7 @@ namespace DotNet.Testcontainers.Builders
         return Clone(new ContainerConfiguration(image: image));
       }
 
-      return Clone(new ContainerConfiguration(image: new DockerImage(image.Repository, image.Name, image.Tag, TestcontainersSettings.HubImageNamePrefix)));
+      return Clone(new ContainerConfiguration(image: new DockerImage(image.Repository, image.Registry, image.Tag, image.Digest, TestcontainersSettings.HubImageNamePrefix)));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/DockerRegistryAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/DockerRegistryAuthenticationProvider.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Builders
 {
   using System;
   using System.Collections.Concurrent;
-  using System.IO;
   using System.Linq;
   using System.Text.Json;
   using DotNet.Testcontainers.Configurations;

--- a/src/Testcontainers/Builders/RootlessUnixEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/RootlessUnixEndpointAuthenticationProvider.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Builders
 {
   using System;
   using System.IO;
-  using System.Linq;
   using System.Runtime.InteropServices;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
@@ -27,7 +26,7 @@ namespace DotNet.Testcontainers.Builders
     /// <param name="socketPaths">A list of socket paths.</param>
     public RootlessUnixEndpointAuthenticationProvider(params string[] socketPaths)
     {
-      var socketPath = socketPaths.FirstOrDefault(File.Exists);
+      var socketPath = Array.Find(socketPaths, File.Exists);
       DockerEngine = socketPath == null ? null : new Uri("unix://" + socketPath);
     }
 

--- a/src/Testcontainers/Images/DockerImage.cs
+++ b/src/Testcontainers/Images/DockerImage.cs
@@ -1,8 +1,7 @@
-namespace DotNet.Testcontainers.Images
+﻿namespace DotNet.Testcontainers.Images
 {
   using System;
   using System.Globalization;
-  using System.Linq;
   using System.Text.RegularExpressions;
   using JetBrains.Annotations;
 
@@ -14,24 +13,31 @@ namespace DotNet.Testcontainers.Images
 
     private const string NightlyTag = "nightly";
 
+    private static readonly char[] TrimChars = [' ', ':', '/'];
+
     private static readonly Func<string, IImage> GetDockerImage = MatchImage.Match;
 
-    private static readonly char[] TrimChars = { ' ', ':', '/' };
+    [NotNull]
+    private readonly string _repository;
 
-    private static readonly char[] HostnameIdentifierChars = { '.', ':' };
+    [CanBeNull]
+    private readonly string _registry;
 
+    [CanBeNull]
+    private readonly string _tag;
+
+    [CanBeNull]
+    private readonly string _digit;
+
+    [CanBeNull]
     private readonly string _hubImageNamePrefix;
-
-    private readonly Lazy<string> _lazyFullName;
-
-    private readonly Lazy<string> _lazyHostname;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerImage" /> class.
     /// </summary>
     /// <param name="image">The image.</param>
     public DockerImage(IImage image)
-      : this(image.Repository, image.Name, image.Tag)
+      : this(image.Repository, image.Registry, image.Tag, image.Digest)
     {
     }
 
@@ -39,8 +45,7 @@ namespace DotNet.Testcontainers.Images
     /// Initializes a new instance of the <see cref="DockerImage" /> class.
     /// </summary>
     /// <param name="image">The image.</param>
-    /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-    /// <example>"fedora/httpd:version1.0" where "fedora" is the repository, "httpd" the name and "version1.0" the tag.</example>
+    /// <example><c>fedora/httpd:version1.0</c> where <c>fedora/httpd</c> is the repository and <c>version1.0</c> the tag.</example>
     public DockerImage(string image)
       : this(GetDockerImage(image))
     {
@@ -51,65 +56,78 @@ namespace DotNet.Testcontainers.Images
     /// </summary>
     /// <param name="repository">The repository.</param>
     /// <param name="name">The name.</param>
+    [Obsolete("We will remove this construct and replace it with a more efficient implementation. Please use 'DockerImage(string, string = null, string = null, string = null, string = null)' instead. All arguments except for 'repository' (the first) are optional.")]
+    public DockerImage(string repository, string name)
+      : this(string.Join("/", repository, name).Trim('/'))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockerImage" /> class.
+    /// </summary>
+    /// <param name="repository">The repository.</param>
+    /// <param name="name">The name.</param>
     /// <param name="tag">The tag.</param>
+    [Obsolete("We will remove this construct and replace it with a more efficient implementation. Please use 'DockerImage(string, string = null, string = null, string = null, string = null)' instead. All arguments except for 'repository' (the first) are optional.")]
+    public DockerImage(string repository, string name, string tag)
+      : this(string.Join("/", repository, name).Trim('/') + (":" + tag).TrimEnd(':'))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockerImage" /> class.
+    /// </summary>
+    /// <param name="repository">The repository.</param>
+    /// <param name="registry">The registry.</param>
+    /// <param name="tag">The tag.</param>
+    /// <param name="digest">The digest.</param>
     /// <param name="hubImageNamePrefix">The Docker Hub image name prefix.</param>
-    /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-    /// <example>"fedora/httpd:version1.0" where "fedora" is the repository, "httpd" the name and "version1.0" the tag.</example>
+    /// <example><c>fedora/httpd:version1.0</c> where <c>fedora/httpd</c> is the repository and <c>version1.0</c> the tag.</example>
     public DockerImage(
       string repository,
-      string name,
+      string registry = null,
       string tag = null,
+      string digest = null,
       string hubImageNamePrefix = null)
     {
       _ = Guard.Argument(repository, nameof(repository))
         .NotNull()
-        .NotUppercase();
-
-      _ = Guard.Argument(name, nameof(name))
-        .NotNull()
         .NotEmpty()
         .NotUppercase();
 
+      var defaultTag = tag == null && digest == null ? LatestTag : null;
+
+      _repository = TrimOrDefault(repository);
+      _registry = TrimOrDefault(registry);
+      _tag = TrimOrDefault(tag, defaultTag);
+      _digit = TrimOrDefault(digest);
       _hubImageNamePrefix = TrimOrDefault(hubImageNamePrefix);
-
-      Repository = TrimOrDefault(repository, repository);
-      Name = TrimOrDefault(name, name);
-      Tag = TrimOrDefault(tag, LatestTag);
-
-      _lazyFullName = new Lazy<string>(() =>
-      {
-        var imageComponents = new[] { _hubImageNamePrefix, Repository, Name }
-          .Where(imageComponent => !string.IsNullOrEmpty(imageComponent));
-
-        return string.Join("/", imageComponents) + ":" + Tag;
-      });
-
-      _lazyHostname = new Lazy<string>(() =>
-      {
-        var firstSegmentOfRepository = new[] { _hubImageNamePrefix, Repository }
-          .Where(imageComponent => !string.IsNullOrEmpty(imageComponent))
-          .DefaultIfEmpty(string.Empty)
-          .First()
-          .Split('/')[0];
-
-        return firstSegmentOfRepository.IndexOfAny(HostnameIdentifierChars) >= 0 ? firstSegmentOfRepository : null;
-      });
     }
 
     /// <inheritdoc />
-    public string Repository { get; }
+    public string Repository => _repository;
 
     /// <inheritdoc />
-    public string Name { get; }
+    public string Registry => string.IsNullOrEmpty(_hubImageNamePrefix) ? _registry : _hubImageNamePrefix;
 
     /// <inheritdoc />
-    public string Tag { get; }
+    public string Tag => _tag;
 
     /// <inheritdoc />
-    public string FullName => _lazyFullName.Value;
+    public string Digest => _digit;
 
     /// <inheritdoc />
-    public string GetHostname() => _lazyHostname.Value;
+    public string FullName => $"{Registry}/{Repository}:{Tag}".Trim(TrimChars);
+
+    /// <inheritdoc />
+    [Obsolete("We will remove this property, it does not follow the DSL. Use the 'Repository' property instead.")]
+    public string Name => GetBackwardsCompatibleName();
+
+    /// <inheritdoc />
+    public string GetHostname()
+    {
+      return Registry;
+    }
 
     /// <inheritdoc />
     public bool MatchLatestOrNightly()
@@ -126,6 +144,11 @@ namespace DotNet.Testcontainers.Images
     /// <inheritdoc />
     public bool MatchVersion(Predicate<Version> predicate)
     {
+      if (Tag == null)
+      {
+        return false;
+      }
+
       var versionMatch = Regex.Match(Tag, "^(\\d+)(\\.\\d+)?(\\.\\d+)?", RegexOptions.None, TimeSpan.FromSeconds(1));
 
       if (!versionMatch.Success)
@@ -142,7 +165,14 @@ namespace DotNet.Testcontainers.Images
       return predicate(new Version(int.Parse(versionMatch.Groups[1].Value, NumberStyles.None), 0));
     }
 
-    private static string TrimOrDefault(string value, string defaultValue = default)
+    private string GetBackwardsCompatibleName()
+    {
+      // The last index will never be a `/`, we trim it in the constructor.
+      var lastIndex = _repository.LastIndexOf('/');
+      return lastIndex == -1 ? _repository : _repository.Substring(lastIndex + 1);
+    }
+
+    private static string TrimOrDefault(string value, string defaultValue = null)
     {
       return string.IsNullOrEmpty(value) ? defaultValue : value.Trim(TrimChars);
     }

--- a/src/Testcontainers/Images/FutureDockerImage.cs
+++ b/src/Testcontainers/Images/FutureDockerImage.cs
@@ -39,12 +39,12 @@ namespace DotNet.Testcontainers.Images
     }
 
     /// <inheritdoc />
-    public string Name
+    public string Registry
     {
       get
       {
         ThrowIfResourceNotFound();
-        return _configuration.Image.Name;
+        return _configuration.Image.Registry;
       }
     }
 
@@ -59,12 +59,32 @@ namespace DotNet.Testcontainers.Images
     }
 
     /// <inheritdoc />
+    public string Digest
+    {
+      get
+      {
+        ThrowIfResourceNotFound();
+        return _configuration.Image.Digest;
+      }
+    }
+
+    /// <inheritdoc />
     public string FullName
     {
       get
       {
         ThrowIfResourceNotFound();
         return _configuration.Image.FullName;
+      }
+    }
+
+    /// <inheritdoc />
+    public string Name
+    {
+      get
+      {
+        ThrowIfResourceNotFound();
+        return _configuration.Image.Name;
       }
     }
 

--- a/src/Testcontainers/Images/IImage.cs
+++ b/src/Testcontainers/Images/IImage.cs
@@ -16,16 +16,22 @@ namespace DotNet.Testcontainers.Images
     string Repository { get; }
 
     /// <summary>
-    /// Gets the name.
+    /// Gets the registry.
     /// </summary>
-    [NotNull]
-    string Name { get; }
+    [CanBeNull]
+    string Registry { get; }
 
     /// <summary>
     /// Gets the tag.
     /// </summary>
-    [NotNull]
+    [CanBeNull]
     string Tag { get; }
+
+    /// <summary>
+    /// Gets the digest.
+    /// </summary>
+    [CanBeNull]
+    string Digest { get; }
 
     /// <summary>
     /// Gets the full image name.
@@ -35,6 +41,13 @@ namespace DotNet.Testcontainers.Images
     /// </remarks>
     [NotNull]
     string FullName { get; }
+
+    /// <summary>
+    /// Gets the name.
+    /// </summary>
+    [NotNull]
+    [Obsolete("We will remove this property, it does not follow the DSL. Use the 'Repository' property instead.")]
+    string Name { get; }
 
     /// <summary>
     /// Gets the registry hostname.

--- a/src/Testcontainers/Images/MatchImage.cs
+++ b/src/Testcontainers/Images/MatchImage.cs
@@ -1,6 +1,7 @@
 namespace DotNet.Testcontainers.Images
 {
   using System;
+  using System.Globalization;
   using System.Text.RegularExpressions;
 
   internal static class MatchImage
@@ -11,7 +12,13 @@ namespace DotNet.Testcontainers.Images
         .NotNull()
         .NotEmpty();
 
+      const string invalidReferenceFormat = "Error parsing reference: '{0}' is not a valid repository/tag.";
+
       var referenceMatch = ReferenceRegex.Instance.Match(image);
+
+      _ = Guard.Argument(referenceMatch, nameof(image))
+        .ThrowIf(argument => !argument.Value.Success, argument => new ArgumentException(string.Format(CultureInfo.InvariantCulture, invalidReferenceFormat, image), argument.Name));
+
       var remoteName = referenceMatch.Groups["remote_name"].Value;
       var tag = referenceMatch.Groups["tag"].Value;
       var digest = referenceMatch.Groups["digest"].Value;

--- a/src/Testcontainers/Images/MatchImage.cs
+++ b/src/Testcontainers/Images/MatchImage.cs
@@ -1,37 +1,48 @@
 namespace DotNet.Testcontainers.Images
 {
   using System;
-  using System.Linq;
+  using System.Text.RegularExpressions;
 
   internal static class MatchImage
   {
-    private static readonly char[] SlashSeparator = { '/' };
-
-    private static readonly char[] ColonSeparator = { ':' };
-
     public static IImage Match(string image)
     {
       _ = Guard.Argument(image, nameof(image))
         .NotNull()
         .NotEmpty();
 
-      var imageComponents = image.Split(SlashSeparator, StringSplitOptions.RemoveEmptyEntries);
+      var referenceMatch = ReferenceRegex.Instance.Match(image);
+      var remoteName = referenceMatch.Groups["remote_name"].Value;
+      var tag = referenceMatch.Groups["tag"].Value;
+      var digest = referenceMatch.Groups["digest"].Value;
 
-      var registry = string.Join("/", imageComponents.Take(imageComponents.Length - 1));
+      // https://github.com/distribution/reference/blob/8c942b0459dfdcc5b6685581dd0a5a470f615bff/normalize.go#L146-L191
+      var slices = remoteName.Split(['/'], 2);
 
-      imageComponents = imageComponents[imageComponents.Length - 1].Split(ColonSeparator, StringSplitOptions.RemoveEmptyEntries);
+      // The following part does not implement the entire Go implementation. It does
+      // not resolve or set the default domain and repository prefix. This is not
+      // necessary at the moment, and it is something we can address later.
+      var (registry, repository) = slices.Length == 2 && slices[0].LastIndexOfAny(['.', ':']) > -1 ? (slices[0], slices[1]) : (null, remoteName);
+      return new DockerImage(repository, registry, tag, digest);
+    }
 
-      if (2.Equals(imageComponents.Length))
+    // The regular expression used here is taken from the Go implementation:
+    // https://github.com/distribution/reference/blob/8c942b0459dfdcc5b6685581dd0a5a470f615bff/reference.go.
+    private sealed class ReferenceRegex : Regex
+    {
+      private const string Pattern = "^(?<remote_name>(?:(?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))*|\\[(?:[a-fA-F0-9:]+)\\])(?::[0-9]+)?\\/)?[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*(?:\\/[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*)*)(?::(?<tag>[\\w][\\w.-]{0,127}))?(?:@(?<digest>[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][0-9A-Fa-f]{32,}))?$";
+
+      static ReferenceRegex()
       {
-        return new DockerImage(registry, imageComponents[0], imageComponents[1]);
       }
 
-      if (1.Equals(imageComponents.Length))
+      private ReferenceRegex()
+        : base(Pattern, RegexOptions.Compiled, TimeSpan.FromSeconds(1))
       {
-        return new DockerImage(registry, imageComponents[0], string.Empty);
       }
 
-      throw new ArgumentException("Cannot parse image: " + image, nameof(image));
+      public static Regex Instance { get; }
+        = new ReferenceRegex();
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixture.cs
@@ -3,24 +3,38 @@ namespace DotNet.Testcontainers.Tests.Fixtures
   using DotNet.Testcontainers.Images;
   using Xunit;
 
-  public sealed class DockerImageFixture : TheoryData<DockerImageFixtureSerializable, string>
+  public sealed class DockerImageFixture : TheoryData<DockerImageFixtureSerializable, string, string>
   {
+    private const string FooBarBaz = "foo/bar/baz";
+    private const string BarBaz = "bar/baz";
+    private const string Baz = "baz";
+    private const string FedoraHttpd = "fedora/httpd";
+    private const string LatestTag = "latest";
+    private const string SemVerTag = "1.0.0";
+    private const string CustomTag1 = "version1.0";
+    private const string CustomTag2 = "version1.0.test";
+    private const string DotSeparatorRegistry = "myregistry.azurecr.io";
+    private const string PortSeparatorRegistry = "myregistry:5000";
+    private const string Digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
     public DockerImageFixture()
     {
-      Add(new DockerImageFixtureSerializable(new DockerImage("baz/foo", "bar", "1.0.0")), "baz/foo/bar:1.0.0");
-      Add(new DockerImageFixtureSerializable(new DockerImage("baz/foo", "bar", string.Empty)), "baz/foo/bar");
-      Add(new DockerImageFixtureSerializable(new DockerImage("baz/foo", "bar", string.Empty)), "baz/foo/bar:latest");
-      Add(new DockerImageFixtureSerializable(new DockerImage("foo", "bar", "1.0.0")), "foo/bar:1.0.0");
-      Add(new DockerImageFixtureSerializable(new DockerImage("foo", "bar", string.Empty)), "foo/bar");
-      Add(new DockerImageFixtureSerializable(new DockerImage("foo", "bar", string.Empty)), "foo/bar:latest");
-      Add(new DockerImageFixtureSerializable(new DockerImage(string.Empty, "bar", "1.0.0")), "bar:1.0.0");
-      Add(new DockerImageFixtureSerializable(new DockerImage(string.Empty, "bar", string.Empty)), "bar:latest");
-      Add(new DockerImageFixtureSerializable(new DockerImage("myregistry.azurecr.io/baz/foo", "bar", "1.0.0")), "myregistry.azurecr.io/baz/foo/bar:1.0.0");
-      Add(new DockerImageFixtureSerializable(new DockerImage("myregistry.azurecr.io/baz/foo", "bar", string.Empty)), "myregistry.azurecr.io/baz/foo/bar");
-      Add(new DockerImageFixtureSerializable(new DockerImage("myregistry.azurecr.io/baz/foo", "bar", string.Empty)), "myregistry.azurecr.io/baz/foo/bar:latest");
-      Add(new DockerImageFixtureSerializable(new DockerImage("fedora", "httpd", "version1.0.test")), "fedora/httpd:version1.0.test");
-      Add(new DockerImageFixtureSerializable(new DockerImage("fedora", "httpd", "version1.0")), "fedora/httpd:version1.0");
-      Add(new DockerImageFixtureSerializable(new DockerImage("myregistryhost:5000/fedora", "httpd", "version1.0")), "myregistryhost:5000/fedora/httpd:version1.0");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, null, SemVerTag, null)), $"{FooBarBaz}:{SemVerTag}", $"{FooBarBaz}:{SemVerTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, null, null, null)), FooBarBaz, $"{FooBarBaz}:{LatestTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, null, null, null)), $"{FooBarBaz}:{LatestTag}", $"{FooBarBaz}:{LatestTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(BarBaz, null, SemVerTag, null)), $"{BarBaz}:{SemVerTag}", $"{BarBaz}:{SemVerTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(BarBaz, null, null, null)), BarBaz, $"{BarBaz}:{LatestTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(BarBaz, null, null, null)), $"{BarBaz}:{LatestTag}", $"{BarBaz}:{LatestTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(Baz, null, SemVerTag, null)), $"{Baz}:{SemVerTag}", $"{Baz}:{SemVerTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(Baz, null, null, null)), $"{Baz}:{LatestTag}", $"{Baz}:{LatestTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, DotSeparatorRegistry, SemVerTag, null)), $"{DotSeparatorRegistry}/{FooBarBaz}:{SemVerTag}", $"{DotSeparatorRegistry}/{FooBarBaz}:{SemVerTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, DotSeparatorRegistry, null, null)), $"{DotSeparatorRegistry}/{FooBarBaz}", $"{DotSeparatorRegistry}/{FooBarBaz}:{LatestTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, DotSeparatorRegistry, null, null)), $"{DotSeparatorRegistry}/{FooBarBaz}:{LatestTag}", $"{DotSeparatorRegistry}/{FooBarBaz}:{LatestTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FedoraHttpd, null, CustomTag1, null)), $"{FedoraHttpd}:{CustomTag1}", $"{FedoraHttpd}:{CustomTag1}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FedoraHttpd, null, CustomTag2, null)), $"{FedoraHttpd}:{CustomTag2}", $"{FedoraHttpd}:{CustomTag2}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FedoraHttpd, PortSeparatorRegistry, CustomTag1, null)), $"{PortSeparatorRegistry}/{FedoraHttpd}:{CustomTag1}", $"{PortSeparatorRegistry}/{FedoraHttpd}:{CustomTag1}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, DotSeparatorRegistry, SemVerTag, Digest)), $"{DotSeparatorRegistry}/{FooBarBaz}:{SemVerTag}@{Digest}", $"{DotSeparatorRegistry}/{FooBarBaz}:{SemVerTag}@{Digest}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, DotSeparatorRegistry, null, Digest)), $"{DotSeparatorRegistry}/{FooBarBaz}@{Digest}", $"{DotSeparatorRegistry}/{FooBarBaz}@{Digest}");
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixtureSerializable.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixtureSerializable.cs
@@ -19,16 +19,18 @@ namespace DotNet.Testcontainers.Tests.Fixtures
     public void Deserialize(IXunitSerializationInfo info)
     {
       var repository = info.GetValue<string>("Repository");
-      var name = info.GetValue<string>("Name");
+      var registry = info.GetValue<string>("Registry");
       var tag = info.GetValue<string>("Tag");
-      Image = new DockerImage(repository, name, tag);
+      var digest = info.GetValue<string>("Digest");
+      Image = new DockerImage(repository, registry, tag, digest);
     }
 
     public void Serialize(IXunitSerializationInfo info)
     {
       info.AddValue("Repository", Image.Repository);
-      info.AddValue("Name", Image.Name);
+      info.AddValue("Registry", Image.Registry);
       info.AddValue("Tag", Image.Tag);
+      info.AddValue("Digest", Image.Digest);
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Images/HealthCheckFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/HealthCheckFixture.cs
@@ -17,11 +17,15 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
     public string Repository => _image.Repository;
 
-    public string Name => _image.Name;
+    public string Registry => _image.Registry;
 
     public string Tag => _image.Tag;
 
+    public string Digest => _image.Digest;
+
     public string FullName => _image.FullName;
+
+    public string Name => _image.Name;
 
     public string GetHostname()
     {

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
@@ -45,13 +45,13 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [Theory]
-    [InlineData("", "docker", "stable")]
-    [InlineData("fedora", "httpd", "1.0")]
-    [InlineData("foo/bar", "baz", "1.0.0")]
-    public void GetHostnameFromHubImageNamePrefix(string repository, string name, string tag)
+    [InlineData("baz/foo/bar", null)]
+    [InlineData("baz/foo/bar", "")]
+    [InlineData("baz/foo/bar", "1.0.0")]
+    public void GetHostnameFromHubImageNamePrefix(string repository, string tag)
     {
       const string hubImageNamePrefix = "myregistry.azurecr.io";
-      IImage image = new DockerImage(repository, name, tag, hubImageNamePrefix);
+      IImage image = new DockerImage(repository, null, tag, null, hubImageNamePrefix);
       Assert.Equal(hubImageNamePrefix, image.GetHostname());
     }
 

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
@@ -34,10 +34,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     [InlineData("fedora/httpd:version1.0", null)]
     [InlineData("myregistryhost:5000/fedora/httpd:version1.0", "myregistryhost:5000")]
     [InlineData("myregistryhost:5000/httpd:version1.0", "myregistryhost:5000")]
-    [InlineData("baz/.foo/bar:1.0.0", null)]
-    [InlineData("baz/:foo/bar:1.0.0", null)]
     [InlineData("myregistry.azurecr.io/baz.foo/bar:1.0.0", "myregistry.azurecr.io")]
-    [InlineData("myregistry.azurecr.io/baz:foo/bar:1.0.0", "myregistry.azurecr.io")]
     public void GetHostnameFromDockerImage(string dockerImageName, string hostname)
     {
       IImage image = new DockerImage(dockerImageName);
@@ -58,7 +55,9 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public void ShouldGetDefaultDockerRegistryAuthenticationConfiguration()
     {
-      var authenticationProvider = new DockerRegistryAuthenticationProvider(DockerConfig.Instance, NullLogger.Instance);
+      // Make sure the auth provider does not accidentally read the user's `config.json` file.
+      ICustomConfiguration customConfiguration = new PropertiesFileConfiguration(new[] { "docker.config=" + Path.Combine("C:", "CON") });
+      var authenticationProvider = new DockerRegistryAuthenticationProvider(new DockerConfig(customConfiguration), NullLogger.Instance);
       Assert.Equal(default(DockerRegistryAuthenticationConfiguration), authenticationProvider.GetAuthConfig("index.docker.io"));
     }
 

--- a/tests/Testcontainers.Tests/Unit/Configurations/ResourcePropertiesTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/ResourcePropertiesTest.cs
@@ -99,9 +99,11 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       // Then
       Assert.Throws<InvalidOperationException>(() => image.Repository);
-      Assert.Throws<InvalidOperationException>(() => image.Name);
+      Assert.Throws<InvalidOperationException>(() => image.Registry);
       Assert.Throws<InvalidOperationException>(() => image.Tag);
+      Assert.Throws<InvalidOperationException>(() => image.Digest);
       Assert.Throws<InvalidOperationException>(() => image.FullName);
+      Assert.Throws<InvalidOperationException>(() => image.Name);
       Assert.Throws<InvalidOperationException>(() => image.GetHostname());
     }
 

--- a/tests/Testcontainers.Tests/Unit/GuardTest.cs
+++ b/tests/Testcontainers.Tests/Unit/GuardTest.cs
@@ -12,7 +12,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         [Fact]
         public void IfNull()
         {
-          var exception = Record.Exception(() => Guard.Argument((object)null, nameof(IfNull)).Null());
+          var exception = Record.Exception(() => Guard.Argument<object>(null, nameof(IfNull)).Null());
           Assert.Null(exception);
         }
 
@@ -36,7 +36,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         [Fact]
         public void IfNull()
         {
-          Assert.Throws<ArgumentException>(() => Guard.Argument((object)null, nameof(IfNull)).NotNull());
+          Assert.Throws<ArgumentException>(() => Guard.Argument<object>(null, nameof(IfNull)).NotNull());
         }
 
         [Fact]

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -130,9 +130,9 @@ namespace DotNet.Testcontainers.Tests.Unit
       Assert.True(DockerCli.ResourceExists(DockerCli.DockerResource.Image, tag1.FullName));
       Assert.True(DockerCli.ResourceExists(DockerCli.DockerResource.Image, tag2.FullName));
       Assert.NotNull(imageFromDockerfileBuilder.Repository);
-      Assert.NotNull(imageFromDockerfileBuilder.Name);
       Assert.NotNull(imageFromDockerfileBuilder.Tag);
       Assert.NotNull(imageFromDockerfileBuilder.FullName);
+      Assert.NotNull(imageFromDockerfileBuilder.Name);
       Assert.Null(imageFromDockerfileBuilder.GetHostname());
     }
   }

--- a/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
@@ -12,7 +12,6 @@ namespace DotNet.Testcontainers.Tests.Unit
     {
       Assert.Throws<ArgumentException>(() => new DockerImage((string)null));
       Assert.Throws<ArgumentException>(() => new DockerImage(null, null));
-      Assert.Throws<ArgumentException>(() => new DockerImage("fedora", null));
     }
 
     [Fact]
@@ -55,9 +54,11 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       // Then
       Assert.Equal(expected.Repository, dockerImage.Repository);
-      Assert.Equal(expected.Name, dockerImage.Name);
+      Assert.Equal(expected.Registry, dockerImage.Registry);
       Assert.Equal(expected.Tag, dockerImage.Tag);
+      Assert.Equal(expected.Digest, dockerImage.Digest);
       Assert.Equal(expected.FullName, dockerImage.FullName);
+      Assert.Equal(expected.Name, dockerImage.Name);
     }
 
     [Fact]

--- a/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
@@ -52,21 +52,23 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     [Theory]
     [ClassData(typeof(DockerImageFixture))]
-    public void WhenImageNameGetsAssigned(DockerImageFixtureSerializable serializable, string fullName)
+    public void WhenImageNameGetsAssigned(DockerImageFixtureSerializable serializable, string image, string fullName)
     {
       // Given
       var expected = serializable.Image;
 
       // When
-      IImage dockerImage = new DockerImage(fullName);
+      IImage actual = new DockerImage(image);
 
       // Then
-      Assert.Equal(expected.Repository, dockerImage.Repository);
-      Assert.Equal(expected.Registry, dockerImage.Registry);
-      Assert.Equal(expected.Tag, dockerImage.Tag);
-      Assert.Equal(expected.Digest, dockerImage.Digest);
-      Assert.Equal(expected.FullName, dockerImage.FullName);
-      Assert.Equal(expected.Name, dockerImage.Name);
+      Assert.Equal(expected.Repository, actual.Repository);
+      Assert.Equal(expected.Registry, actual.Registry);
+      Assert.Equal(expected.Tag, actual.Tag);
+      Assert.Equal(expected.Digest, actual.Digest);
+      Assert.Equal(expected.FullName, actual.FullName);
+      Assert.Equal(expected.Name, actual.Name);
+      // Assert.Equal(fullName, expected.FullName);
+      // Assert.Equal(fullName, actual.FullName);
     }
 
     [Fact]

--- a/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
@@ -34,6 +34,14 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [Theory]
+    [InlineData("baz/.foo/bar:1.0.0")]
+    [InlineData("baz/:foo/bar:1.0.0")]
+    public void ShouldThrowArgumentExceptionIfImageIsInvalidReferenceFormat(string image)
+    {
+      Assert.Throws<ArgumentException>(() => new DockerImage(image));
+    }
+
+    [Theory]
     [InlineData("bar:LATEST")]
     [InlineData("foo/bar:LATEST")]
     public void ShouldNotThrowArgumentExceptionIfImageTagHasUppercaseCharacters(string image)

--- a/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
@@ -52,7 +52,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     [Theory]
     [ClassData(typeof(DockerImageFixture))]
-    public void WhenImageNameGetsAssigned(DockerImageFixtureSerializable serializable, string image, string fullName)
+    public void WhenImageNameGetsAssigned(DockerImageFixtureSerializable serializable, string image, string _)
     {
       // Given
       var expected = serializable.Image;
@@ -67,7 +67,6 @@ namespace DotNet.Testcontainers.Tests.Unit
       Assert.Equal(expected.Digest, actual.Digest);
       Assert.Equal(expected.FullName, actual.FullName);
       Assert.Equal(expected.Name, actual.Name);
-      // Assert.Equal(fullName, expected.FullName);
       // Assert.Equal(fullName, actual.FullName);
     }
 


### PR DESCRIPTION
## What does this PR do?

The PR updates the `IImage` and `DockerImage` implementations. It improves parsing and resolving the reference format, using parts of the official Go implementation. The table below shows the changes:

|  | Actual | Expected |
|---|---|---|
| Registry | - | myregistryhost:5000 |
| Repository | myregistryhost:5000/fedora | fedora/httpd |
| Name | httpd | - |
| Tag | version1.0 | version1.0 |
| Digest | - | sha256:37a3b014d320... |
| GetHostname() | myregistryhost:5000 | myregistryhost:5000 |

The `Registry` and `Digest` properties have been added to the interface. The `Name` property is marked obsolete and will be removed in the next minor version. The `Repository` property now resolves the correct value from the reference format according to the Docker DSL.

I’ve marked all obsolete parts and provided guidance on how to transition to the new interface. I tried to make the transition as smooth as possible, but relying on the `Repository` property might cause issues since it now resolves a different value than before.

## Why is it important?

These changes align with other Testcontainers language implementations and address inconsistent APIs and incorrect DSL.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #740
- Closes #962
- Relates #1249

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
