### PR TITLE
fix(Redpanda): Add missing command-line arguments to the startup script (smp, memory)

### DIFF
--- a/src/Testcontainers.Redpanda/RedpandaBuilder.cs
+++ b/src/Testcontainers.Redpanda/RedpandaBuilder.cs
@@ -59,6 +59,8 @@ public sealed class RedpandaBuilder : ContainerBuilder<RedpandaBuilder, Redpanda
                 startupScript.Append(lf);
                 startupScript.Append("/usr/bin/rpk redpanda start ");
                 startupScript.Append("--mode dev-container ");
+                startupScript.Append("--smp 1 ");
+                startupScript.Append("--memory 1G ");
                 startupScript.Append("--kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092 ");
                 startupScript.Append("--advertise-kafka-addr PLAINTEXT://127.0.0.1:29092,OUTSIDE://" + container.Hostname + ":" + container.GetMappedPublicPort(RedpandaPort));
                 return container.CopyAsync(Encoding.Default.GetBytes(startupScript.ToString()), StartupScriptFilePath, Unix.FileMode755, ct);


### PR DESCRIPTION
## What does this PR do?

Fixes issues when multiple concurrent redpanda test containers are running and some fail to startup due to resouce exhaustion

Updated Startup Script to include command line arguments for smp and memory
Command Line argument Values are now consitent with python, go, java, node and ruby implementations:
- https://github.com/testcontainers/testcontainers-python/blob/main/modules/kafka/testcontainers/kafka/_redpanda.py
- https://github.com/testcontainers/testcontainers-go/blob/main/modules/redpanda/redpanda.go
- https://github.com/testcontainers/testcontainers-java/blob/main/modules/redpanda/src/main/java/org/testcontainers/redpanda/RedpandaContainer.java
- https://github.com/testcontainers/testcontainers-node/blob/main/packages/modules/redpanda/src/redpanda-container.ts
- https://github.com/testcontainers/testcontainers-ruby/blob/main/redpanda/lib/testcontainers/redpanda.rb

## Why is it important?

These updated values adresses the scenario where multiple redpanda test containers instances are wired up and that some containers stop / fail due to resource exhaustion. The following error is captured from the container which has failed:

```
2025-02-07 09:45:20 WARN  2025-02-07 17:45:20,613 seastar - Requested AIO slots too large, please increase request capacity in /proc/sys/fs/aio-max-nr. available:6559 requested:110260 
2025-02-07 09:45:20 Could not initialize seastar: std::runtime_error (Could not setup Async I/O: Not enough request capacity in /proc/sys/fs/aio-max-nr. Try increasing that number or reducing the amount of logical CPUs available for your application)
```

## Related issues

N/A -> No open issues have been reported
