### PR TITLE
fix(MongoDb): Evaluate replica set status in wait strategy

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,7 +58,7 @@
         <PackageVersion Include="Microsoft.Azure.Kusto.Data" Version="12.2.8"/>
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2"/>
         <PackageVersion Include="Milvus.Client" Version="2.2.2-preview.6"/>
-        <PackageVersion Include="MongoDB.Driver" Version="2.19.0"/>
+        <PackageVersion Include="MongoDB.Driver" Version="3.2.0"/>
         <PackageVersion Include="MyCouch" Version="7.6.0"/>
         <PackageVersion Include="MySqlConnector" Version="2.2.5"/>
         <PackageVersion Include="NATS.Client" Version="1.0.8"/>

--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -190,7 +190,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
         /// <param name="configuration">The container configuration.</param>
         public WaitInitiateReplicaSet(MongoDbConfiguration configuration)
         {
-            _scriptContent = $"try{{rs.status().ok}}catch(e){{rs.initiate({{'_id':'{configuration.ReplicaSetName}',members:[{{'_id':1,'host':'127.0.0.1:27017'}}]}}).ok}}";
+            _scriptContent = $"try{{rs.status()}}catch(e){{rs.initiate({{_id:'{configuration.ReplicaSetName}',members:[{{_id:0,host:'127.0.0.1:27017'}}]}});throw e;}}";
         }
 
         /// <inheritdoc />

--- a/src/Testcontainers.MongoDb/MongoDbContainer.cs
+++ b/src/Testcontainers.MongoDb/MongoDbContainer.cs
@@ -26,6 +26,7 @@ public sealed class MongoDbContainer : DockerContainer
         var endpoint = new UriBuilder("mongodb", Hostname, GetMappedPublicPort(MongoDbBuilder.MongoDbPort));
         endpoint.UserName = Uri.EscapeDataString(_configuration.Username);
         endpoint.Password = Uri.EscapeDataString(_configuration.Password);
+        endpoint.Query = "?directConnection=true";
         return endpoint.ToString();
     }
 

--- a/tests/Testcontainers.MongoDb.Tests/MongoDbContainerTest.cs
+++ b/tests/Testcontainers.MongoDb.Tests/MongoDbContainerTest.cs
@@ -73,7 +73,7 @@ public abstract class MongoDbContainerTest : IAsyncLifetime
         }
         else
         {
-            Assert.Equal(1L, execResult.ExitCode);
+            Assert.True(1L.Equals(execResult.ExitCode), execResult.Stdout);
             Assert.Equal("MongoServerError: not running with --replSet\n", execResult.Stderr);
         }
     }


### PR DESCRIPTION
## What does this PR do?

The PR updates the MongoDB shell script that initiates the replica set during startup. The previous script contained a bug where the script succeed on `rs.initiate()` but never check the actually replica set status (`rs.status()`).

## Why is it important?

This caused race conditions where the MongoDB module indicated readiness too early (before the replica set was fully initiated).

Kudos to @Yorie for taking the time to look into the bug. Thanks again.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1284

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
