### PR TITLE
fix: Add HTTP wait strategy to prevent race-condition in TarOutputMemoryStreamTest

### DIFF
--- a/src/Testcontainers.WebDriver/WebDriverBuilder.cs
+++ b/src/Testcontainers.WebDriver/WebDriverBuilder.cs
@@ -100,8 +100,8 @@ public sealed class WebDriverBuilder : ContainerBuilder<WebDriverBuilder, WebDri
             .WithNetworkAliases(WebDriverNetworkAlias)
             .WithPortBinding(WebDriverPort, true)
             .WithPortBinding(VncServerPort, true)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request
-                => request.ForPath("/wd/hub/status").ForPort(WebDriverPort).ForResponseMessageMatching(IsGridReadyAsync)));
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
+                request.ForPath("/wd/hub/status").ForPort(WebDriverPort).ForResponseMessageMatching(IsGridReadyAsync)));
     }
 
     /// <inheritdoc />

--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -176,6 +176,8 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
                 .WithEntrypoint("/bin/sh", "-c")
                 .WithCommand($"while true; do echo \"HTTP/1.1 200 OK\r\n\r\n\" | nc -l -p {HttpPort}; done")
                 .WithPortBinding(HttpPort, true)
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => 
+                    request.ForPath("/")))
                 .Build();
 
             public string BaseAddress


### PR DESCRIPTION
## What does this PR do?

The PR resolves a race-condition in the `TestFileExistsInContainer` test. The `HttpFixture` indicated readiness too early, which caused flaky tests because `netcat` was not yet listening for incoming HTTP requests. This PR addresses the issue by ensuring that `netcat` is listening before the fixture is passed to the actual test.

## Why is it important?

Maintain a stable CI pipeline.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
