### PR TITLE
chore: Run each test project on a separate runner

### DIFF
--- a/.cake-scripts/parameters.cake
+++ b/.cake-scripts/parameters.cake
@@ -19,6 +19,7 @@ internal sealed class BuildParameters
   public string PullRequestId { get; private set; }
   public string Version { get; private set; }
   public string TestFilter { get; private set; }
+  public string TestProject { get; private set; }
   public bool IsLocalBuild { get; private set; }
   public bool IsReleaseBuild { get; private set; }
   public bool IsPullRequest { get; private set; }
@@ -49,6 +50,7 @@ internal sealed class BuildParameters
       PullRequestId = buildInformation.PullRequestId,
       Version = buildInformation.Version,
       TestFilter = context.Argument<string>("test-filter", null),
+      TestProject = context.Argument<string>("test-project", null),
       IsLocalBuild = buildInformation.IsLocalBuild,
       IsReleaseBuild = !buildInformation.IsLocalBuild && buildInformation.IsReleaseBuild,
       IsPullRequest = buildInformation.IsPullRequest,

--- a/.cake-scripts/paths.cake
+++ b/.cake-scripts/paths.cake
@@ -9,7 +9,7 @@ internal sealed class BuildPaths
 
   public static BuildPaths Instance(ICakeContext context, string version)
   {
-    var baseDir = (DirectoryPath) context.Directory(".");
+    var baseDir = (DirectoryPath)context.Directory(".");
 
     var testResultsDir = baseDir.Combine("test-results");
     var testCoverageDir = baseDir.Combine("test-coverage");

--- a/.cake-scripts/version.cake
+++ b/.cake-scripts/version.cake
@@ -1,4 +1,4 @@
-#addin nuget:?package=Cake.Git&version=3.0.0
+#addin nuget:?package=Cake.Git&version=4.0.0
 
 internal sealed class BuildInformation
 {

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "3.2.0",
+      "version": "4.2.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,13 +25,61 @@ env:
   TZ: CET # https://stackoverflow.com/q/53510011
 
 jobs:
-  build:
+  ci:
     strategy:
-      fail-fast: false
+      max-parallel: 6
       matrix:
-        os: [ ubuntu-22.04, windows-2022 ]
+        test-projects: [
+          { name: "Testcontainers", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Platform.Linux", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Platform.Windows", runs-on: "windows-2022" },
+          { name: "Testcontainers.Databases", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.ResourceReaper", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.ActiveMq", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.ArangoDb", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Azurite", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.BigQuery", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Bigtable", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.ClickHouse", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.CockroachDb", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Consul", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.CosmosDb", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Couchbase", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.CouchDb", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.DynamoDb", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Elasticsearch", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.EventStoreDb", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.FakeGcsServer", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.FirebirdSql", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Firestore", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.InfluxDb", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.JanusGraph", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.K3s", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Kafka", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Keycloak", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Kusto", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.LocalStack", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.MariaDb", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Milvus", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Minio", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.MongoDb", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.MsSql", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.MySql", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Nats", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Neo4j", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Oracle", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Papercut", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.PostgreSql", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.PubSub", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Pulsar", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.RabbitMq", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.RavenDb", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Redis", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.Redpanda", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.WebDriver", runs-on: "ubuntu-22.04" }
+        ]
 
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.test-projects.runs-on }}
 
     steps:
       - name: Checkout Repository
@@ -42,26 +90,8 @@ jobs:
       - name: Cache NuGet Packages
         uses: actions/cache@v4
         with:
-          key: ${{ matrix.os }}-nuget-${{ hashFiles('Directory.Packages.props') }}
+          key: ${{ matrix.test-projects.runs-on }}-nuget-${{ hashFiles('Directory.Packages.props') }}
           path: ~/.nuget/packages
-
-      # Our modules occupy too much disk space. The GitHub-hosted runners ran into the
-      # error: "no space left on device." The pulled images are not cleaned up between
-      # the test runs. One obvious approach is splitting the tests and running them on
-      # multiple runners. However, we need to keep in mind that running too many
-      # simultaneous builds has an impact on others as well. We observed that scheduled
-      # Dependabot builds blocked others in the Testcontainers organization.
-      - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@v1.3.1
-        if: runner.os == 'Linux'
-        with:
-          tool-cache: true
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -76,27 +106,27 @@ jobs:
         run: dotnet cake --target=Build
 
       - name: Run Tests
-        run: dotnet cake --target=Tests --test-filter=${{ startsWith(matrix.os, 'ubuntu') && 'FullyQualifiedName~Testcontainers' || 'DockerPlatform=Windows' }}
+        run: dotnet cake --target=Test --test-project=${{ matrix.test-projects.name }}
 
       - name: Upload Test And Coverage Results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ matrix.os }}
+          name: ${{ matrix.test-projects.name }}
           path: test-results
 
-  publish:
+  cd:
     if: ${{ contains(fromJson('["develop", "main"]'), github.ref_name) }}
 
-    needs: build
+    needs: ci
 
     environment: production
-
-    runs-on: ubuntu-22.04
 
     permissions:
       contents: write
       pull-requests: read
+
+    runs-on: ubuntu-22.04
 
     env:
       CODE_SIGNING_CERTIFICATE_BASE64: ${{ secrets.CODE_SIGNING_CERTIFICATE_BASE64 }}
@@ -116,16 +146,10 @@ jobs:
           lfs: true
           fetch-depth: 0
 
-      - name: Download Test And Coverage Results (ubuntu-22.04)
+      - name: Download Test And Coverage Results
         uses: actions/download-artifact@v4
         with:
-          name: ubuntu-22.04
-          path: test-results
-
-      - name: Download Test And Coverage Results (windows-2022)
-        uses: actions/download-artifact@v4
-        with:
-          name: windows-2022
+          pattern: Testcontainers*
           path: test-results
 
       - name: Fix Absolute Code Coverage Paths
@@ -142,7 +166,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -8,24 +8,19 @@ on:
 
 jobs:
   report:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-22.04, windows-2022 ]
-
-    runs-on: ${{ matrix.os }}
-
     permissions:
       actions: read
       checks: write
       contents: read
+
+    runs-on: ubuntu-22.04
 
     steps:
       # https://github.com/dorny/test-reporter/issues/363#issuecomment-2381625959.
       - name: Publish Test Report
         uses: dorny/test-reporter@v1.9.1
         with:
-          artifact: ${{ matrix.os }}
-          name: report (${{ matrix.os }})
+          artifact: Testcontainers*
+          name: Test Report
           path: '*.trx'
           reporter: dotnet-trx

--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -174,7 +174,7 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
             private readonly IContainer _container = new ContainerBuilder()
                 .WithImage(CommonImages.Alpine)
                 .WithEntrypoint("/bin/sh", "-c")
-                .WithCommand($"while true; do echo \"HTTP/1.1 200 OK\r\n\" | nc -l -p {HttpPort}; done")
+                .WithCommand($"while true; do echo \"HTTP/1.1 200 OK\r\n\r\n\" | nc -l -p {HttpPort}; done")
                 .WithPortBinding(HttpPort, true)
                 .Build();
 

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
@@ -19,7 +19,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     private readonly IContainer _container = new ContainerBuilder()
       .WithImage(CommonImages.Alpine)
       .WithEntrypoint("/bin/sh", "-c")
-      .WithCommand($"while true; do echo \"HTTP/1.1 200 OK\r\n\" | nc -l -p {HttpPort}; done")
+      .WithCommand($"while true; do echo \"HTTP/1.1 200 OK\r\n\r\n\" | nc -l -p {HttpPort}; done")
       .WithPortBinding(HttpPort, true)
       .Build();
 


### PR DESCRIPTION
## What does this PR do?

The pull request changes how we run our tests by running each test project on a separate runner. Previously, all test projects were run on the same runner, which caused issues due to running out of disk space and subsequently blocked merging new module pull requests. We need to monitor whether this change affects the Testcontainers organization. I am uncertain if creating too many runners might lead to degradation of the entire organization.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #1136

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
