### PR TITLE
docs: Add Bitbucket Pipelines configuration

### DIFF
--- a/docs/cicd/index.md
+++ b/docs/cicd/index.md
@@ -21,76 +21,22 @@ variables:
   DOCKER_HOST: tcp://docker:2375
 ```
 
-## Bitbucket CI/CD
+## Bitbucket Pipelines
 
-Enable your bitbucket CI/CD pipeline as usual on the admin-pipelines-settings page. After enabling your pipeline, replace the content of *bitbucket-pipelines.yml* (you can find this file in the root of your source folder) with:
+Enable Bitbucket Pipelines as usual on the **Repository settings → Pipelines → Settings** page. After enabling your pipeline, replace the contents of the `bitbucket-pipelines.yml` file, located at the root of your repository, with the following:
 
 ```yml
-image: mcr.microsoft.com/dotnet/sdk:9.0
-
+image: mcr.microsoft.com/dotnet/sdk:8.0
 options:
   docker: true
-
 pipelines:
   default:
     - step:
-        name: Build and Test
-        services:
-          - docker
-        caches:
-          - dotnetcore
-        script:
-          - dotnet restore
-          - dotnet build --configuration Release
-          - dotnet test --configuration Release --no-build --logger "trx;LogFileName=test-results.trx"
-        artifacts:
-          - test-results.trx
+      script:
+        # Bitbucket Pipelines does not support Ryuk:
+        # https://dotnet.testcontainers.org/api/resource_reaper/.
+        - export TESTCONTAINERS_RYUK_DISABLED=true
+        - dotnet test
+      services:
+        - docker
 ```
-
-In your code, you can use a [standard hello world xUnit application](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-with-dotnet-test). Replace the test code with the following code:
-
-```csharp
-[Fact]
-public async Task Test_HelloWorldContainer()
-{
-    //https://github.com/testcontainers/testcontainers-dotnet/issues/492
-    TestcontainersSettings.ResourceReaperEnabled = false;
-    //Arrange
-    
-    // Create a new instance of a container.
-    var container = new ContainerBuilder()
-      // Set the image for the container to "testcontainers/helloworld:1.1.0".
-      .WithImage("testcontainers/helloworld:1.1.0")
-      // Bind port 8080 of the container to a random port on the host.
-      .WithPortBinding(8080, true)
-      // Wait until the HTTP endpoint of the container is available.
-      .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(r => r.ForPort(8080)))
-      // Build the container configuration.
-      .Build();
-    
-    await container.StartAsync();
-
-    // Act
-    var httpClient = new HttpClient
-    {
-        BaseAddress = new Uri($"http://{container.Hostname}:{container.GetMappedPublicPort(8080)}")
-    };
-
-    var response = await httpClient.GetAsync("/");
-    var content = await response.Content.ReadAsStringAsync();
-
-    // Assert
-    Assert.True(response.IsSuccessStatusCode, "Expected a successful HTTP response");
-    Assert.Contains("Hello world", content, StringComparison.OrdinalIgnoreCase);
-}
-```
-
-Note the *Reaper* config:
-
-```csharp
-TestcontainersSettings.ResourceReaperEnabled = false;
-```
-
-If you don't enable this config, the test container will not function correctly.
-
-Run the pipeline by pushing code or by clicking *Run pipeline* on the Pipelines page.


### PR DESCRIPTION
## What does this PR do?

The documentation to get testcontainers-dotnet up and running in bitbucket seems to be missing.  This PR suggests bitbucket CI/CD documentation.

## Why is it important?

Bitbucket users cannot copy/paste the existing CI/CD examples, a particular Bitbucket config (reaper setting) is mandatory.

## Related issues

Relates #1393
