### PR TITLE
Bump Azurite to 3.31.0

### DIFF
--- a/src/Testcontainers.Azurite/AzuriteBuilder.cs
+++ b/src/Testcontainers.Azurite/AzuriteBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.Azurite;
 [PublicAPI]
 public sealed class AzuriteBuilder : ContainerBuilder<AzuriteBuilder, AzuriteContainer, AzuriteConfiguration>
 {
-    public const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.28.0";
+    public const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.31.0";
 
     public const ushort BlobPort = 10000;
 


### PR DESCRIPTION
## What does this PR do?

Bump to the latest (June 2024) release of Azurite image.

## Why is it important?

Our renovatebot is bumping the Azure.Storage.Blobs package to 12.21.2, which is incompatible with the 3.28.0 azurite. Keeping Azure client packages up-to-date is kind of important to not get far behind with the risk of losing support for your API version in Azure.

## Related issues

-

## How to test this PR

Regression test; using latest Azure (eg Storage.Blobs) client package.

## Follow-ups

Any way we can set up smth like renovatebot on this project itself, to keep packages up-to-date more automatically?
