### PR TITLE
fix: Prepend Docker Hub namespace to repository

### DIFF
--- a/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixture.cs
@@ -16,6 +16,8 @@ namespace DotNet.Testcontainers.Tests.Fixtures
     private const string DotSeparatorRegistry = "myregistry.azurecr.io";
     private const string PortSeparatorRegistry = "myregistry:5000";
     private const string Digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private const string HubImageNamePrefixImplicitLibrary = "myregistry.azurecr.io";
+    private const string HubImageNamePrefixExplicitLibrary = "myregistry.azurecr.io/library";
 
     public DockerImageFixture()
     {
@@ -35,6 +37,8 @@ namespace DotNet.Testcontainers.Tests.Fixtures
       Add(new DockerImageFixtureSerializable(new DockerImage(FedoraHttpd, PortSeparatorRegistry, CustomTag1, null)), $"{PortSeparatorRegistry}/{FedoraHttpd}:{CustomTag1}", $"{PortSeparatorRegistry}/{FedoraHttpd}:{CustomTag1}");
       Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, DotSeparatorRegistry, SemVerTag, Digest)), $"{DotSeparatorRegistry}/{FooBarBaz}:{SemVerTag}@{Digest}", $"{DotSeparatorRegistry}/{FooBarBaz}:{SemVerTag}@{Digest}");
       Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, DotSeparatorRegistry, null, Digest)), $"{DotSeparatorRegistry}/{FooBarBaz}@{Digest}", $"{DotSeparatorRegistry}/{FooBarBaz}@{Digest}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, null, null, null, HubImageNamePrefixImplicitLibrary)), $"{HubImageNamePrefixImplicitLibrary}/{FooBarBaz}", $"{HubImageNamePrefixImplicitLibrary}/{FooBarBaz}:{LatestTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, null, null, null, HubImageNamePrefixExplicitLibrary)), $"{HubImageNamePrefixExplicitLibrary}/{FooBarBaz}", $"{HubImageNamePrefixExplicitLibrary}/{FooBarBaz}:{LatestTag}");
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

If the `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` custom configuration contains a namespace, such as `registry.example.com/library`, Testcontainers retains the namespace when attempting to locate registry credentials. However, the registry credentials key does not (may not) include the namespace, preventing Testcontainers for .NET from finding and using existing credentials. This PR ensures that the namespace is prepended to the repository and that only the hostname is used to resolve registry credentials.

When we use the custom configuration from above, Testcontainers will resolve the following property values:

| Property | Value |
|---|---|
| Registry | registry.example.com |
| Repository | library/testcontainers/helloworld |
| Tag | latest |
| GetHostname() | registry.example.com |

## Why is it important?

Fixes an issue where Testcontainers for .NET is unable to find existing and valid configured private registry credentials. This is a regression.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1286

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
