### PR TITLE
chore: Set PackageLicenseExpression property to MIT

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <Summary>Choose from existing pre-configured modules and start containers within a second, to support and run your tests. Or create your own container images with Dockerfiles and run your containers and tests immediately afterward.</Summary>
     <PackageIcon>docs/logo.png</PackageIcon>
     <PackageIconUrl>https://github.com/testcontainers/testcontainers-dotnet/raw/develop/docs/logo.png</PackageIconUrl>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageProjectUrl>https://dotnet.testcontainers.org/</PackageProjectUrl>
     <PackageTags>automation;docker;dotnet;testcontainers;testcontainers-dotnet;testing</PackageTags>


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->
Switches from using the license file to indicate the license in the nuget package to using PackageLicenseExpression to explicitly define the license for the nugets.


## Why is it important?


<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

This allows
- Allows tools like nuget-license (https://github.com/sensslen/nuget-license) to automatically detect the license of a package - currently we need to configure manual overrides and update the version in the override each time testconatainers gets updated
- nuget.org to show the license in the sidebar directly like this (see here: https://www.nuget.org/packages/dotnet-ef)
![grafik](https://github.com/user-attachments/assets/679e1f0b-eafb-449f-9377-bb7b72f2ff5e)




## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- no releated issues

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Manual test:
- Run `nuget pack` for any project in the repo
- Start manual upload process for a nuget here: https://www.nuget.org/packages/manage/upload
- The page will show the package metadata with license information for verification before finishing the upload

