### PR TITLE
feat: Add pausing and unpausing container

### DIFF
--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -91,6 +91,18 @@ namespace DotNet.Testcontainers.Clients
       return DockerClient.Containers.StopContainerAsync(id, new ContainerStopParameters { WaitBeforeKillSeconds = 15 }, ct);
     }
 
+    public Task PauseAsync(string id, CancellationToken ct = default)
+    {
+      Logger.PauseDockerContainer(id);
+      return DockerClient.Containers.PauseContainerAsync(id, ct);
+    }
+
+    public Task UnpauseAsync(string id, CancellationToken ct = default)
+    {
+      Logger.UnpauseDockerContainer(id);
+      return DockerClient.Containers.UnpauseContainerAsync(id, ct);
+    }
+
     public Task RemoveAsync(string id, CancellationToken ct = default)
     {
       Logger.DeleteDockerContainer(id);

--- a/src/Testcontainers/Clients/IDockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/IDockerContainerOperations.cs
@@ -19,6 +19,10 @@ namespace DotNet.Testcontainers.Clients
 
     Task StopAsync(string id, CancellationToken ct = default);
 
+    Task PauseAsync(string id, CancellationToken ct = default);
+
+    Task UnpauseAsync(string id, CancellationToken ct = default);
+
     Task RemoveAsync(string id, CancellationToken ct = default);
 
     Task ExtractArchiveToContainerAsync(string id, string path, TarOutputMemoryStream tarStream, CancellationToken ct = default);

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -78,21 +78,20 @@ namespace DotNet.Testcontainers.Clients
     /// <returns>Task that completes when the container has been stopped.</returns>
     Task StopAsync(string id, CancellationToken ct = default);
 
-
     /// <summary>
-    /// Pause the container.
+    /// Pauses the container.
     /// </summary>
     /// <param name="id">The container id.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the container has been started.</returns>
+    /// <returns>Task that completes when the container has been paused.</returns>
     Task PauseAsync(string id, CancellationToken ct = default);
 
     /// <summary>
-    /// Unpause the container.
+    /// Unpauses the container.
     /// </summary>
     /// <param name="id">The container id.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the container has been stopped.</returns>
+    /// <returns>Task that completes when the container has been unpaused.</returns>
     Task UnpauseAsync(string id, CancellationToken ct = default);
 
     /// <summary>

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -78,6 +78,23 @@ namespace DotNet.Testcontainers.Clients
     /// <returns>Task that completes when the container has been stopped.</returns>
     Task StopAsync(string id, CancellationToken ct = default);
 
+
+    /// <summary>
+    /// Pause the container.
+    /// </summary>
+    /// <param name="id">The container id.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been started.</returns>
+    Task PauseAsync(string id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Unpause the container.
+    /// </summary>
+    /// <param name="id">The container id.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been stopped.</returns>
+    Task UnpauseAsync(string id, CancellationToken ct = default);
+
     /// <summary>
     /// Removes the container.
     /// </summary>

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -142,6 +142,26 @@ namespace DotNet.Testcontainers.Clients
       }
     }
 
+    public async Task PauseAsync(string id, CancellationToken ct = default)
+    {
+      if (await Container.ExistsWithIdAsync(id, ct)
+            .ConfigureAwait(false))
+      {
+        await Container.PauseAsync(id, ct)
+          .ConfigureAwait(false);
+      }
+    }
+
+    public async Task UnpauseAsync(string id, CancellationToken ct = default)
+    {
+      if (await Container.ExistsWithIdAsync(id, ct)
+            .ConfigureAwait(false))
+      {
+        await Container.UnpauseAsync(id, ct)
+          .ConfigureAwait(false);
+      }
+    }
+
     /// <inheritdoc />
     public async Task RemoveAsync(string id, CancellationToken ct = default)
     {

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -142,6 +142,7 @@ namespace DotNet.Testcontainers.Clients
       }
     }
 
+    /// <inheritdoc />
     public async Task PauseAsync(string id, CancellationToken ct = default)
     {
       if (await Container.ExistsWithIdAsync(id, ct)
@@ -152,6 +153,7 @@ namespace DotNet.Testcontainers.Clients
       }
     }
 
+    /// <inheritdoc />
     public async Task UnpauseAsync(string id, CancellationToken ct = default)
     {
       if (await Container.ExistsWithIdAsync(id, ct)

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -606,11 +606,6 @@ namespace DotNet.Testcontainers.Containers
         return;
       }
 
-      if (!TestcontainersStates.Paused.Equals(State))
-      {
-        return;
-      }
-
       Unpausing?.Invoke(this, EventArgs.Empty);
 
       await _client.UnpauseAsync(_container.ID, ct)

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -606,7 +606,7 @@ namespace DotNet.Testcontainers.Containers
     {
       ThrowIfLockNotAcquired();
 
-      if (!Exists())
+      if (State != TestcontainersStates.Paused)
       {
         return;
       }

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -35,6 +35,18 @@ namespace DotNet.Testcontainers.Containers
     event EventHandler Stopping;
 
     /// <summary>
+    /// Subscribes to the pausing event.
+    /// </summary>
+    [CanBeNull]
+    event EventHandler Pausing;
+
+    /// <summary>
+    /// Subscribes to the unpausing event.
+    /// </summary>
+    [CanBeNull]
+    event EventHandler Unpausing;
+
+    /// <summary>
     /// Subscribes to the created event.
     /// </summary>
     [CanBeNull]
@@ -53,6 +65,18 @@ namespace DotNet.Testcontainers.Containers
     event EventHandler Stopped;
 
     /// <summary>
+    /// Subscribes to the paused event.
+    /// </summary>
+    [CanBeNull]
+    event EventHandler Paused;
+
+    /// <summary>
+    /// Subscribes to the unpaused event.
+    /// </summary>
+    [CanBeNull]
+    event EventHandler Unpaused;
+
+    /// <summary>
     /// Gets the created timestamp.
     /// </summary>
     DateTime CreatedTime { get; }
@@ -66,6 +90,16 @@ namespace DotNet.Testcontainers.Containers
     /// Gets the stopped timestamp.
     /// </summary>
     DateTime StoppedTime { get; }
+
+    /// <summary>
+    /// Gets the paused timestamp.
+    /// </summary>
+    DateTime PausedTime { get; }
+
+    /// <summary>
+    /// Gets the unpaused timestamp.
+    /// </summary>
+    DateTime UnpausedTime { get; }
 
     /// <summary>
     /// Gets the logger.
@@ -186,6 +220,26 @@ namespace DotNet.Testcontainers.Containers
     /// <exception cref="OperationCanceledException">Thrown when a Docker API call gets canceled.</exception>
     /// <exception cref="TaskCanceledException">Thrown when a Testcontainers task gets canceled.</exception>
     Task StopAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Pause the container.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been paused.</returns>
+    /// <exception cref="OperationCanceledException">Thrown when a Docker API call gets canceled.</exception>
+    /// <exception cref="TaskCanceledException">Thrown when a Testcontainers task gets canceled.</exception>
+    /// <exception cref="TimeoutException">Thrown when the wait strategy task gets canceled or the timeout expires.</exception>
+    Task PauseAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Unpause the container.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been unpaused.</returns>
+    /// <exception cref="OperationCanceledException">Thrown when a Docker API call gets canceled.</exception>
+    /// <exception cref="TaskCanceledException">Thrown when a Testcontainers task gets canceled.</exception>
+    /// <exception cref="TimeoutException">Thrown when the wait strategy task gets canceled or the timeout expires.</exception>
+    Task UnpauseAsync(CancellationToken ct = default);
 
     /// <summary>
     /// Copies a test host file to the container.

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -222,23 +222,21 @@ namespace DotNet.Testcontainers.Containers
     Task StopAsync(CancellationToken ct = default);
 
     /// <summary>
-    /// Pause the container.
+    /// Pauses the container.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that completes when the container has been paused.</returns>
     /// <exception cref="OperationCanceledException">Thrown when a Docker API call gets canceled.</exception>
     /// <exception cref="TaskCanceledException">Thrown when a Testcontainers task gets canceled.</exception>
-    /// <exception cref="TimeoutException">Thrown when the wait strategy task gets canceled or the timeout expires.</exception>
     Task PauseAsync(CancellationToken ct = default);
 
     /// <summary>
-    /// Unpause the container.
+    /// Unpauses the container.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that completes when the container has been unpaused.</returns>
     /// <exception cref="OperationCanceledException">Thrown when a Docker API call gets canceled.</exception>
     /// <exception cref="TaskCanceledException">Thrown when a Testcontainers task gets canceled.</exception>
-    /// <exception cref="TimeoutException">Thrown when the wait strategy task gets canceled or the timeout expires.</exception>
     Task UnpauseAsync(CancellationToken ct = default);
 
     /// <summary>

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -23,6 +23,12 @@ namespace DotNet.Testcontainers
     private static readonly Action<ILogger, string, Exception> _StopDockerContainer
       = LoggerMessage.Define<string>(LogLevel.Information, default, "Stop Docker container {Id}");
 
+    private static readonly Action<ILogger, string, Exception> _PauseDockerContainer
+      = LoggerMessage.Define<string>(LogLevel.Information, default, "Pause Docker container {Id}");
+
+    private static readonly Action<ILogger, string, Exception> _UnpauseDockerContainer
+      = LoggerMessage.Define<string>(LogLevel.Information, default, "Unpause Docker container {Id}");
+
     private static readonly Action<ILogger, string, Exception> _DeleteDockerContainer
       = LoggerMessage.Define<string>(LogLevel.Information, default, "Delete Docker container {Id}");
 
@@ -130,6 +136,16 @@ namespace DotNet.Testcontainers
     public static void StopDockerContainer(this ILogger logger, string id)
     {
       _StopDockerContainer(logger, TruncId(id), null);
+    }
+
+    public static void PauseDockerContainer(this ILogger logger, string id)
+    {
+      _PauseDockerContainer(logger, TruncId(id), null);
+    }
+
+    public static void UnpauseDockerContainer(this ILogger logger, string id)
+    {
+      _UnpauseDockerContainer(logger, TruncId(id), null);
     }
 
     public static void DeleteDockerContainer(this ILogger logger, string id)

--- a/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
@@ -1,0 +1,25 @@
+namespace Testcontainers.Tests
+{
+    public abstract class PauseUnpauseTest
+    {
+        [Fact]
+        public async Task PauseContainer()
+        {
+            await using var container = new ContainerBuilder()
+                .WithImage(CommonImages.Alpine)
+                .WithEntrypoint(CommonCommands.SleepInfinity)
+                .Build();
+
+            await container.StartAsync()
+                .ConfigureAwait(true);
+
+            await container.PauseAsync().ConfigureAwait(true);
+
+            Assert.Equal(TestcontainersStates.Paused, container.State);
+
+            await container.UnpauseAsync().ConfigureAwait(true);
+
+            Assert.Equal(TestcontainersStates.Running, container.State);
+        }
+    }
+}

--- a/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
@@ -1,25 +1,31 @@
-namespace Testcontainers.Tests
+namespace Testcontainers.Tests;
+
+public sealed class PauseUnpauseTest : IAsyncLifetime
 {
-    public abstract class PauseUnpauseTest
+    private readonly IContainer _container = new ContainerBuilder()
+        .WithImage(CommonImages.Alpine)
+        .WithCommand(CommonCommands.SleepInfinity)
+        .Build();
+
+    public Task InitializeAsync()
     {
-        [Fact]
-        public async Task PauseContainer()
-        {
-            await using var container = new ContainerBuilder()
-                .WithImage(CommonImages.Alpine)
-                .WithEntrypoint(CommonCommands.SleepInfinity)
-                .Build();
+        return _container.StartAsync();
+    }
 
-            await container.StartAsync()
-                .ConfigureAwait(true);
+    public Task DisposeAsync()
+    {
+        return _container.DisposeAsync().AsTask();
+    }
 
-            await container.PauseAsync().ConfigureAwait(true);
+    [Fact]
+    public async Task PausesAndUnpausesContainerSuccessfully()
+    {
+        await _container.PauseAsync()
+            .ConfigureAwait(true);
+        Assert.Equal(TestcontainersStates.Paused, _container.State);
 
-            Assert.Equal(TestcontainersStates.Paused, container.State);
-
-            await container.UnpauseAsync().ConfigureAwait(true);
-
-            Assert.Equal(TestcontainersStates.Running, container.State);
-        }
+        await _container.UnpauseAsync()
+            .ConfigureAwait(true);
+        Assert.Equal(TestcontainersStates.Running, _container.State);
     }
 }

--- a/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
@@ -1,3 +1,6 @@
+using Docker.DotNet;
+using Xunit.Sdk;
+
 namespace Testcontainers.Tests;
 
 public sealed class PauseUnpauseTest : IAsyncLifetime
@@ -27,5 +30,14 @@ public sealed class PauseUnpauseTest : IAsyncLifetime
         await _container.UnpauseAsync()
             .ConfigureAwait(true);
         Assert.Equal(TestcontainersStates.Running, _container.State);
+    }
+    
+    [Fact]
+    public async Task Unpauses_NotPaused_ContainerSuccessfully()
+    {
+        var thrown = await Assert.ThrowsAsync<DockerApiException>(async () => await _container.UnpauseAsync().ConfigureAwait(true));
+        
+        Assert.Equal(HttpStatusCode.InternalServerError, thrown.StatusCode);
+        Assert.Equal($"Docker API responded with status code=InternalServerError, response={{\"message\":\"Container {_container.Id} is not paused\"}}\n", thrown.Message);
     }
 }

--- a/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
@@ -1,6 +1,3 @@
-using Docker.DotNet;
-using Xunit.Sdk;
-
 namespace Testcontainers.Tests;
 
 public sealed class PauseUnpauseTest : IAsyncLifetime
@@ -31,13 +28,10 @@ public sealed class PauseUnpauseTest : IAsyncLifetime
             .ConfigureAwait(true);
         Assert.Equal(TestcontainersStates.Running, _container.State);
     }
-    
+
     [Fact]
-    public async Task Unpauses_NotPaused_ContainerSuccessfully()
+    public Task UnpausingRunningContainerThrowsDockerApiException()
     {
-        var thrown = await Assert.ThrowsAsync<DockerApiException>(async () => await _container.UnpauseAsync().ConfigureAwait(true));
-        
-        Assert.Equal(HttpStatusCode.InternalServerError, thrown.StatusCode);
-        Assert.Equal($"Docker API responded with status code=InternalServerError, response={{\"message\":\"Container {_container.Id} is not paused\"}}\n", thrown.Message);
+        return Assert.ThrowsAsync<DockerApiException>(() => _container.UnpauseAsync());
     }
 }

--- a/tests/Testcontainers.Platform.Linux.Tests/Usings.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/Usings.cs
@@ -8,6 +8,7 @@ global using System.Net.Sockets;
 global using System.Text;
 global using System.Threading;
 global using System.Threading.Tasks;
+global using Docker.DotNet;
 global using Docker.DotNet.Models;
 global using DotNet.Testcontainers;
 global using DotNet.Testcontainers.Builders;

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -567,26 +567,6 @@ namespace DotNet.Testcontainers.Tests.Unit
         await Assert.ThrowsAnyAsync<Exception>(() => container.StartAsync())
           .ConfigureAwait(true);
       }
-
-      [Fact]
-      public async Task PauseContainer()
-      {
-        await using var container = new ContainerBuilder()
-          .WithImage(CommonImages.Alpine)
-          .WithEntrypoint(CommonCommands.SleepInfinity)
-          .Build();
-
-        await container.StartAsync()
-          .ConfigureAwait(true);
-
-        await container.PauseAsync().ConfigureAwait(true);
-
-        Assert.Equal(TestcontainersStates.Paused, container.State);
-
-        await container.UnpauseAsync().ConfigureAwait(true);
-        
-        Assert.Equal(TestcontainersStates.Running, container.State);
-      }
     }
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using DotNet.Testcontainers.Containers;
+
 namespace DotNet.Testcontainers.Tests.Unit
 {
   using System;
@@ -563,6 +566,26 @@ namespace DotNet.Testcontainers.Tests.Unit
 
         await Assert.ThrowsAnyAsync<Exception>(() => container.StartAsync())
           .ConfigureAwait(true);
+      }
+
+      [Fact]
+      public async Task PauseContainer()
+      {
+        await using var container = new ContainerBuilder()
+          .WithImage(CommonImages.Alpine)
+          .WithEntrypoint(CommonCommands.SleepInfinity)
+          .Build();
+
+        await container.StartAsync()
+          .ConfigureAwait(true);
+
+        await container.PauseAsync().ConfigureAwait(true);
+
+        Assert.Equal(TestcontainersStates.Paused, container.State);
+
+        await container.UnpauseAsync().ConfigureAwait(true);
+        
+        Assert.Equal(TestcontainersStates.Running, container.State);
       }
     }
   }

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -1,6 +1,3 @@
-using System.Threading;
-using DotNet.Testcontainers.Containers;
-
 namespace DotNet.Testcontainers.Tests.Unit
 {
   using System;


### PR DESCRIPTION
## What does this PR do?

Added Methods to Pause and Unpause an container

## Why is it important?

Wanted to change some tests in CoreWCF to Testcontainers. Pause and Unpause is used there. Tho I need those methods to continue the implementation

