### PR TITLE
feat: Add getter for Azurite blob, queue and table endpoint

### DIFF
--- a/src/Testcontainers.Azurite/AzuriteContainer.cs
+++ b/src/Testcontainers.Azurite/AzuriteContainer.cs
@@ -23,9 +23,39 @@ public sealed class AzuriteContainer : DockerContainer
         properties.Add("DefaultEndpointsProtocol", Uri.UriSchemeHttp);
         properties.Add("AccountName", AzuriteBuilder.AccountName);
         properties.Add("AccountKey", AzuriteBuilder.AccountKey);
-        properties.Add("BlobEndpoint", new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.BlobPort), AzuriteBuilder.AccountName).ToString());
-        properties.Add("QueueEndpoint", new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.QueuePort), AzuriteBuilder.AccountName).ToString());
-        properties.Add("TableEndpoint", new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.TablePort), AzuriteBuilder.AccountName).ToString());
+        properties.Add("BlobEndpoint", GetBlobEndpoint());
+        properties.Add("QueueEndpoint", GetQueueEndpoint());
+        properties.Add("TableEndpoint", GetTableEndpoint());
         return string.Join(";", properties.Select(property => string.Join("=", property.Key, property.Value)));
+    }
+
+    /// <summary>
+    /// Gets the blob endpoint
+    /// </summary>
+    /// <returns>The azurite blob endpoint</returns>
+    public string GetBlobEndpoint()
+    {
+        return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.BlobPort),
+            AzuriteBuilder.AccountName).ToString();
+    }
+
+    /// <summary>
+    /// Gets the queue endpoint
+    /// </summary>
+    /// <returns>The azurite queue endpoint</returns>
+    public string GetQueueEndpoint()
+    {
+        return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.QueuePort),
+            AzuriteBuilder.AccountName).ToString();
+    }
+
+    /// <summary>
+    /// Gets the table endpoint
+    /// </summary>
+    /// <returns>The azurite table endpoint</returns>
+    public string GetTableEndpoint()
+    {
+        return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.TablePort),
+            AzuriteBuilder.AccountName).ToString();
     }
 }


### PR DESCRIPTION
## What does this PR do?

Exposes extra methods on azurite to get the individual endpoints for blob, queue & table.
This is useful if managed identity is used in the actual implementation.

## Why is it important?

The storage connection string parser is internal in the azure sdk. 

## Related issues
n/a


