### PR TITLE
fix(Pulsar): Set memory limits

### DIFF
--- a/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
+++ b/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
@@ -2,6 +2,8 @@ namespace Testcontainers.Pulsar;
 
 public abstract class PulsarContainerTest : IAsyncLifetime
 {
+    private static readonly IReadOnlyDictionary<string, string> MemorySettings = new Dictionary<string, string> { { "PULSAR_MEM", "-Xms256m -Xmx512m" } };
+
     private readonly PulsarContainer _pulsarContainer;
 
     private readonly bool _authenticationEnabled;
@@ -69,7 +71,9 @@ public abstract class PulsarContainerTest : IAsyncLifetime
     public sealed class PulsarDefaultConfiguration : PulsarContainerTest
     {
         public PulsarDefaultConfiguration()
-            : base(new PulsarBuilder().Build(), false)
+            : base(new PulsarBuilder()
+                .WithEnvironment(MemorySettings)
+                .Build(), false)
         {
         }
     }
@@ -79,7 +83,10 @@ public abstract class PulsarContainerTest : IAsyncLifetime
     public sealed class PulsarAuthConfiguration : PulsarContainerTest
     {
         public PulsarAuthConfiguration()
-            : base(new PulsarBuilder().WithAuthentication().Build(), true)
+            : base(new PulsarBuilder()
+                .WithAuthentication()
+                .WithEnvironment(MemorySettings)
+                .Build(), true)
         {
         }
     }
@@ -88,7 +95,10 @@ public abstract class PulsarContainerTest : IAsyncLifetime
     public sealed class PulsarV4Configuration : PulsarContainerTest
     {
         public PulsarV4Configuration()
-            : base(new PulsarBuilder().WithImage("apachepulsar/pulsar:4.0.2").Build(), false)
+            : base(new PulsarBuilder()
+                .WithImage("apachepulsar/pulsar:4.0.2")
+                .WithEnvironment(MemorySettings)
+                .Build(), false)
         {
         }
     }
@@ -97,7 +107,11 @@ public abstract class PulsarContainerTest : IAsyncLifetime
     public sealed class PulsarV4AuthConfiguration : PulsarContainerTest
     {
         public PulsarV4AuthConfiguration()
-            : base(new PulsarBuilder().WithImage("apachepulsar/pulsar:4.0.2").WithAuthentication().Build(), true)
+            : base(new PulsarBuilder()
+                .WithImage("apachepulsar/pulsar:4.0.2")
+                .WithAuthentication()
+                .WithEnvironment(MemorySettings)
+                .Build(), true)
         {
         }
     }

--- a/tests/Testcontainers.Pulsar.Tests/Usings.cs
+++ b/tests/Testcontainers.Pulsar.Tests/Usings.cs
@@ -1,4 +1,5 @@
 global using System;
+global using System.Collections.Generic;
 global using System.Text;
 global using System.Threading;
 global using System.Threading.Tasks;


### PR DESCRIPTION
## What does this PR do?

The Pulsar tests fail occasionally. I wasn't able to reproduce the issue locally, but after running the test in a Codespace, it seems that the container sometimes doesn't start (crashes) due to an OOM error. Our tests run multiple configurations in parallel. This PR reduces the default allocated JVM heap memory for our tests from 2GB to 512MB.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
