### PR TITLE
feat: Use `exec` to replace current shell with the Kafka process (as ENTRYPOINT)

### DIFF
--- a/src/Testcontainers.Kafka/KafkaBuilder.cs
+++ b/src/Testcontainers.Kafka/KafkaBuilder.cs
@@ -83,7 +83,7 @@ public sealed class KafkaBuilder : ContainerBuilder<KafkaBuilder, KafkaContainer
                 startupScript.Append(lf);
                 startupScript.Append("echo '' > /etc/confluent/docker/ensure");
                 startupScript.Append(lf);
-                startupScript.Append("/etc/confluent/docker/run");
+                startupScript.Append("exec /etc/confluent/docker/run");
                 return container.CopyAsync(Encoding.Default.GetBytes(startupScript.ToString()), StartupScriptFilePath, Unix.FileMode755, ct);
             });
     }


### PR DESCRIPTION
Without this, signals (including SIGTERM/SIGINT) are sent to the script instead of the kafka process, delaying container shutdown until docker times out and sends SIGKILL

## What does this PR do?

Launch apache kafka using exec to pass signals to the kafka process, for faster shutdown.

## Why is it important?

Tests take 30 seconds when shutting down kafka containers, because the kafka process does not receive SIGTERM and must wait for docker to send SIGKILL after the timeout period

## How to test this PR

Run test container before this change, and observe the time taken to shut down.
Run the same container with this change, and observe the same, but without the delay.