### PR TITLE
feat(EventHubs, ServiceBus): Replace wait strategy with HTTP health check

### DIFF
--- a/src/Testcontainers.Db2/Db2Container.cs
+++ b/src/Testcontainers.Db2/Db2Container.cs
@@ -42,7 +42,7 @@ public sealed class Db2Container : DockerContainer, IDatabaseContainer
         await CopyAsync(Encoding.Default.GetBytes(scriptContent), scriptFilePath, Unix.FileMode644, ct)
             .ConfigureAwait(false);
 
-        return await ExecAsync(new [] { "/bin/sh", "-c", db2ShellCommand}, ct)
+        return await ExecAsync(new[] { "/bin/sh", "-c", db2ShellCommand}, ct)
             .ConfigureAwait(false);
     }
 }

--- a/src/Testcontainers.EventHubs/EventHubsBuilder.cs
+++ b/src/Testcontainers.EventHubs/EventHubsBuilder.cs
@@ -139,7 +139,7 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
             .WithPortBinding(EventHubsPort, true)
             .WithPortBinding(EventHubsHttpPort, true)
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
-                request.ForPath("/health").ForPort(EventHubsHttpPort)));
+                request.ForPort(EventHubsHttpPort).ForPath("/health")));
     }
 
     /// <inheritdoc />
@@ -158,23 +158,5 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
     protected override EventHubsBuilder Merge(EventHubsConfiguration oldValue, EventHubsConfiguration newValue)
     {
         return new EventHubsBuilder(new EventHubsConfiguration(oldValue, newValue));
-    }
-
-    /// <inheritdoc cref="IWaitUntil" />
-    /// <remarks>
-    /// This is a workaround to ensure that the wait strategy does not indicate
-    /// readiness too early:
-    /// https://github.com/Azure/azure-service-bus-emulator-installer/issues/35#issuecomment-2497164533.
-    /// </remarks>
-    private sealed class WaitTwoSeconds : IWaitUntil
-    {
-        /// <inheritdoc />
-        public async Task<bool> UntilAsync(IContainer container)
-        {
-            await Task.Delay(TimeSpan.FromSeconds(2))
-                .ConfigureAwait(false);
-
-            return true;
-        }
     }
 }

--- a/src/Testcontainers.EventHubs/EventHubsBuilder.cs
+++ b/src/Testcontainers.EventHubs/EventHubsBuilder.cs
@@ -12,6 +12,8 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
 
     public const ushort EventHubsPort = 5672;
 
+    public const ushort EventHubsHttpPort = 5300;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="EventHubsBuilder" /> class.
     /// </summary>
@@ -135,9 +137,9 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
         return base.Init()
             .WithImage(EventHubsImage)
             .WithPortBinding(EventHubsPort, true)
-            .WithWaitStrategy(Wait.ForUnixContainer()
-                .UntilMessageIsLogged("Emulator Service is Successfully Up!")
-                .AddCustomWaitStrategy(new WaitTwoSeconds()));
+            .WithPortBinding(EventHubsHttpPort, true)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
+                request.ForPath("/health").ForPort(EventHubsHttpPort)));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
@@ -120,7 +120,7 @@ public sealed class ServiceBusBuilder : ContainerBuilder<ServiceBusBuilder, Serv
             .WithPortBinding(ServiceBusHttpPort, true)
             .WithEnvironment("SQL_WAIT_INTERVAL", "0")
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
-                request.ForPath("/health").ForPort(ServiceBusHttpPort)));
+                request.ForPort(ServiceBusHttpPort).ForPath("/health")));
     }
 
     /// <inheritdoc />
@@ -139,23 +139,5 @@ public sealed class ServiceBusBuilder : ContainerBuilder<ServiceBusBuilder, Serv
     protected override ServiceBusBuilder Merge(ServiceBusConfiguration oldValue, ServiceBusConfiguration newValue)
     {
         return new ServiceBusBuilder(new ServiceBusConfiguration(oldValue, newValue));
-    }
-
-    /// <inheritdoc cref="IWaitUntil" />
-    /// <remarks>
-    /// This is a workaround to ensure that the wait strategy does not indicate
-    /// readiness too early:
-    /// https://github.com/Azure/azure-service-bus-emulator-installer/issues/35#issuecomment-2497164533.
-    /// </remarks>
-    private sealed class WaitTwoSeconds : IWaitUntil
-    {
-        /// <inheritdoc />
-        public async Task<bool> UntilAsync(IContainer container)
-        {
-            await Task.Delay(TimeSpan.FromSeconds(2))
-                .ConfigureAwait(false);
-
-            return true;
-        }
     }
 }

--- a/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
@@ -12,6 +12,8 @@ public sealed class ServiceBusBuilder : ContainerBuilder<ServiceBusBuilder, Serv
 
     public const ushort ServiceBusPort = 5672;
 
+    public const ushort ServiceBusHttpPort = 5300;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ServiceBusBuilder" /> class.
     /// </summary>
@@ -115,9 +117,10 @@ public sealed class ServiceBusBuilder : ContainerBuilder<ServiceBusBuilder, Serv
         return base.Init()
             .WithImage(ServiceBusImage)
             .WithPortBinding(ServiceBusPort, true)
-            .WithWaitStrategy(Wait.ForUnixContainer()
-                .UntilMessageIsLogged("Emulator Service is Successfully Up!")
-                .AddCustomWaitStrategy(new WaitTwoSeconds()));
+            .WithPortBinding(ServiceBusHttpPort, true)
+            .WithEnvironment("SQL_WAIT_INTERVAL", "0")
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
+                request.ForPath("/health").ForPort(ServiceBusHttpPort)));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -505,7 +505,7 @@ namespace DotNet.Testcontainers.Containers
       await _client.StartAsync(_container.ID, ct)
         .ConfigureAwait(false);
 
-      _ = await CheckReadinessAsync(new [] { portBindingsMapped }, ct)
+      _ = await CheckReadinessAsync(new[] { portBindingsMapped }, ct)
         .ConfigureAwait(false);
 
       Starting?.Invoke(this, EventArgs.Empty);

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -202,6 +202,7 @@ namespace DotNet.Testcontainers.Images
 
       // Default to 755 for Windows and fall back to 755 for Unix when `GetUnixFileMode`
       // is not available.
+      _ = filePath;
       return (int)Unix.FileMode755;
     }
   }

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -4,7 +4,6 @@ namespace DotNet.Testcontainers.Images
   using System.Collections.Generic;
   using System.IO;
   using System.Linq;
-  using System.Runtime.InteropServices;
   using System.Text;
   using System.Text.RegularExpressions;
   using System.Threading;
@@ -150,7 +149,7 @@ namespace DotNet.Testcontainers.Images
               {
                 var entry = TarEntry.CreateTarEntry(relativeFilePath);
                 entry.TarHeader.Size = inputStream.Length;
-                entry.TarHeader.Mode = GetFileMode(absoluteFilePath);
+                entry.TarHeader.Mode = GetUnixFileMode(absoluteFilePath);
 
                 await tarOutputStream.PutNextEntryAsync(entry, ct)
                   .ConfigureAwait(false);
@@ -188,21 +187,21 @@ namespace DotNet.Testcontainers.Images
     }
 
     /// <summary>
-    /// Gets the file mode for a given file.
+    /// Gets the Unix file mode of the file on the path.
     /// </summary>
-    /// <param name="path">The path to the file.</param>
-    /// <returns>The file mode for the <see cref="TarEntry"/></returns>
-    private static int GetFileMode(string path)
+    /// <param name="filePath">The path to the file.</param>
+    /// <returns>The Unix file mode of the file on the path.</returns>
+    private static int GetUnixFileMode(string filePath)
     {
 #if NET7_0_OR_GREATER
-      if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+      if (!OperatingSystem.IsWindows())
       {
-        return (int)File.GetUnixFileMode(path);
+        return (int)File.GetUnixFileMode(filePath);
       }
 #endif
 
-      // Default to 755 for Windows and fallback to 755 for Unix when
-      // `GetUnixFileMode` is not available.
+      // Default to 755 for Windows and fall back to 755 for Unix when `GetUnixFileMode`
+      // is not available.
       return (int)Unix.FileMode755;
     }
   }


### PR DESCRIPTION
## What does this PR do?

Reduce startup time of the service bus testcontainer by up to 10 seconds using the new available features.

## Why is it important?

Reduce total test run time.

## Related issues

- https://github.com/Azure/azure-service-bus-emulator-installer/issues/15
- https://github.com/Azure/azure-service-bus-emulator-installer/issues/35
