### PR TITLE
chore: Replace Docker.DotNet with the Testcontainers organization's build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,22 +4,22 @@
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include="BouncyCastle.Cryptography" Version="2.3.1"/>
-        <PackageVersion Include="Docker.DotNet.X509" Version="3.125.15"/>
-        <PackageVersion Include="Docker.DotNet" Version="3.125.15"/>
-        <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0"/>
+        <PackageVersion Include="BouncyCastle.Cryptography" Version="2.4.0"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="3.126.0"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.126.0"/>
+        <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
         <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.4"/>
-        <PackageVersion Include="ReflectionMagic" Version="5.0.1"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2"/>
         <PackageVersion Include="SharpZipLib" Version="1.4.2"/>
-        <PackageVersion Include="SSH.NET" Version="2023.0.0"/>
-        <PackageVersion Include="System.Text.Json" Version="6.0.10"/>
+        <PackageVersion Include="SSH.NET" Version="2024.1.0"/>
+        <PackageVersion Include="System.Text.Json" Version="8.0.5"/>
         <!-- Unit and integration test dependencies: -->
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-        <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.9.1"/>
+        <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0"/>
         <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
+        <PackageVersion Include="ReflectionMagic" Version="5.0.1"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
-        <PackageVersion Include="xunit" Version="2.9.0"/>
+        <PackageVersion Include="xunit" Version="2.9.2"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->
         <PackageVersion Include="Apache.NMS.ActiveMQ" Version="2.1.0"/>
         <PackageVersion Include="ArangoDBNetStandard" Version="2.0.1"/>

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -100,7 +100,7 @@ namespace DotNet.Testcontainers.Clients
     public Task ExtractArchiveToContainerAsync(string id, string path, TarOutputMemoryStream tarStream, CancellationToken ct = default)
     {
       Logger.CopyArchiveToDockerContainer(id, tarStream.ContentLength);
-      return DockerClient.Containers.ExtractArchiveToContainerAsync(id, new ContainerPathStatParameters { Path = path, AllowOverwriteDirWithFile = false }, tarStream, ct);
+      return DockerClient.Containers.ExtractArchiveToContainerAsync(id, new ContainerPathStatParameters { Path = path }, tarStream, ct);
     }
 
     public async Task<Stream> GetArchiveFromContainerAsync(string id, string path, CancellationToken ct = default)

--- a/src/Testcontainers/Testcontainers.csproj
+++ b/src/Testcontainers/Testcontainers.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" VersionOverride="2023.3.0" PrivateAssets="All"/>
-    <PackageReference Include="Docker.DotNet.X509"/>
-    <PackageReference Include="Docker.DotNet"/>
+    <PackageReference Include="Docker.DotNet.Enhanced.X509"/>
+    <PackageReference Include="Docker.DotNet.Enhanced"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
     <PackageReference Include="SharpZipLib"/>
     <PackageReference Include="SSH.NET"/>


### PR DESCRIPTION
## What does this PR do?

As mentioned in the forked [repository](https://github.com/testcontainers/Docker.DotNet), we tried to reach out to the .NET Foundation, the maintainer, and others to offer our help in maintaining the project, addressing Docker Engine API updates, bug fixes, new features, and GitHub issues. Unfortunately, we were not able to get in touch with anyone properly. If the upstream repository becomes active again, I would be happy to replace the package again and bring the changes made in the fork back to the upstream.

This PR replaces Docker.DotNet with the build from the Testcontainers organization. The new version already includes several improvements: [v3.126.0](https://github.com/testcontainers/Docker.DotNet/releases/tag/v3.126.0).

## Why is it important?

The upstream repository appears to been inactive for quite a while now. Docker.DotNet is an important upstream dependency for Testcontainers, and we need to ensure that we can quickly provide changes to the Docker Engine API or important bug fixes.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
