### PR TITLE
chore: Use Docker Compose to host documentation locally

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,9 @@
+services:
+  docs:
+    image: python:3.8
+    command: sh -c "pip install -r requirements.txt && mkdocs serve -a 0.0.0.0:8000"
+    working_dir: /docs
+    volumes:
+      - ./:/docs
+    ports:
+      - 8000:8000

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   docs:
-    image: python:3.8
+    image: python:3.8-alpine
     command: sh -c "pip install -r requirements.txt && mkdocs serve -a 0.0.0.0:8000"
     working_dir: /docs
     volumes:

--- a/docs/contributing_docs.md
+++ b/docs/contributing_docs.md
@@ -16,7 +16,8 @@ We publish our documentation using Netlify.
 * Once Python dependencies have been installed, run `mkdocs serve` to start a local auto-updating MkDocs server.
 
 ### Using Docker
-The root of the project contains a `compose.yml` file. Simply run `docker compose up` and then access the docs at http://localhost:8000.
+
+The root of the project contains a `compose.yml` file. Simply run `docker compose up` and access the docs at: `http://localhost:8000`.
 
 ### PR preview deployments
 

--- a/docs/contributing_docs.md
+++ b/docs/contributing_docs.md
@@ -15,6 +15,9 @@ We publish our documentation using Netlify.
 * Set up a virtualenv and run `pip install -r requirements.txt` in the `testcontainers-dotnet` root directory.
 * Once Python dependencies have been installed, run `mkdocs serve` to start a local auto-updating MkDocs server.
 
+### Using Docker
+The root of the project contains a `compose.yml` file. Simply run `docker compose up` and then access the docs at http://localhost:8000.
+
 ### PR preview deployments
 
 Note that documentation for pull requests will automatically be published by Netlify as 'deploy preview'.


### PR DESCRIPTION
## What does this PR do?

Added `compose.yml` file to been able to start local mkdocs server without installing python3.8 on host machine. Took inspiration from tc for node project.

## Why is it important?

Do not need to install python on host to be able to work with docs.

## How to test this PR

Run `docker compose up` and visit `http://localhost:8000`

