### PR TITLE
fix: Load PKCS#12 correctly for mTLS on Windows in .NET 9

### DIFF
--- a/src/Testcontainers/Builders/MTlsEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/MTlsEndpointAuthenticationProvider.cs
@@ -56,7 +56,7 @@ namespace DotNet.Testcontainers.Builders
       return Polyfills.X509Certificate2.CreateFromPemFile(clientCertificateFilePath, clientCertificateKeyFilePath);
 #elif NET9_0_OR_GREATER
       var certificate = X509Certificate2.CreateFromPemFile(clientCertificateFilePath, clientCertificateKeyFilePath);
-      return OperatingSystem.IsWindows() ? X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Pfx)) : certificate;
+      return OperatingSystem.IsWindows() ? X509CertificateLoader.LoadPkcs12(certificate.Export(X509ContentType.Pfx), null) : certificate;
 #elif NET6_0_OR_GREATER
       var certificate = X509Certificate2.CreateFromPemFile(clientCertificateFilePath, clientCertificateKeyFilePath);
       return OperatingSystem.IsWindows() ? new X509Certificate2(certificate.Export(X509ContentType.Pfx)) : certificate;


### PR DESCRIPTION
## What does this PR do?
Fixes loading of PKCS12 for mTLS on WIndows in .NET 9

As documented at https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0057#workaround, `LoadCertificate` does not support PKCS12. PFX files are PKCS12 these days.

## Why is it important?
Currently mTLS is broken for Windows in .NET 9

## Related issues
 - Closes #1319 

