### PR TITLE
fix: Add Docker Hub image name prefix to image builder API `WithName(IImage)`

### DIFF
--- a/docs/examples/dind.md
+++ b/docs/examples/dind.md
@@ -33,5 +33,5 @@ services:
     # environment:
     #   - TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock.raw:/var/run/docker.sock
 ```

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -92,17 +92,7 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc />
     public TBuilderEntity WithImage(IImage image)
     {
-      if (string.IsNullOrEmpty(TestcontainersSettings.HubImageNamePrefix))
-      {
-        return Clone(new ContainerConfiguration(image: image));
-      }
-
-      if (!string.IsNullOrEmpty(image.GetHostname()))
-      {
-        return Clone(new ContainerConfiguration(image: image));
-      }
-
-      return Clone(new ContainerConfiguration(image: new DockerImage(image.Repository, image.Registry, image.Tag, image.Digest, TestcontainersSettings.HubImageNamePrefix)));
+      return Clone(new ContainerConfiguration(image: image.ApplyHubImageNamePrefix()));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
+++ b/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
@@ -23,10 +23,10 @@ namespace DotNet.Testcontainers.Builders
     /// <summary>
     /// Sets the name.
     /// </summary>
-    /// <param name="name">The name.</param>
+    /// <param name="image">The image.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
-    TBuilderEntity WithName(IImage name);
+    TBuilderEntity WithName(IImage image);
 
     /// <summary>
     /// Sets the Dockerfile.

--- a/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
@@ -58,9 +58,9 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
-    public ImageFromDockerfileBuilder WithName(IImage name)
+    public ImageFromDockerfileBuilder WithName(IImage image)
     {
-      return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(image: name));
+      return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(image: image.ApplyHubImageNamePrefix()));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Images/IImageExtensions.cs
+++ b/src/Testcontainers/Images/IImageExtensions.cs
@@ -1,0 +1,33 @@
+﻿namespace DotNet.Testcontainers.Images
+{
+  using DotNet.Testcontainers.Configurations;
+
+  /// <summary>
+  /// Provides extension methods for the <see cref="IImage" /> interface.
+  /// </summary>
+  internal static class IImageExtensions
+  {
+    /// <summary>
+    /// Applies the Docker Hub image name prefix if it is configured.
+    /// </summary>
+    /// <param name="image">The original <see cref="IImage" /> instance.</param>
+    /// <returns>
+    /// A new <see cref="IImage" /> instance with the Docker Hub image name prefix
+    /// applied, or the original instance if no prefix is set.
+    /// </returns>
+    public static IImage ApplyHubImageNamePrefix(this IImage image)
+    {
+      if (string.IsNullOrEmpty(TestcontainersSettings.HubImageNamePrefix))
+      {
+        return image;
+      }
+
+      if (!string.IsNullOrEmpty(image.GetHostname()))
+      {
+        return image;
+      }
+
+      return new DockerImage(image.Repository, image.Registry, image.Tag, image.Digest, TestcontainersSettings.HubImageNamePrefix);
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

The PR fixes an issue where using the image and container builder together with the `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX` fails, and the built image is not found. The image builder does not consider this configuration, while the container builder does. This results in a mismatch where the container builder expects a different image name than the one the builder actually created.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #424

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
