### PR TITLE
docs: Add binding redirects doc for .NET framework

### DIFF
--- a/docs/cicd/index.md
+++ b/docs/cicd/index.md
@@ -25,7 +25,7 @@ variables:
 
 Enable Bitbucket Pipelines as usual on the **Repository settings → Pipelines → Settings** page. After enabling your pipeline, replace the contents of the `bitbucket-pipelines.yml` file, located at the root of your repository, with the following:
 
-```yml
+```yml title="bitbucket-pipelines.yml file"
 image: mcr.microsoft.com/dotnet/sdk:8.0
 options:
   docker: true

--- a/docs/dind/index.md
+++ b/docs/dind/index.md
@@ -33,5 +33,5 @@ services:
     # environment:
     #   - TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock.raw:/var/run/docker.sock
 ```

--- a/docs/dind/index.md
+++ b/docs/dind/index.md
@@ -1,6 +1,6 @@
-# Running inside another container
+# Running inside a container
 
-## 'Docker wormhole' pattern - Sibling Docker containers
+## 'Docker Wormhole' pattern - Sibling Docker containers
 
 ### Docker-only example
 

--- a/docs/full_framework/index.md
+++ b/docs/full_framework/index.md
@@ -1,0 +1,11 @@
+# .NET Framework
+
+When working with older versions of the .NET Framework (e.g., .NET Framework 4.x), you may encounter issues related to assembly binding conflicts. These conflicts typically occur when your application requires specific versions of assemblies that are different from the versions being loaded at runtime.
+
+To resolve these conflicts and ensure the correct versions of assemblies are used, binding redirects are often necessary. Binding redirects allow you to specify which version of an assembly should be used by the runtime, preventing errors and version mismatches during execution.
+
+Testcontainers for .NET relies on several external dependencies, which may require different versions of assemblies. Legacy applications or projects targeting the full .NET Framework may not automatically resolve these dependencies correctly, and without binding redirects, runtime errors or unexpected behavior may occur.
+
+In executable .NET Framework projects (such as console apps, web apps, etc.), Visual Studio typically handles binding redirects automatically. However, this is not the case for class libraries or test projects.
+
+For **test projects**, binding redirects are **not automatically added** by Visual Studio, which means you may need to manually configure them in the `App.config` file (or enable [`AutoGenerateBindingRedirects`](https://learn.microsoft.com/dotnet/framework/configure-apps/redirect-assembly-versions#rely-on-automatic-binding-redirection)).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,9 +41,10 @@ nav:
   - api/resource_reuse.md
   - api/wait_strategies.md
   - api/best_practices.md
+  - dind/index.md
+  - full_framework/index.md
   - test_frameworks/xunit_net.md
   - Examples:
-    - examples/dind.md
     - examples/aspnet.md
   - Modules:
     - modules/index.md


### PR DESCRIPTION
## What does this PR do?

The PR provides additional information about the necessary binding redirect configurations for .NET Framework users.

After some research, it appears that class libraries (third-party libraries) are not supposed to configure automatic binding redirects. Instead, it is the responsibility of the consumer to configure them properly.

If there is anything we can do to make this process easier for .NET Framework users, please let us know. We are happy to adjust the documentation or project configurations accordingly.

## Why is it important?

If the binding redirects are not properly configured, users may encounter runtime issues.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1394

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
