### PR TITLE
docs(ClickHouse): Add example

### DIFF
--- a/docs/modules/activemq.md
+++ b/docs/modules/activemq.md
@@ -30,9 +30,9 @@ You can start an Apache ActiveMQ Artemis container instance from any .NET applic
 
 Connect to the container and produce a message:
 
-=== "EstablishesConnection"
+=== "Establish connection"
     ```csharp
-    --8<-- "tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs:ArtemisContainerEstablishesConnection"
+    --8<-- "tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs:EstablishConnection"
     ```
 
 The test example uses the following NuGet dependencies:

--- a/docs/modules/clickhouse.md
+++ b/docs/modules/clickhouse.md
@@ -12,20 +12,22 @@ You can start a ClickHouse container instance from any .NET application. This ex
 
 === "Test class"
     ```csharp
-    --8<-- "tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs:Class"
+    --8<-- "tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs:UseClickHouseContainer"
     }
     ```
 
-Connecting to container example:
-=== "Connecting to ClickHouse"
+Connect to the container:
+
+=== "Establish connection"
     ```csharp
-    --8<-- "tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs:Connecting"
+    --8<-- "tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs:EstablishConnection"
     ```
 
-Execute SQL script example:
-=== "SQL Script"
+Execute a SQL script:
+
+=== "Run SQL script"
     ```csharp
-    --8<-- "tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs:SQLScript"
+    --8<-- "tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs:RunSQLScript"
     ```
 
 The test example uses the following NuGet dependencies:

--- a/docs/modules/clickhouse.md
+++ b/docs/modules/clickhouse.md
@@ -12,57 +12,20 @@ You can start a ClickHouse container instance from any .NET application. This ex
 
 === "Test class"
     ```csharp
-    public sealed class ClickHouseContainerTest : IAsyncLifetime
-    {
-        private readonly ClickHouseContainer _clickHouseContainer = new ClickHouseBuilder().Build();
-
-        public Task InitializeAsync()
-        {
-            return _clickHouseContainer.StartAsync();
-        }
-
-        public Task DisposeAsync()
-        {
-            return _clickHouseContainer.DisposeAsync().AsTask();
-        }
+    --8<-- "tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs:Class"
     }
     ```
 
+Connecting to container example:
 === "Connecting to ClickHouse"
     ```csharp
-    [Fact]
-    [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
-    public void ConnectionStateReturnsOpen()
-    {
-        // Given
-        using DbConnection connection = new ClickHouseConnection(_clickHouseContainer.GetConnectionString());
-
-        // When
-        connection.Open();
-
-        // Then
-        Assert.Equal(ConnectionState.Open, connection.State);
-    }
+    --8<-- "tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs:Connecting"
     ```
 
 Execute SQL script example:
 === "SQL Script"
     ```csharp
-    [Fact]
-    [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
-    public async Task ExecScriptReturnsSuccessful()
-    {
-        // Given
-        const string scriptContent = "SELECT 1;";
-
-        // When
-        var execResult = await _clickHouseContainer.ExecScriptAsync(scriptContent)
-            .ConfigureAwait(true);
-
-        // Then
-        Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
-        Assert.Empty(execResult.Stderr);
-    }
+    --8<-- "tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs:SQLScript"
     ```
 
 The test example uses the following NuGet dependencies:

--- a/docs/modules/clickhouse.md
+++ b/docs/modules/clickhouse.md
@@ -1,0 +1,77 @@
+# ClickHouse
+
+[ClickHouse](https://clickhouse.com/) is a high-performance, column-oriented SQL database management system (DBMS) for online analytical processing (OLAP).
+
+Add the following dependency to your project file:
+
+```shell title="NuGet"
+dotnet add package Testcontainers.ClickHouse
+```
+
+You can start a ClickHouse container instance from any .NET application. This example uses xUnit.net's `IAsyncLifetime` interface to manage the lifecycle of the container. The container is started in the `InitializeAsync` method before the test method runs, ensuring that the environment is ready for testing. After the test completes, the container is removed in the `DisposeAsync` method.
+
+=== "Test class"
+    ```csharp
+    public sealed class ClickHouseContainerTest : IAsyncLifetime
+    {
+        private readonly ClickHouseContainer _clickHouseContainer = new ClickHouseBuilder().Build();
+
+        public Task InitializeAsync()
+        {
+            return _clickHouseContainer.StartAsync();
+        }
+
+        public Task DisposeAsync()
+        {
+            return _clickHouseContainer.DisposeAsync().AsTask();
+        }
+    }
+    ```
+
+=== "Connecting to ClickHouse"
+    ```csharp
+    [Fact]
+    [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+    public void ConnectionStateReturnsOpen()
+    {
+        // Given
+        using DbConnection connection = new ClickHouseConnection(_clickHouseContainer.GetConnectionString());
+
+        // When
+        connection.Open();
+
+        // Then
+        Assert.Equal(ConnectionState.Open, connection.State);
+    }
+    ```
+
+Execute SQL script example:
+=== "SQL Script"
+    ```csharp
+    [Fact]
+    [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+    public async Task ExecScriptReturnsSuccessful()
+    {
+        // Given
+        const string scriptContent = "SELECT 1;";
+
+        // When
+        var execResult = await _clickHouseContainer.ExecScriptAsync(scriptContent)
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
+        Assert.Empty(execResult.Stderr);
+    }
+    ```
+
+The test example uses the following NuGet dependencies:
+
+=== "Package References"
+    ```xml
+    --8<-- "tests/Testcontainers.ClickHouse.Tests/Testcontainers.ClickHouse.Tests.csproj:PackageReferences"
+    ```
+
+To execute the tests, use the command `dotnet test` from a terminal.
+
+--8<-- "docs/modules/_call_out_test_projects.txt"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
     - modules/pulsar.md # Apache
     - modules/eventhubs.md # Azure
     - modules/servicebus.md # Azure
+    - modules/clickhouse.md
     - modules/db2.md
     - modules/elasticsearch.md
     - modules/mongodb.md

--- a/tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs
+++ b/tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs
@@ -31,7 +31,7 @@ public abstract class ArtemisContainerTest : IAsyncLifetime
     }
     // # --8<-- [end:UseArtemisContainer]
 
-    // # --8<-- [start:ArtemisContainerEstablishesConnection]
+    // # --8<-- [start:EstablishConnection]
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task EstablishesConnection()
@@ -74,7 +74,7 @@ public abstract class ArtemisContainerTest : IAsyncLifetime
 
         Assert.Equal(producedMessage.Text, receivedMessage.Body<string>());
     }
-    // # --8<-- [end:ArtemisContainerEstablishesConnection]
+    // # --8<-- [end:EstablishConnection]
 
     protected virtual ValueTask DisposeAsyncCore()
     {

--- a/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.cs
+++ b/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.cs
@@ -1,6 +1,6 @@
 namespace Testcontainers.ClickHouse;
 
-public abstract class ClickHouseContainerTest(ClickHouseContainerTest.ClickHouseDefaultFixture fixture)
+public abstract partial class ClickHouseContainerTest(ClickHouseContainerTest.ClickHouseDefaultFixture fixture)
 {
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]

--- a/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs
+++ b/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs
@@ -45,7 +45,7 @@ public abstract partial class ClickHouseContainerTest
             const string scriptContent = "SELECT 1;";
 
             // When
-            var execResult = await _clickHouseContainer.ExecScriptAsync(scriptContent, CancellationToken.None)
+            var execResult = await _clickHouseContainer.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
                 .ConfigureAwait(true);
 
             // Then

--- a/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs
+++ b/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs
@@ -1,25 +1,26 @@
 namespace Testcontainers.ClickHouse;
 
-public partial class ClickHouseContainerTest
+public abstract partial class ClickHouseContainerTest
 {
-    [UsedImplicitly]
-    // <!-- -8<- [start:Class] -->
-    public sealed class ClickHouseContainerTestDocumentation : IAsyncLifetime
+    // <!-- -8<- [start:UseClickHouseContainer] -->
+    public sealed class ClickHouseContainerExample : IAsyncLifetime
     {
         private readonly ClickHouseContainer _clickHouseContainer = new ClickHouseBuilder().Build();
 
         public async ValueTask DisposeAsync()
         {
-            await _clickHouseContainer.DisposeAsync();
+            await _clickHouseContainer.DisposeAsync()
+                .ConfigureAwait(false);
         }
 
         public async ValueTask InitializeAsync()
         {
-            await _clickHouseContainer.StartAsync(TestContext.Current.CancellationToken);
+            await _clickHouseContainer.StartAsync(TestContext.Current.CancellationToken)
+                .ConfigureAwait(false);
         }
-        // <!-- -8<- [end:Class] -->
+        // <!-- -8<- [end:UseClickHouseContainer] -->
 
-        // <!-- -8<- [start:Connecting] -->
+        // <!-- -8<- [start:EstablishConnection] -->
         [Fact]
         [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
         public void ConnectionStateReturnsOpen()
@@ -33,9 +34,9 @@ public partial class ClickHouseContainerTest
             // Then
             Assert.Equal(ConnectionState.Open, connection.State);
         }
-        // <!-- -8<- [end:Connecting] -->
+        // <!-- -8<- [end:EstablishConnection] -->
 
-        // <!-- -8<- [start:SQLScript] -->
+        // <!-- -8<- [start:RunSQLScript] -->
         [Fact]
         [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
         public async Task ExecScriptReturnsSuccessful()
@@ -44,14 +45,13 @@ public partial class ClickHouseContainerTest
             const string scriptContent = "SELECT 1;";
 
             // When
-            var execResult = await _clickHouseContainer
-                .ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
+            var execResult = await _clickHouseContainer.ExecScriptAsync(scriptContent, CancellationToken.None)
                 .ConfigureAwait(true);
 
             // Then
             Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
             Assert.Empty(execResult.Stderr);
         }
-        // <!-- -8<- [end:SQLScript] -->
+        // <!-- -8<- [end:RunSQLScript] -->
     }
 }

--- a/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs
+++ b/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs
@@ -1,0 +1,57 @@
+namespace Testcontainers.ClickHouse;
+
+public partial class ClickHouseContainerTest
+{
+    [UsedImplicitly]
+    // <!-- -8<- [start:Class] -->
+    public sealed class ClickHouseContainerTestDocumentation : IAsyncLifetime
+    {
+        private readonly ClickHouseContainer _clickHouseContainer = new ClickHouseBuilder().Build();
+
+        public async ValueTask DisposeAsync()
+        {
+            await _clickHouseContainer.DisposeAsync();
+        }
+
+        public async ValueTask InitializeAsync()
+        {
+            await _clickHouseContainer.StartAsync(TestContext.Current.CancellationToken);
+        }
+        // <!-- -8<- [end:Class] -->
+
+        // <!-- -8<- [start:Connecting] -->
+        [Fact]
+        [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+        public void ConnectionStateReturnsOpen()
+        {
+            // Given
+            using DbConnection connection = new ClickHouseConnection(_clickHouseContainer.GetConnectionString());
+
+            // When
+            connection.Open();
+
+            // Then
+            Assert.Equal(ConnectionState.Open, connection.State);
+        }
+        // <!-- -8<- [end:Connecting] -->
+
+        // <!-- -8<- [start:SQLScript] -->
+        [Fact]
+        [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+        public async Task ExecScriptReturnsSuccessful()
+        {
+            // Given
+            const string scriptContent = "SELECT 1;";
+
+            // When
+            var execResult = await _clickHouseContainer
+                .ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+
+            // Then
+            Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
+            Assert.Empty(execResult.Stderr);
+        }
+        // <!-- -8<- [end:SQLScript] -->
+    }
+}

--- a/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs
+++ b/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.docs.cs
@@ -7,15 +7,15 @@ public abstract partial class ClickHouseContainerTest
     {
         private readonly ClickHouseContainer _clickHouseContainer = new ClickHouseBuilder().Build();
 
-        public async ValueTask DisposeAsync()
-        {
-            await _clickHouseContainer.DisposeAsync()
-                .ConfigureAwait(false);
-        }
-
         public async ValueTask InitializeAsync()
         {
             await _clickHouseContainer.StartAsync(TestContext.Current.CancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _clickHouseContainer.DisposeAsync()
                 .ConfigureAwait(false);
         }
         // <!-- -8<- [end:UseClickHouseContainer] -->

--- a/tests/Testcontainers.ClickHouse.Tests/Testcontainers.ClickHouse.Tests.csproj
+++ b/tests/Testcontainers.ClickHouse.Tests/Testcontainers.ClickHouse.Tests.csproj
@@ -6,11 +6,13 @@
         <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
+        <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
         <PackageReference Include="xunit.v3"/>
         <PackageReference Include="ClickHouse.Client"/>
+        <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj"/>

--- a/tests/Testcontainers.ClickHouse.Tests/Usings.cs
+++ b/tests/Testcontainers.ClickHouse.Tests/Usings.cs
@@ -1,5 +1,6 @@
 global using System.Data;
 global using System.Data.Common;
+global using System.Threading;
 global using System.Threading.Tasks;
 global using ClickHouse.Client.ADO;
 global using DotNet.Testcontainers.Builders;


### PR DESCRIPTION
## What does this PR do?

Add ClickHouse example to modules section in docs.

## Why is it important?

ClickHouse module docs are missing.

## How to test this PR

Simply run `docker compose up` and access the docs at: `http://localhost:8000`.
