### PR TITLE
docs: Bump `testcontainers/helloworld` image in docs to version `1.2.0`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@ dotnet add package Testcontainers
 ```csharp title="Run the Hello World container"
 // Create a new instance of a container.
 var container = new ContainerBuilder()
-  // Set the image for the container to "testcontainers/helloworld:1.1.0".
-  .WithImage("testcontainers/helloworld:1.1.0")
+  // Set the image for the container to "testcontainers/helloworld:1.2.0".
+  .WithImage("testcontainers/helloworld:1.2.0")
   // Bind port 8080 of the container to a random port on the host.
   .WithPortBinding(8080, true)
   // Wait until the HTTP endpoint of the container is available.
@@ -21,7 +21,7 @@ await container.StartAsync()
   .ConfigureAwait(false);
 
 // Create a new instance of HttpClient to send HTTP requests.
-var httpClient = new HttpClient();
+using httpClient = new HttpClient();
 
 // Construct the request URI by specifying the scheme, hostname, assigned random host port, and the endpoint "uuid".
 var requestUri = new UriBuilder(Uri.UriSchemeHttp, container.Hostname, container.GetMappedPublicPort(8080), "uuid").Uri;


### PR DESCRIPTION
## What does this PR do?

Updated the example docs to use latest available `helloworld` image i.e `1.2.0`

## Why is it important?

this `1.2.0` version of `helloworld` image can also be used in WCOW context