### PR TITLE
feat(Keycloak): Support admin bootstrapping for version 26 onwards

### DIFF
--- a/src/Testcontainers.Keycloak/KeycloakBuilder.cs
+++ b/src/Testcontainers.Keycloak/KeycloakBuilder.cs
@@ -44,6 +44,7 @@ public sealed class KeycloakBuilder : ContainerBuilder<KeycloakBuilder, Keycloak
     public KeycloakBuilder WithUsername(string username)
     {
         return Merge(DockerResourceConfiguration, new KeycloakConfiguration(username: username))
+            .WithEnvironment("KC_BOOTSTRAP_ADMIN_USERNAME", username)
             .WithEnvironment("KEYCLOAK_ADMIN", username);
     }
 
@@ -55,6 +56,7 @@ public sealed class KeycloakBuilder : ContainerBuilder<KeycloakBuilder, Keycloak
     public KeycloakBuilder WithPassword(string password)
     {
         return Merge(DockerResourceConfiguration, new KeycloakConfiguration(password: password))
+            .WithEnvironment("KC_BOOTSTRAP_ADMIN_PASSWORD", password)
             .WithEnvironment("KEYCLOAK_ADMIN_PASSWORD", password);
     }
 

--- a/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
+++ b/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
@@ -65,4 +65,13 @@ public abstract class KeycloakContainerTest : IAsyncLifetime
         {
         }
     }
+
+    [UsedImplicitly]
+    public sealed class KeycloakV26Configuration : KeycloakContainerTest
+    {
+        public KeycloakV26Configuration()
+            : base(new KeycloakBuilder().WithImage("quay.io/keycloak/keycloak:26.0").Build())
+        {
+        }
+    }
 }


### PR DESCRIPTION
- Added private fields for username and password in KeycloakBuilder.
- Modified Build method to handle environment variables based on Keycloak version.
- Introduced KeycloakV26Configuration for testing with Keycloak version 26.

## What does this PR do?

From https://www.keycloak.org/docs/26.0.0/upgrading/#admin-bootstrapping-and-recovery

> It used to be difficult to regain access to a Keycloak instance when all admin users were locked out. The process required multiple advanced steps, including direct database access and manual changes. In an effort to improve the user experience, Keycloak now provides multiple ways to bootstrap a new admin account, which can be used to recover from such situations.
> 
> Consequently, the environment variables `KEYCLOAK_ADMIN` and `KEYCLOAK_ADMIN_PASSWORD` have been deprecated. You should use `KC_BOOTSTRAP_ADMIN_USERNAME` and `KC_BOOTSTRAP_ADMIN_PASSWORD` instead. These are also general options, so they may be specified via the cli or other config sources, for example `--bootstrap-admin-username=admin`. For more information, see the new [Bootstrap admin and recovery](https://www.keycloak.org/server/bootstrap-admin-recovery) guide.

## Why is it important?

Keep up to date with Keycloak.

## Related issues

- Closes #1399
