### PR TITLE
fix: Add HTTP wait strategy to prevent race-condition in WaitUntilHttpRequestIsSucceededTest

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -175,7 +175,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["analyze (csharp)", "build (ubuntu-22.04)", "build (windows-2022)", "netlify/testcontainers-dotnet/deploy-preview"]
+        contexts: ["Test Report", "analyze (csharp)"]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false
       # Prevent merge commits from being pushed to matching branches
@@ -207,7 +207,7 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["analyze (csharp)", "build (ubuntu-22.04)", "build (windows-2022)", "netlify/testcontainers-dotnet/deploy-preview"]
+        contexts: ["Test Report", "analyze (csharp)"]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false
       # Prevent merge commits from being pushed to matching branches

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -7,6 +7,8 @@ public static class CommonImages
 
     public static readonly IImage Alpine = new DockerImage("alpine:3.17");
 
+    public static readonly IImage Socat = new DockerImage("alpine/socat:1.8.0.0");
+
     public static readonly IImage Curl = new DockerImage("curlimages/curl:8.00.1");
 
     public static readonly IImage Nginx = new DockerImage("nginx:1.22");

--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -172,12 +172,12 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
             private const ushort HttpPort = 80;
 
             private readonly IContainer _container = new ContainerBuilder()
-                .WithImage(CommonImages.Alpine)
-                .WithEntrypoint("/bin/sh", "-c")
-                .WithCommand($"while true; do echo \"HTTP/1.1 200 OK\r\n\r\n\" | nc -l -p {HttpPort}; done")
+                .WithImage(CommonImages.Socat)
+                .WithCommand("-v")
+                .WithCommand($"TCP-LISTEN:{HttpPort},crlf,reuseaddr,fork")
+                .WithCommand("EXEC:\"echo -e 'HTTP/1.1 200 OK'\n\n\"")
                 .WithPortBinding(HttpPort, true)
-                .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => 
-                    request.ForPath("/")))
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request))
                 .Build();
 
             public string BaseAddress

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
@@ -17,10 +17,12 @@ namespace DotNet.Testcontainers.Tests.Unit
     private const ushort HttpPort = 80;
 
     private readonly IContainer _container = new ContainerBuilder()
-      .WithImage(CommonImages.Alpine)
-      .WithEntrypoint("/bin/sh", "-c")
-      .WithCommand($"while true; do echo \"HTTP/1.1 200 OK\r\n\r\n\" | nc -l -p {HttpPort}; done")
+      .WithImage(CommonImages.Socat)
+      .WithCommand("-v")
+      .WithCommand($"TCP-LISTEN:{HttpPort},crlf,reuseaddr,fork")
+      .WithCommand("EXEC:\"echo -e 'HTTP/1.1 200 OK'\n\n\"")
       .WithPortBinding(HttpPort, true)
+      .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request))
       .Build();
 
     public static TheoryData<HttpWaitStrategy> GetHttpWaitStrategies()
@@ -74,15 +76,15 @@ namespace DotNet.Testcontainers.Tests.Unit
       await Task.Delay(TimeSpan.FromSeconds(1))
         .ConfigureAwait(true);
 
-      var (stdout, _) = await _container.GetLogsAsync()
+      var (_, stderr) = await _container.GetLogsAsync()
         .ConfigureAwait(true);
 
       // Then
       Assert.True(succeeded);
-      Assert.Contains("Authorization", stdout);
-      Assert.Contains("QWxhZGRpbjpvcGVuIHNlc2FtZQ==", stdout);
-      Assert.Contains(httpHeaders.First().Key, stdout);
-      Assert.Contains(httpHeaders.First().Value, stdout);
+      Assert.Contains("Authorization", stderr);
+      Assert.Contains("QWxhZGRpbjpvcGVuIHNlc2FtZQ==", stderr);
+      Assert.Contains(httpHeaders.First().Key, stderr);
+      Assert.Contains(httpHeaders.First().Value, stderr);
     }
 
     [Fact]
@@ -104,13 +106,13 @@ namespace DotNet.Testcontainers.Tests.Unit
       await Task.Delay(TimeSpan.FromSeconds(1))
         .ConfigureAwait(true);
 
-      var (stdout, _) = await _container.GetLogsAsync()
+      var (_, stderr) = await _container.GetLogsAsync()
         .ConfigureAwait(true);
 
       // Then
       Assert.True(succeeded);
-      Assert.Contains("Cookie", stdout);
-      Assert.Contains("Key1=Value1", stdout);
+      Assert.Contains("Cookie", stderr);
+      Assert.Contains("Key1=Value1", stderr);
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

This PR fixes a race-condition in tests that depend on HTTP responses. Previously, we used `nc` to listen for HTTP requests and send responses. However, `nc` cannot handle multiple incoming connections, and there is a small window where no listener is available. This could end up in flaky behavior. 

The changes leverage `socat` to send HTTP responses, which works reliably for multiple incoming requests.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #1297

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
