### PR TITLE
fix: Postpone exception in `DbContainerFixture` to match the behavior of `ContainerFixture`

### DIFF
--- a/src/Testcontainers.Xunit/DbContainerFixture.cs
+++ b/src/Testcontainers.Xunit/DbContainerFixture.cs
@@ -21,7 +21,7 @@ public abstract class DbContainerFixture<TBuilderEntity, TContainerEntity>(IMess
         await base.InitializeAsync()
             .ConfigureAwait(false);
 
-        _testMethods = new DbContainerTestMethods(DbProviderFactory, ConnectionString);
+        _testMethods = new DbContainerTestMethods(DbProviderFactory, new Lazy<string>(() => ConnectionString));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Xunit/DbContainerTest.cs
+++ b/src/Testcontainers.Xunit/DbContainerTest.cs
@@ -20,7 +20,7 @@ public abstract class DbContainerTest<TBuilderEntity, TContainerEntity>(ITestOut
         await base.InitializeAsync()
             .ConfigureAwait(false);
 
-        _testMethods = new DbContainerTestMethods(DbProviderFactory, ConnectionString);
+        _testMethods = new DbContainerTestMethods(DbProviderFactory, new Lazy<string>(() => ConnectionString));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Xunit/DbContainerTestMethods.cs
+++ b/src/Testcontainers.Xunit/DbContainerTestMethods.cs
@@ -1,9 +1,9 @@
 namespace Testcontainers.Xunit;
 
-internal sealed class DbContainerTestMethods(DbProviderFactory dbProviderFactory, string connectionString) : IDbContainerTestMethods, IAsyncDisposable
+internal sealed class DbContainerTestMethods(DbProviderFactory dbProviderFactory, Lazy<string> connectionString) : IDbContainerTestMethods, IAsyncDisposable
 {
     private readonly DbProviderFactory _dbProviderFactory = dbProviderFactory ?? throw new ArgumentNullException(nameof(dbProviderFactory));
-    private readonly string _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
+    private readonly Lazy<string> _connectionString = connectionString ?? throw new ArgumentNullException(nameof(connectionString));
 
 #if NET8_0_OR_GREATER
     [CanBeNull]
@@ -12,7 +12,7 @@ internal sealed class DbContainerTestMethods(DbProviderFactory dbProviderFactory
     {
         get
         {
-            _dbDataSource ??= _dbProviderFactory.CreateDataSource(_connectionString);
+            _dbDataSource ??= _dbProviderFactory.CreateDataSource(_connectionString.Value);
             return _dbDataSource;
         }
     }
@@ -32,7 +32,7 @@ internal sealed class DbContainerTestMethods(DbProviderFactory dbProviderFactory
     public DbConnection CreateConnection()
     {
         var connection = _dbProviderFactory.CreateConnection() ?? throw new InvalidOperationException($"DbProviderFactory.CreateConnection() returned null for {_dbProviderFactory}");
-        connection.ConnectionString = _connectionString;
+        connection.ConnectionString = _connectionString.Value;
         return connection;
     }
 


### PR DESCRIPTION
## What does this PR do?

This pull request fixes a discrepancy between `ContainerFixture` and `DbContainerFixture`. Accessing the `ConnectionString` property in the `Testcontainers.Xunit.DbContainerFixture<TBuilderEntity,TContainerEntity>.InitializeAsync` method might throw. Using a `Lazy<string>` instead makes it throw when the fixture is actually used.

## Why is it important?

To make `ContainerFixture` and `DbContainerFixture` have a consistent behaviour.

## Related issues

I discovered this issue while helping someone here: https://github.com/xunit/xunit/issues/3066
