### PR TITLE
fix: Do not run reusable resource tests in parallel

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,11 +15,11 @@
         <PackageVersion Include="SSH.NET" Version="2023.0.0"/>
         <PackageVersion Include="System.Text.Json" Version="6.0.9"/>
         <!-- Unit and integration test dependencies: -->
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.2.0"/>
-        <PackageVersion Include="coverlet.collector" Version="6.0.1"/>
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7"/>
-        <PackageVersion Include="xunit" Version="2.7.0"/>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.9.1"/>
+        <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageVersion Include="xunit" Version="2.9.0"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->
         <PackageVersion Include="Apache.NMS.ActiveMQ" Version="2.1.0"/>
         <PackageVersion Include="ArangoDBNetStandard" Version="2.0.1"/>

--- a/build.cake
+++ b/build.cake
@@ -84,6 +84,7 @@ Task("Tests")
     Filter = param.TestFilter,
     ResultsDirectory = param.Paths.Directories.TestResultsDirectoryPath,
     ArgumentCustomization = args => args
+      .AppendSwitchQuoted("--blame-hang-timeout", "5m")
   });
 });
 

--- a/src/Testcontainers/Clients/DockerApiClient.cs
+++ b/src/Testcontainers/Clients/DockerApiClient.cs
@@ -4,6 +4,7 @@ namespace DotNet.Testcontainers.Clients
   using System.Collections.Concurrent;
   using System.Collections.Generic;
   using System.Globalization;
+  using System.Linq;
   using System.Text;
   using System.Threading;
   using System.Threading.Tasks;
@@ -107,18 +108,14 @@ namespace DotNet.Testcontainers.Clients
         runtimeInfo.AppendLine(dockerInfo.OperatingSystem);
 
         runtimeInfo.Append("  Total Memory: ");
-        runtimeInfo.AppendLine(string.Format(CultureInfo.InvariantCulture, "{0:F} {1}", dockerInfo.MemTotal / Math.Pow(1024, byteUnits.Length), byteUnits[byteUnits.Length - 1]));
+        runtimeInfo.AppendFormat(CultureInfo.InvariantCulture, "{0:F} {1}", dockerInfo.MemTotal / Math.Pow(1024, byteUnits.Length), byteUnits[byteUnits.Length - 1]);
 
         var labels = dockerInfo.Labels;
         if (labels != null && labels.Count > 0)
         {
+          runtimeInfo.AppendLine();
           runtimeInfo.AppendLine("  Labels: ");
-
-          foreach (var label in labels)
-          {
-            runtimeInfo.Append("    ");
-            runtimeInfo.AppendLine(label);
-          }
+          runtimeInfo.Append(string.Join(Environment.NewLine, labels.Select(label => "    " + label)));
         }
         Logger.LogInformation("{RuntimeInfo}", runtimeInfo);
       }

--- a/src/Testcontainers/Logger.cs
+++ b/src/Testcontainers/Logger.cs
@@ -106,7 +106,8 @@ namespace DotNet.Testcontainers
     {
       if (IsEnabled(logLevel))
       {
-        Console.Out.WriteLine("[testcontainers.org {0:hh\\:mm\\:ss\\.ff}] {1}", _stopwatch.Elapsed, formatter.Invoke(state, exception));
+        var message = exception == null ? formatter.Invoke(state, null) : string.Join(Environment.NewLine, formatter.Invoke(state, exception), exception);
+        Console.Out.WriteLine("[testcontainers.org {0:hh\\:mm\\:ss\\.ff}] {1}", _stopwatch.Elapsed, message);
       }
     }
 

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -3,7 +3,7 @@ namespace DotNet.Testcontainers.Commons;
 [PublicAPI]
 public static class CommonImages
 {
-    public static readonly IImage Ryuk = new DockerImage("testcontainers/ryuk:0.6.0");
+    public static readonly IImage Ryuk = new DockerImage("testcontainers/ryuk:0.9.0");
 
     public static readonly IImage Alpine = new DockerImage("alpine:3.17");
 


### PR DESCRIPTION
## What does this PR do?

This PR addresses a flaky unit test I noticed some time ago. The reusable resource tests (reuse feature) have been flaky, and today I discovered that they interfere with the port forwarding tests. When the port forwarding container is running, Testcontainers automatically injects the necessary extra hosts into the builder configuration using `WithPortForwarding()` internally. Depending on when the test framework starts the port forwarding container, these extra hosts can cause flakiness. This happens because the reuse hash may change during iterating and creating the container resource(s), resulting in two containers with the same label running instead of one. 

I noticed the issue by looking into the actual container configurations and their hashes (see the JSON node `ExtraHosts`):

```json
// ReuseHash=SwYoG2DcNHf2MEnMvH7tWLmN0Yw=
"RealObject": {
    "Image": {
        "Repository": "alpine",
        "Registry": null,
        "Tag": "3.17",
        "Digest": null,
        "FullName": "alpine:3.17",
        "Name": "alpine"
    },
    "Name": null,
    "Entrypoint": [
        "/bin/sh",
        "-c",
        "trap : TERM INT; sleep infinity \u0026 wait"
    ],
    "Command": [],
    "Environments": {},
    "ExposedPorts": {},
    "PortBindings": {},
    "NetworkAliases": [],
    "ExtraHosts": [],
    "Labels": {
        "71dd3cf7-1df3-4c53-8b9d-8890c93dca85": "7f90fea5-afc3-4e06-8a6a-77638d6640a8",
        "org.testcontainers": "true",
        "org.testcontainers.lang": "dotnet"
    }
}

// ReuseHash=yb7MflZnn0sD0kWz/eiVR/rC9Ao=
"RealObject": {
    "Image": {
        "Repository": "alpine",
        "Registry": null,
        "Tag": "3.17",
        "Digest": null,
        "FullName": "alpine:3.17",
        "Name": "alpine"
    },
    "Name": null,
    "Entrypoint": [
        "/bin/sh",
        "-c",
        "trap : TERM INT; sleep infinity \u0026 wait"
    ],
    "Command": [],
    "Environments": {},
    "ExposedPorts": {},
    "PortBindings": {},
    "NetworkAliases": [],
    "ExtraHosts": [
        "host.testcontainers.internal:172.17.0.14"
    ],
    "Labels": {
        "71dd3cf7-1df3-4c53-8b9d-8890c93dca85": "7f90fea5-afc3-4e06-8a6a-77638d6640a8",
        "org.testcontainers": "true",
        "org.testcontainers.lang": "dotnet"
    }
}
```

In addition to fixing this issue, the PR aligns two similar tests, now includes the stack trace of an exception in the log message and bumps the test dependencies to their latest version.

## Why is it important?

This PR improves the stability and resilience of the CI pipeline and tests.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
