### PR TITLE
fix: Retrieve logs since `CreatedTime` for `UntilMessageIsLogged` wait strategy

### DIFF
--- a/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
@@ -21,7 +21,8 @@ namespace DotNet.Testcontainers.Configurations
 
     public async Task<bool> UntilAsync(IContainer container)
     {
-      var (stdout, stderr) = await container.GetLogsAsync(since: container.StoppedTime, timestampsEnabled: false)
+      var maxTime = container.StoppedTime > container.CreatedTime ? container.StoppedTime : container.CreatedTime;
+      var (stdout, stderr) = await container.GetLogsAsync(since: maxTime, timestampsEnabled: false)
         .ConfigureAwait(false);
 
       return _pattern.IsMatch(stdout) || _pattern.IsMatch(stderr);


### PR DESCRIPTION
## What does this PR do?

This pull request retrieves logs since `CreatedTime` for the `UntilMessageIsLogged` wait strategy to ensure that logs from the previous run are ignored and only logs from the current run are processed.

## Why is it important?

This is required for reused containers since old logs (from previous runs) are still available.

## Related issues

Fixes #1383

## How to test this PR

See sample program in #1383