### PR TITLE
feat: Update Azurite image version to 3.32.0

### DIFF
--- a/src/Testcontainers.Azurite/AzuriteBuilder.cs
+++ b/src/Testcontainers.Azurite/AzuriteBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.Azurite;
 [PublicAPI]
 public sealed class AzuriteBuilder : ContainerBuilder<AzuriteBuilder, AzuriteContainer, AzuriteConfiguration>
 {
-    public const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.28.0";
+    public const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.32.0";
 
     public const ushort BlobPort = 10000;
 


### PR DESCRIPTION
## What does this PR do?

This PR updates Azurite version from `3.28.0` to `3.32.0`

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

This change is needed to support the Azurite/Azure Storage API version 2024-11-04, which is required by `Azure.Storage.Blobs` version >= `12.20.0`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
