### PR TITLE
fix: Make Testcontainers.XunitV3 publishable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,10 +18,11 @@
         <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
         <PackageVersion Include="Dapper" Version="2.1.35"/>
         <PackageVersion Include="ReflectionMagic" Version="5.0.1"/>
-        <PackageVersion Include="xunit.extensibility.execution" Version="2.9.0"/>
-        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
-        <PackageVersion Include="xunit.v3.extensibility.core" Version="0.2.0-pre.69"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0"/>
         <PackageVersion Include="xunit" Version="2.9.2"/>
+        <!-- xUnit.net extensibility for Testcontainers.Xunit and Testcontainers.XunitV3 packages: -->
+        <PackageVersion Include="xunit.extensibility.execution" Version="2.9.0"/>
+        <PackageVersion Include="xunit.v3.extensibility.core" Version="1.0.0"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->
         <PackageVersion Include="Apache.NMS.ActiveMQ" Version="2.1.0"/>
         <PackageVersion Include="ArangoDBNetStandard" Version="2.0.1"/>

--- a/src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj
+++ b/src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj
@@ -2,8 +2,6 @@
     <PropertyGroup>
         <TargetFrameworks>net8.0;net9.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>
-        <IsPackable>false</IsPackable>
-        <IsPublishable>false</IsPublishable>
         <DefineConstants>$(DefineConstants);XUNIT_V3</DefineConstants>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
Now that xUnit.net v3 is released , the `Testcontainers.XunitV3` package can be published as a non pre-release too.