### PR TITLE
fix: Add timeout to CosmosDb wait strategy

### DIFF
--- a/src/Testcontainers.CosmosDb/CosmosDbBuilder.cs
+++ b/src/Testcontainers.CosmosDb/CosmosDbBuilder.cs
@@ -45,7 +45,7 @@ public sealed class CosmosDbBuilder : ContainerBuilder<CosmosDbBuilder, CosmosDb
         return base.Init()
             .WithImage(CosmosDbImage)
             .WithPortBinding(CosmosDbPort, true)
-            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil()));
+            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil(), s => s.WithTimeout(TimeSpan.FromMinutes(5))));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## What does this PR do?

Adds a timeout to the custom wait strategy for CosmosDb. The wait strategy refactor made this timeout only 15 seconds, which is not long enough for CosmosDb to start.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

Without this timeout, the CosmosDb emulator will fail to start as it cannot start within 15 seconds.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
