### PR TITLE
fix(Pulsar): Support Apache Pulsar 4

### DIFF
--- a/src/Testcontainers.Pulsar/PulsarBuilder.cs
+++ b/src/Testcontainers.Pulsar/PulsarBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.Pulsar;
 [PublicAPI]
 public sealed class PulsarBuilder : ContainerBuilder<PulsarBuilder, PulsarContainer, PulsarConfiguration>
 {
-    public const string PulsarImage = "apachepulsar/pulsar:3.0.8";
+    public const string PulsarImage = "apachepulsar/pulsar:3.0.9";
 
     public const ushort PulsarBrokerDataPort = 6650;
 

--- a/src/Testcontainers.Pulsar/PulsarBuilder.cs
+++ b/src/Testcontainers.Pulsar/PulsarBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.Pulsar;
 [PublicAPI]
 public sealed class PulsarBuilder : ContainerBuilder<PulsarBuilder, PulsarContainer, PulsarConfiguration>
 {
-    public const string PulsarImage = "apachepulsar/pulsar:3.0.6";
+    public const string PulsarImage = "apachepulsar/pulsar:3.0.8";
 
     public const ushort PulsarBrokerDataPort = 6650;
 
@@ -12,7 +12,7 @@ public sealed class PulsarBuilder : ContainerBuilder<PulsarBuilder, PulsarContai
 
     public const string StartupScriptFilePath = "/testcontainers.sh";
 
-    public const string SecretKeyFilePath = "/pulsar/secret.key";
+    public const string SecretKeyFilePath = "/tmp/secret.key";
 
     public const string Username = "test-user";
 

--- a/src/Testcontainers.Pulsar/PulsarContainer.cs
+++ b/src/Testcontainers.Pulsar/PulsarContainer.cs
@@ -105,7 +105,7 @@ public sealed class PulsarContainer : DockerContainer
             startupScript.WriteLine("export brokerClientAuthenticationParameters=token:$(bin/pulsar tokens create --secret-key $PULSAR_PREFIX_tokenSecretKey --subject $superUserRoles)");
             startupScript.WriteLine("export CLIENT_PREFIX_authParams=$brokerClientAuthenticationParameters");
             startupScript.WriteLine("bin/apply-config-from-env.py conf/standalone.conf");
-            startupScript.WriteLine("bin/apply-config-from-env-with-prefix.py CLIENT_PREFIX_ conf/client.conf");
+            startupScript.WriteLine("bin/apply-config-from-env.py --prefix CLIENT_PREFIX_ conf/client.conf");
         }
 
         startupScript.Write("bin/pulsar standalone");

--- a/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
+++ b/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
@@ -84,4 +84,22 @@ public abstract class PulsarContainerTest : IAsyncLifetime
         {
         }
     }
+    
+    [UsedImplicitly]
+    public sealed class PulsarDefaultConfigurationLts4 : PulsarContainerTest
+    {
+        public PulsarDefaultConfigurationLts4()
+            : base(new PulsarBuilder().WithImage("apachepulsar/pulsar:4.0.2").Build(), false)
+        {
+        }
+    }
+    
+    [UsedImplicitly]
+    public sealed class PulsarAuthConfigurationLts4 : PulsarContainerTest
+    {
+        public PulsarAuthConfigurationLts4()
+            : base(new PulsarBuilder().WithImage("apachepulsar/pulsar:4.0.2").WithAuthentication().Build(), true)
+        {
+        }
+    }
 }


### PR DESCRIPTION
## What does this PR do?
- Replaced deprecated script arguments with the updated ones to ensure proper configuration handling.
- Upgraded the Pulsar image to version **3.0.8**.
- Updated default file paths to align with version **4.0.X** for better compatibility and usability.

## Why is it important?
The new Apache Pulsar **4.0.X** container image enforces stricter security by reducing user privileges. As a result, the `secret.key` file needs to be created in a location that can be written to in both **3.0.X** and **4.0.X** versions.
This change ensures **backward compatibility**, which is a core principle of Testcontainers, while also taking advantage of the latest improvements in Pulsar **4.0.X**.

## How to test this PR
- Ran the test suite using Apache Pulsar broker images for both versions **3.0.8** and **4.0.2** to successfully validate compatibility across both versions.
- Tests passed in both scenarios.

### Open Question
@HofmeisterAn, would you prefer that I configure the tests to explicitly validate against both image versions (e.g., **3.0.X** and **4.0.X**), or is it sufficient to test exclusively with the latest default version (`3.0.X`)? Let me know how you'd like to proceed.

- Closes #1291
- Closes #1294
