### PR TITLE
chore: Add test to ensure that all test projects are configured for CI

### DIFF
--- a/tests/Testcontainers.Tests/ContinuousIntegration/JobsTest.cs
+++ b/tests/Testcontainers.Tests/ContinuousIntegration/JobsTest.cs
@@ -1,0 +1,37 @@
+namespace DotNet.Testcontainers.Tests.ContinuousIntegration
+{
+  using System.IO;
+  using System.Linq;
+  using System.Runtime.CompilerServices;
+  using System.Text.RegularExpressions;
+  using Xunit;
+
+  public partial class JobsTest
+  {
+    [GeneratedRegex("name: \"(.+?)\"")]
+    private static partial Regex ProjectNameRegex();
+
+    [Fact]
+    public void AllTestProjectsShouldBeConfiguredForContinuousIntegration()
+    {
+      var ciCdFilePath = GetCiCdFilePath();
+      var configuredProjects = File.ReadAllLines(ciCdFilePath).Select(line => ProjectNameRegex().Match(line).Groups[1].Value).Where(line => line.Length > 0).ToList();
+      Assert.NotEmpty(configuredProjects);
+
+      var existingProjects = Directory.GetFiles(GetTestsPath(), "*.Tests.csproj", SearchOption.AllDirectories).Select(name => Path.GetFileName(name)[..^13]).ToList();
+      Assert.NotEmpty(existingProjects);
+
+      var missingConfiguredProjects = existingProjects.Except(configuredProjects).ToList();
+      if (missingConfiguredProjects.Count > 0)
+      {
+        Assert.Fail($"{string.Join(", ", missingConfiguredProjects)} must be configured in {ciCdFilePath}");
+      }
+    }
+
+    private static string GetCiCdFilePath() => Path.Combine(GetRepositoryPath(), ".github", "workflows", "cicd.yml");
+
+    private static string GetTestsPath() => Path.Combine(GetRepositoryPath(), "tests");
+
+    private static string GetRepositoryPath([CallerFilePath] string path = "") => Path.GetFullPath(Path.Combine(Path.GetDirectoryName(path)!, "..", "..", ".."));
+  }
+}


### PR DESCRIPTION
## What does this PR do?

This pull request introduces a new test to ensure that all test projects are configured for Continuous Integration & Delivery.

## Why is it important?

Because it's too easy to forget to add a line in the cicd.yml after creating a new module. This new test will catch this common error.

## Related issues

This is a safety measure after the introduction of running each test project on a separate runner in #1295.

## How to test this PR

Of course if the `{ name: "Testcontainers", runs-on: "ubuntu-22.04" }` line is deleted from the `cicd.yaml` file then this new test won't run. 🙃