### PR TITLE
chore: Remove binding of ports to IPv4 only

### DIFF
--- a/src/Testcontainers/Clients/ContainerConfigurationConverter.cs
+++ b/src/Testcontainers/Clients/ContainerConfigurationConverter.cs
@@ -148,9 +148,8 @@ namespace DotNet.Testcontainers.Clients
 
       public override IEnumerable<KeyValuePair<string, IList<PortBinding>>> Convert([CanBeNull] IEnumerable<KeyValuePair<string, string>> source)
       {
-        // https://github.com/moby/moby/pull/41805#issuecomment-893349240.
         return source?.Select(portBinding => new KeyValuePair<string, IList<PortBinding>>(
-          GetQualifiedPort(portBinding.Key), new[] { new PortBinding { HostIP = IPAddress.Any.ToString(), HostPort = portBinding.Value } }));
+          GetQualifiedPort(portBinding.Key), new[] { new PortBinding { HostPort = portBinding.Value } }));
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Removes the HostIP from the Port Binding so that it does not restrict itself to IPv4.

## Why is it important?

Not needed anymore.

## Related issues

- Closes #825
- Closes #1360 
