### PR TITLE
feat: Update docker image to Apache Pulsar 4.0 LTS

### DIFF
--- a/src/Testcontainers.Pulsar/PulsarBuilder.cs
+++ b/src/Testcontainers.Pulsar/PulsarBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.Pulsar;
 [PublicAPI]
 public sealed class PulsarBuilder : ContainerBuilder<PulsarBuilder, PulsarContainer, PulsarConfiguration>
 {
-    public const string PulsarImage = "apachepulsar/pulsar:3.0.6";
+    public const string PulsarImage = "apachepulsar/pulsar:4.0.0";
 
     public const ushort PulsarBrokerDataPort = 6650;
 
@@ -87,6 +87,7 @@ public sealed class PulsarBuilder : ContainerBuilder<PulsarBuilder, PulsarContai
             .WithPortBinding(PulsarBrokerDataPort, true)
             .WithPortBinding(PulsarWebServicePort, true)
             .WithFunctionsWorker(false)
+            .WithCreateParameterModifier(parameterModifier => parameterModifier.User = "root")
             .WithEntrypoint("/bin/sh", "-c")
             .WithCommand("while [ ! -f " + StartupScriptFilePath + " ]; do sleep 0.1; done; " + StartupScriptFilePath)
             .WithStartupCallback((container, ct) => container.CopyStartupScriptAsync(ct));

--- a/src/Testcontainers.Pulsar/PulsarContainer.cs
+++ b/src/Testcontainers.Pulsar/PulsarContainer.cs
@@ -105,7 +105,6 @@ public sealed class PulsarContainer : DockerContainer
             startupScript.WriteLine("export brokerClientAuthenticationParameters=token:$(bin/pulsar tokens create --secret-key $PULSAR_PREFIX_tokenSecretKey --subject $superUserRoles)");
             startupScript.WriteLine("export CLIENT_PREFIX_authParams=$brokerClientAuthenticationParameters");
             startupScript.WriteLine("bin/apply-config-from-env.py conf/standalone.conf");
-            startupScript.WriteLine("bin/apply-config-from-env-with-prefix.py CLIENT_PREFIX_ conf/client.conf");
         }
 
         startupScript.Write("bin/pulsar standalone");

--- a/src/Testcontainers.Pulsar/PulsarContainer.cs
+++ b/src/Testcontainers.Pulsar/PulsarContainer.cs
@@ -101,7 +101,7 @@ public sealed class PulsarContainer : DockerContainer
 
         if (_configuration.AuthenticationEnabled.HasValue && _configuration.AuthenticationEnabled.Value)
         {
-            startupScript.WriteLine("bin/pulsar tokens create-secret-key --output " + PulsarBuilder.SecretKeyFilePath);
+            startupScript.WriteLine("bin/pulsar tokens create-secret-key --output secret.key");
             startupScript.WriteLine("export brokerClientAuthenticationParameters=token:$(bin/pulsar tokens create --secret-key $PULSAR_PREFIX_tokenSecretKey --subject $superUserRoles)");
             startupScript.WriteLine("export CLIENT_PREFIX_authParams=$brokerClientAuthenticationParameters");
             startupScript.WriteLine("bin/apply-config-from-env.py conf/standalone.conf");


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

- Upgraded the default Apache Pulsar docker image to 4.0 LTS.
- Changed user to root, to create secret.key for auth.
- Fixed start up to use correct secret.key file.
- Remove deprecated usage of `apply-config-from-env-with-prefix.py` causing 'standalone' cluster to disappear.

## Why is it important?

To use the latest version of Apache Pulsar 4.0 LTS to allow developers to take advantage of the new features by having a working testing environment.

## Related issues

- Closes #1291
