### PR TITLE
docs(ActiveMq): Add example

### DIFF
--- a/docs/modules/activemq.md
+++ b/docs/modules/activemq.md
@@ -1,0 +1,47 @@
+# Apache ActiveMQ Artemis
+
+[Apache ActiveMQ Artemis](https://activemq.apache.org/components/artemis/) is an open source project to build a multi-protocol, embeddable, very high performance, clustered, asynchronous messaging system.
+
+Add the following dependency to your project file:
+
+```shell title="NuGet"
+dotnet add package Testcontainers.ActiveMq
+```
+
+You can start an Apache ActiveMQ Artemis container instance from any .NET application. This example uses xUnit.net's `IAsyncLifetime` interface to manage the lifecycle of the container. The container is started in the `InitializeAsync` method before the test method runs, ensuring that the environment is ready for testing. After the test completes, the container is removed in the `DisposeAsync` method.
+
+=== "Base test class"
+    ```csharp
+    --8<-- "tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs:UseArtemisContainer"
+    }
+    ```
+=== "Without auth"
+    ```csharp
+    --8<-- "tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs:UseArtemisContainerNoAuth"
+    ```
+=== "Default credentials"
+    ```csharp
+    --8<-- "tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs:UseArtemisContainerDefaultAuth"
+    ```
+=== "Custom credentials"
+    ```csharp
+    --8<-- "tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs:UseArtemisContainerCustomAuth"
+    ```
+
+Connect to the container and produce a message:
+
+=== "EstablishesConnection"
+    ```csharp
+    --8<-- "tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs:ArtemisContainerEstablishesConnection"
+    ```
+
+The test example uses the following NuGet dependencies:
+
+=== "Package References"
+    ```xml
+    --8<-- "tests/Testcontainers.ActiveMq.Tests/Testcontainers.ActiveMq.Tests.csproj:PackageReferences"
+    ```
+
+To execute the tests, use the command `dotnet test` from a terminal.
+
+--8<-- "docs/modules/_call_out_test_projects.txt"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,15 +33,14 @@ nav:
   - index.md
   - cicd/index.md
   - custom_configuration/index.md
-  - Testcontainers API:
-    - api/create_docker_image.md
-    - api/create_docker_container.md
-    - api/create_docker_network.md
-    - api/low_level_api_access.md
-    - api/resource_reaper.md
-    - api/resource_reuse.md
-    - api/wait_strategies.md
-    - api/best_practices.md
+  - api/create_docker_image.md
+  - api/create_docker_container.md
+  - api/create_docker_network.md
+  - api/low_level_api_access.md
+  - api/resource_reaper.md
+  - api/resource_reuse.md
+  - api/wait_strategies.md
+  - api/best_practices.md
   - dind/index.md
   - full_framework/index.md
   - test_frameworks/xunit_net.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,14 +33,15 @@ nav:
   - index.md
   - cicd/index.md
   - custom_configuration/index.md
-  - api/create_docker_image.md
-  - api/create_docker_container.md
-  - api/create_docker_network.md
-  - api/low_level_api_access.md
-  - api/resource_reaper.md
-  - api/resource_reuse.md
-  - api/wait_strategies.md
-  - api/best_practices.md
+  - Testcontainers API:
+    - api/create_docker_image.md
+    - api/create_docker_container.md
+    - api/create_docker_network.md
+    - api/low_level_api_access.md
+    - api/resource_reaper.md
+    - api/resource_reuse.md
+    - api/wait_strategies.md
+    - api/best_practices.md
   - dind/index.md
   - full_framework/index.md
   - test_frameworks/xunit_net.md
@@ -48,10 +49,11 @@ nav:
     - examples/aspnet.md
   - Modules:
     - modules/index.md
-    - modules/cassandra.md
-    - modules/pulsar.md
-    - modules/eventhubs.md
-    - modules/servicebus.md
+    - modules/activemq.md # Apache
+    - modules/cassandra.md # Apache
+    - modules/pulsar.md # Apache
+    - modules/eventhubs.md # Azure
+    - modules/servicebus.md # Azure
     - modules/db2.md
     - modules/elasticsearch.md
     - modules/mongodb.md

--- a/tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs
+++ b/tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs
@@ -1,5 +1,6 @@
 namespace Testcontainers.ActiveMq;
 
+// # --8<-- [start:UseArtemisContainer]
 public abstract class ArtemisContainerTest : IAsyncLifetime
 {
     private readonly ArtemisContainer _artemisContainer;
@@ -24,7 +25,9 @@ public abstract class ArtemisContainerTest : IAsyncLifetime
     {
         return _artemisContainer.DisposeAsync().AsTask();
     }
+    // # --8<-- [end:UseArtemisContainer]
 
+    // # --8<-- [start:ArtemisContainerEstablishesConnection]
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task EstablishesConnection()
@@ -67,7 +70,9 @@ public abstract class ArtemisContainerTest : IAsyncLifetime
 
         Assert.Equal(producedMessage.Text, receivedMessage.Body<string>());
     }
+    // # --8<-- [end:ArtemisContainerEstablishesConnection]
 
+    // # --8<-- [start:UseArtemisContainerDefaultAuth]
     [UsedImplicitly]
     public sealed class DefaultCredentialsConfiguration : ArtemisContainerTest
     {
@@ -76,7 +81,9 @@ public abstract class ArtemisContainerTest : IAsyncLifetime
         {
         }
     }
+    // # --8<-- [end:UseArtemisContainerDefaultAuth]
 
+    // # --8<-- [start:UseArtemisContainerCustomAuth]
     [UsedImplicitly]
     public sealed class CustomCredentialsConfiguration : ArtemisContainerTest
     {
@@ -89,7 +96,9 @@ public abstract class ArtemisContainerTest : IAsyncLifetime
         {
         }
     }
+    // # --8<-- [end:UseArtemisContainerCustomAuth]
 
+    // # --8<-- [start:UseArtemisContainerNoAuth]
     [UsedImplicitly]
     public sealed class NoAuthCredentialsConfiguration : ArtemisContainerTest
     {
@@ -98,4 +107,5 @@ public abstract class ArtemisContainerTest : IAsyncLifetime
         {
         }
     }
+    // # --8<-- [end:UseArtemisContainerNoAuth]
 }

--- a/tests/Testcontainers.ActiveMq.Tests/Testcontainers.ActiveMq.Tests.csproj
+++ b/tests/Testcontainers.ActiveMq.Tests/Testcontainers.ActiveMq.Tests.csproj
@@ -5,11 +5,13 @@
         <IsPublishable>false</IsPublishable>
     </PropertyGroup>
     <ItemGroup>
+        <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
         <PackageReference Include="xunit"/>
         <PackageReference Include="Apache.NMS.ActiveMQ"/>
+        <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.ActiveMq/Testcontainers.ActiveMq.csproj"/>


### PR DESCRIPTION
## What does this PR do?

Added docs for Apache ActiveMQ Artemis.

~~Also moved all `api/*` docs to the new section `Testcontainers API`. This change helps with decluttering side nav menu.~~

## Why is it important?

Apache ActiveMQ Artemis docs section is currently missing.

## How to test this PR

`docker compose up` and visit `http://localhost:8000/`

## Follow-ups

Will be adding docs for other missing modules.
