### PR TITLE
fix: Add support for postgres 9.2 and lower

### DIFF
--- a/src/Testcontainers.PostgreSql/PostgreSqlBuilder.cs
+++ b/src/Testcontainers.PostgreSql/PostgreSqlBuilder.cs
@@ -74,9 +74,16 @@ public sealed class PostgreSqlBuilder : ContainerBuilder<PostgreSqlBuilder, Post
     {
         Validate();
 
+        // The PostgreSql image does not contain pg_isready before version 9.3. Wait for logging message that says server is ready - "PostgreSQL init process complete; ready for start up."
+        // this was used instead of using psql select version() because the database is still not ready to accept external connection https://github.com/docker-library/postgres/issues/146
+        var isLegacyPostgreSql = DockerResourceConfiguration.Image.MatchVersion(v => v.Major <= 9 && v.Minor < 3);
         // By default, the base builder waits until the container is running. However, for PostgreSql, a more advanced waiting strategy is necessary that requires access to the configured database and username.
         // If the user does not provide a custom waiting strategy, append the default PostgreSql waiting strategy.
-        var postgreSqlBuilder = DockerResourceConfiguration.WaitStrategies.Count() > 1 ? this : WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil(DockerResourceConfiguration)));
+        var postgreSqlBuilder = DockerResourceConfiguration.WaitStrategies.Count() > 1
+            ? this
+            : isLegacyPostgreSql
+                ? WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("PostgreSQL init process complete; ready for start up."))
+                : WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil(DockerResourceConfiguration)));
         return new PostgreSqlContainer(postgreSqlBuilder.DockerResourceConfiguration);
     }
 

--- a/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
+++ b/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
@@ -1,9 +1,16 @@
 namespace Testcontainers.PostgreSql;
 
-public sealed class PostgreSqlContainerTest : IAsyncLifetime
+public abstract class PostgreSqlContainerTest : IAsyncLifetime
 {
     // # --8<-- [start:UsePostgreSqlContainer]
-    private readonly PostgreSqlContainer _postgreSqlContainer = new PostgreSqlBuilder().Build();
+    private readonly PostgreSqlContainer _postgreSqlContainer;
+
+    public PostgreSqlContainer Container { get { return _postgreSqlContainer; } }
+
+    public PostgreSqlContainerTest(PostgreSqlContainer postgreSqlContainer)
+    {
+        _postgreSqlContainer = postgreSqlContainer;
+    }
 
     public Task InitializeAsync()
     {
@@ -46,13 +53,13 @@ public sealed class PostgreSqlContainerTest : IAsyncLifetime
     }
     // # --8<-- [end:UsePostgreSqlContainer]
 
-    public sealed class ReuseContainerTest : IClassFixture<PostgreSqlFixture>, IDisposable
+    public sealed class ReusePostgres15ContainerTest : IClassFixture<PostgreSql15Fixture>, IDisposable
     {
         private readonly CancellationTokenSource _cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
 
-        private readonly PostgreSqlFixture _fixture;
+        private readonly PostgreSql15Fixture _fixture;
 
-        public ReuseContainerTest(PostgreSqlFixture fixture)
+        public ReusePostgres15ContainerTest(PostgreSql15Fixture fixture)
         {
             _fixture = fixture;
         }
@@ -79,10 +86,20 @@ public sealed class PostgreSqlContainerTest : IAsyncLifetime
     }
 
     [UsedImplicitly]
-    public sealed class PostgreSqlFixture : ContainerFixture<PostgreSqlBuilder, PostgreSqlContainer>
+    public sealed class PostgreSql15Fixture : PostgreSqlContainerTest
     {
-        public PostgreSqlFixture(IMessageSink messageSink)
-            : base(messageSink)
+        public PostgreSql15Fixture()
+            : base(new PostgreSqlBuilder().Build())
+        {
+        }
+    }
+
+    [UsedImplicitly]
+    public sealed class PostgreSql9Fixture : PostgreSqlContainerTest
+    {
+        // https://github.com/testcontainers/testcontainers-dotnet/issues/1142.
+        public PostgreSql9Fixture()
+            : base(new PostgreSqlBuilder().WithImage("postgres:9.2").Build())
         {
         }
     }


### PR DESCRIPTION
## What does this PR do?

This PR adds support for running Postgres containers below version 9.3. Adds to the `PostgreSqlBuilder.Build` method to check for Postgres versions below 9.3 (which doesn't have support for `pg_isready` to check for database readiness) using `Image.MatchVersion` - for these versions check for message logged in container using `UntilMessageIsLogged `helper method for the message "PostgreSQL init process complete; ready for start up."

Other strategies tried
- using psql to connect to container db and running `select 1` or `select version()` - these were not reliable and the database was not in a state ready to accept connections
- using "database system is ready to accept connections" - but couldn't reliably connect on the first instance of the message

related github discussion that helped determine above strategy: https://github.com/docker-library/postgres/issues/146

## Why is it important?

some older codebases are built on older versions of postgres, and being able to build tests using those older versions before migrating the version gives peace of mind for validating successful migration
