### PR TITLE
feat: Change visibility of `AccountName` and `AccountKey` to public, move to `AzuriteBuilder`

### DIFF
--- a/src/Testcontainers.Azurite/AzuriteBuilder.cs
+++ b/src/Testcontainers.Azurite/AzuriteBuilder.cs
@@ -12,6 +12,10 @@ public sealed class AzuriteBuilder : ContainerBuilder<AzuriteBuilder, AzuriteCon
 
     public const ushort TablePort = 10002;
 
+    public const string AccountName = "devstoreaccount1";
+
+    public const string AccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
     private static readonly ISet<AzuriteService> EnabledServices = new HashSet<AzuriteService>();
 
     static AzuriteBuilder()

--- a/src/Testcontainers.Azurite/AzuriteContainer.cs
+++ b/src/Testcontainers.Azurite/AzuriteContainer.cs
@@ -4,10 +4,6 @@ namespace Testcontainers.Azurite;
 [PublicAPI]
 public sealed class AzuriteContainer : DockerContainer
 {
-    private const string AccountName = "devstoreaccount1";
-
-    private const string AccountKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
-
     /// <summary>
     /// Initializes a new instance of the <see cref="AzuriteContainer" /> class.
     /// </summary>
@@ -25,11 +21,11 @@ public sealed class AzuriteContainer : DockerContainer
     {
         var properties = new Dictionary<string, string>();
         properties.Add("DefaultEndpointsProtocol", Uri.UriSchemeHttp);
-        properties.Add("AccountName", AccountName);
-        properties.Add("AccountKey", AccountKey);
-        properties.Add("BlobEndpoint", new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.BlobPort), AccountName).ToString());
-        properties.Add("QueueEndpoint", new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.QueuePort), AccountName).ToString());
-        properties.Add("TableEndpoint", new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.TablePort), AccountName).ToString());
+        properties.Add("AccountName", AzuriteBuilder.AccountName);
+        properties.Add("AccountKey", AzuriteBuilder.AccountKey);
+        properties.Add("BlobEndpoint", new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.BlobPort), AzuriteBuilder.AccountName).ToString());
+        properties.Add("QueueEndpoint", new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.QueuePort), AzuriteBuilder.AccountName).ToString());
+        properties.Add("TableEndpoint", new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.TablePort), AzuriteBuilder.AccountName).ToString());
         return string.Join(";", properties.Select(property => string.Join("=", property.Key, property.Value)));
     }
 }


### PR DESCRIPTION
## What does this PR do?

The visiblity of AccountName and AccountKey are private in AzuriteContainer. This makes it difficult to construct a custom connection string if your AzuriteContainer is on a network. 

## Why is it important?

This helps the consumer to construct a connection string.

## Related issues

- Closes #1238 

## How to test this PR

As this widened the visibility of two variables, risk is low. The solution compiled and all tests ran.

