### PR TITLE
fix: Do not pre-pull scratch image

### DIFF
--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -383,6 +383,12 @@ namespace DotNet.Testcontainers.Clients
 
       if (dockerRegistryServerAddress == null)
       {
+        // https://hub.docker.com/_/scratch.
+        if ("scratch".Equals(image.Repository, StringComparison.OrdinalIgnoreCase))
+        {
+          return;
+        }
+
         var info = await System.GetInfoAsync(ct)
           .ConfigureAwait(false);
 

--- a/tests/Testcontainers.Tests/Assets/.dockerignore
+++ b/tests/Testcontainers.Tests/Assets/.dockerignore
@@ -3,4 +3,5 @@ credHelpers
 credsStore
 healthWaitStrategy
 pullBaseImages
+scratch
 **/*.md

--- a/tests/Testcontainers.Tests/Assets/scratch/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/scratch/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+LABEL "maintainer"="9199345+HofmeisterAn@users.noreply.github.com"

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -100,11 +100,31 @@ namespace DotNet.Testcontainers.Tests.Unit
       Assert.Equal($"Directory '{Path.GetFullPath(dockerfileDirectory)}' does not exist.", exception.Message);
     }
 
+    [Fact]
+    public async Task BuildsDockerScratchImage()
+    {
+      // Given
+      var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
+        .WithDockerfileDirectory("Assets/scratch")
+        .Build();
+
+      // When
+      var exception = await Record.ExceptionAsync(() => imageFromDockerfileBuilder.CreateAsync())
+        .ConfigureAwait(true);
+
+      // Then
+      Assert.Null(exception);
+      Assert.NotNull(imageFromDockerfileBuilder.Repository);
+      Assert.NotNull(imageFromDockerfileBuilder.Tag);
+      Assert.NotNull(imageFromDockerfileBuilder.FullName);
+      Assert.Null(imageFromDockerfileBuilder.GetHostname());
+    }
+
     [Theory]
     [InlineData("Dockerfile")]
     [InlineData("./Dockerfile")]
     [InlineData(".\\Dockerfile")]
-    public async Task BuildsDockerImage(string dockerfile)
+    public async Task BuildsDockerAlpineImage(string dockerfile)
     {
       // Given
       IImage tag1 = new DockerImage(new DockerImage(string.Join("/", "localhost", "testcontainers", Guid.NewGuid().ToString("D"))));


### PR DESCRIPTION
## What does this PR do?

While building an image, Testcontainers for .NET pre-pulls base images. However, building an image from [scratch](https://hub.docker.com/_/scratch) fails because the image cannot be pulled (the name is reserved). This pull request skips pre-pulling the base image to address this issue.

## Why is it important?

The change is necessary to allow developers building images that depend on `scratch`.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1303

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
