### PR TITLE
chore: Add xUnit.net v3 tests

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -90,7 +90,8 @@ jobs:
           { name: "Testcontainers.Sftp", runs-on: "ubuntu-22.04" },
           { name: "Testcontainers.Weaviate", runs-on: "ubuntu-22.04" },
           { name: "Testcontainers.WebDriver", runs-on: "ubuntu-22.04" },
-          { name: "Testcontainers.Xunit", runs-on: "ubuntu-22.04" }
+          { name: "Testcontainers.Xunit", runs-on: "ubuntu-22.04" },
+          { name: "Testcontainers.XunitV3", runs-on: "ubuntu-22.04" }
         ]
 
     runs-on: ${{ matrix.test-projects.runs-on }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
         <PackageVersion Include="ReflectionMagic" Version="5.0.1"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2"/>
         <PackageVersion Include="xunit" Version="2.9.3"/>
+        <PackageVersion Include="xunit.v3" Version="2.0.1"/>
         <!-- xUnit.net extensibility for Testcontainers.Xunit and Testcontainers.XunitV3 packages: -->
         <PackageVersion Include="xunit.extensibility.execution" Version="2.9.3"/>
         <PackageVersion Include="xunit.v3.extensibility.core" Version="1.1.0"/>

--- a/Testcontainers.sln
+++ b/Testcontainers.sln
@@ -239,6 +239,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testcontainers.WebDriver.Te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testcontainers.Xunit.Tests", "tests\Testcontainers.Xunit.Tests\Testcontainers.Xunit.Tests.csproj", "{E901DF14-6F05-4FC2-825A-3055FAD33561}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testcontainers.XunitV3.Tests", "tests\Testcontainers.XunitV3.Tests\Testcontainers.XunitV3.Tests.csproj", "{B2E8B7FB-7D1E-4DD3-A25E-34DE4386B1EB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -700,6 +702,10 @@ Global
 		{E901DF14-6F05-4FC2-825A-3055FAD33561}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E901DF14-6F05-4FC2-825A-3055FAD33561}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E901DF14-6F05-4FC2-825A-3055FAD33561}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2E8B7FB-7D1E-4DD3-A25E-34DE4386B1EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2E8B7FB-7D1E-4DD3-A25E-34DE4386B1EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2E8B7FB-7D1E-4DD3-A25E-34DE4386B1EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2E8B7FB-7D1E-4DD3-A25E-34DE4386B1EB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{5365F780-0E6C-41F0-B1B9-7DC34368F80C} = {673F23AE-7694-4BB9-ABD4-136D6C13634E}
@@ -815,5 +821,6 @@ Global
 		{DDB41BC8-5826-4D97-9C5F-001151E3FFD6} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
 		{EBA72C3B-57D5-43FF-A5B4-3D55B3B6D4C2} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
 		{E901DF14-6F05-4FC2-825A-3055FAD33561} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
+		{B2E8B7FB-7D1E-4DD3-A25E-34DE4386B1EB} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
 	EndGlobalSection
 EndGlobal

--- a/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
+++ b/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
@@ -11,8 +11,9 @@
         <PackageReference Include="xunit"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="../Testcontainers.*.Tests/Testcontainers.*.Tests.csproj"
-                          Exclude="../Testcontainers.XunitV3.Tests/Testcontainers.XunitV3.Tests.csproj"/>
+        <ProjectReference Include="../Testcontainers.*.Tests/Testcontainers.*.Tests.csproj"/>
+        <ProjectReference Remove="../Testcontainers.Xunit.Tests/Testcontainers.Xunit.Tests.csproj"/>
+        <ProjectReference Remove="../Testcontainers.XunitV3.Tests/Testcontainers.XunitV3.Tests.csproj"/>
         <ProjectReference Remove="Testcontainers.Databases.Tests.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
+++ b/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
@@ -11,7 +11,8 @@
         <PackageReference Include="xunit"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="../Testcontainers.*.Tests/Testcontainers.*.Tests.csproj"/>
+        <ProjectReference Include="../Testcontainers.*.Tests/Testcontainers.*.Tests.csproj"
+                          Exclude="../Testcontainers.XunitV3.Tests/Testcontainers.XunitV3.Tests.csproj"/>
         <ProjectReference Remove="Testcontainers.Databases.Tests.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Xunit.Tests/AlphabeticalTestCaseOrderer.cs
+++ b/tests/Testcontainers.Xunit.Tests/AlphabeticalTestCaseOrderer.cs
@@ -2,8 +2,15 @@ namespace Testcontainers.Xunit.Tests;
 
 public class AlphabeticalTestCaseOrderer : ITestCaseOrderer
 {
+#if XUNIT_V3
+    public IReadOnlyCollection<TTestCase> OrderTestCases<TTestCase>(IReadOnlyCollection<TTestCase> testCases) where TTestCase : notnull, ITestCase
+    {
+        return testCases.OrderBy(testCase => testCase.TestMethod?.MethodName).ToList();
+    }
+#else
     public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases) where TTestCase : ITestCase
     {
         return testCases.OrderBy(testCase => testCase.TestMethod.Method.Name);
     }
+#endif
 }

--- a/tests/Testcontainers.Xunit.Tests/AlphabeticalTestCaseOrderer.cs
+++ b/tests/Testcontainers.Xunit.Tests/AlphabeticalTestCaseOrderer.cs
@@ -3,12 +3,14 @@ namespace Testcontainers.Xunit.Tests;
 public class AlphabeticalTestCaseOrderer : ITestCaseOrderer
 {
 #if XUNIT_V3
-    public IReadOnlyCollection<TTestCase> OrderTestCases<TTestCase>(IReadOnlyCollection<TTestCase> testCases) where TTestCase : notnull, ITestCase
+    public IReadOnlyCollection<TTestCase> OrderTestCases<TTestCase>(IReadOnlyCollection<TTestCase> testCases)
+        where TTestCase : notnull, ITestCase
     {
-        return testCases.OrderBy(testCase => testCase.TestMethod?.MethodName).ToList();
+        return testCases.OrderBy(testCase => testCase.TestMethod?.MethodName).ToImmutableList();
     }
 #else
-    public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases) where TTestCase : ITestCase
+    public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
+        where TTestCase : ITestCase
     {
         return testCases.OrderBy(testCase => testCase.TestMethod.Method.Name);
     }

--- a/tests/Testcontainers.Xunit.Tests/PostgreSqlContainer.cs
+++ b/tests/Testcontainers.Xunit.Tests/PostgreSqlContainer.cs
@@ -46,7 +46,11 @@ public sealed partial class PostgreSqlContainerTest
     public async Task Test1()
     {
         const string sql = "SELECT title FROM album ORDER BY album_id";
+#if XUNIT_V3
+        using var connection = await OpenConnectionAsync(TestContext.Current.CancellationToken);
+#else
         using var connection = await OpenConnectionAsync();
+#endif
         var title = await connection.QueryFirstAsync<string>(sql);
         Assert.Equal("For Those About To Rock We Salute You", title);
     }

--- a/tests/Testcontainers.Xunit.Tests/RedisContainerTest`1.cs
+++ b/tests/Testcontainers.Xunit.Tests/RedisContainerTest`1.cs
@@ -12,7 +12,11 @@ public sealed partial class RedisContainerTest(ITestOutputHelper testOutputHelpe
 }
 // # --8<-- [end:ConfigureRedisContainer]
 
+#if XUNIT_V3
+[TestCaseOrderer(ordererType: typeof(Testcontainers.Xunit.Tests.AlphabeticalTestCaseOrderer))]
+#else
 [TestCaseOrderer(ordererTypeName: "Testcontainers.Xunit.Tests.AlphabeticalTestCaseOrderer", ordererAssemblyName: "Testcontainers.Xunit.Tests")]
+#endif
 public sealed partial class RedisContainerTest
 {
     [Fact]

--- a/tests/Testcontainers.Xunit.Tests/RedisContainerTest`2.cs
+++ b/tests/Testcontainers.Xunit.Tests/RedisContainerTest`2.cs
@@ -17,7 +17,11 @@ public sealed partial class RedisContainerTest(RedisContainerFixture fixture)
     : IClassFixture<RedisContainerFixture>;
 // # --8<-- [end:InjectContainerFixture]
 
+#if XUNIT_V3
+[TestCaseOrderer(ordererType: typeof(Testcontainers.Xunit.Tests.AlphabeticalTestCaseOrderer))]
+#else
 [TestCaseOrderer(ordererTypeName: "Testcontainers.Xunit.Tests.AlphabeticalTestCaseOrderer", ordererAssemblyName: "Testcontainers.Xunit.Tests")]
+#endif
 public sealed partial class RedisContainerTest
 {
     [Fact]

--- a/tests/Testcontainers.Xunit.Tests/Testcontainers.Xunit.Tests.csproj
+++ b/tests/Testcontainers.Xunit.Tests/Testcontainers.Xunit.Tests.csproj
@@ -7,15 +7,17 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
-        <PackageReference Include="Dapper"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
         <PackageReference Include="xunit"/>
+        <PackageReference Include="Dapper"/>
+        <PackageReference Include="Npgsql"/>
+        <PackageReference Include="StackExchange.Redis"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Redis/Testcontainers.Redis.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
-        <ProjectReference Include="../Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj"/>
-        <ProjectReference Include="../Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj"/>
     </ItemGroup>
     <ItemGroup>
         <None Update="Chinook_PostgreSql_AutoIncrementPKs.sql">

--- a/tests/Testcontainers.Xunit.Tests/Usings.cs
+++ b/tests/Testcontainers.Xunit.Tests/Usings.cs
@@ -1,4 +1,5 @@
 global using System.Collections.Generic;
+global using System.Collections.Immutable;
 global using System.Data.Common;
 global using System.Linq;
 global using System.Threading.Tasks;

--- a/tests/Testcontainers.Xunit.Tests/Usings.cs
+++ b/tests/Testcontainers.Xunit.Tests/Usings.cs
@@ -9,5 +9,9 @@ global using StackExchange.Redis;
 global using Testcontainers.PostgreSql;
 global using Testcontainers.Redis;
 global using Xunit;
+#if XUNIT_V3
+global using Xunit.v3;
+#else
 global using Xunit.Abstractions;
+#endif
 global using Xunit.Sdk;

--- a/tests/Testcontainers.XunitV3.Tests/.editorconfig
+++ b/tests/Testcontainers.XunitV3.Tests/.editorconfig
@@ -1,0 +1,1 @@
+root = true

--- a/tests/Testcontainers.XunitV3.Tests/Testcontainers.XunitV3.Tests.csproj
+++ b/tests/Testcontainers.XunitV3.Tests/Testcontainers.XunitV3.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net9.0</TargetFrameworks>
+        <IsPackable>false</IsPackable>
+        <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
+        <DefineConstants>$(DefineConstants);XUNIT_V3</DefineConstants>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="Dapper"/>
+        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="xunit.v3"/>
+        <PackageReference Include="StackExchange.Redis"/>
+        <PackageReference Include="Npgsql"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Redis/Testcontainers.Redis.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj"/>
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="../Testcontainers.Xunit.Tests/*.cs"/>
+        <None Include="../Testcontainers.Xunit.Tests/Chinook_PostgreSql_AutoIncrementPKs.sql">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+</Project>

--- a/tests/Testcontainers.XunitV3.Tests/Testcontainers.XunitV3.Tests.csproj
+++ b/tests/Testcontainers.XunitV3.Tests/Testcontainers.XunitV3.Tests.csproj
@@ -25,7 +25,7 @@
         <Compile Include="../Testcontainers.Xunit.Tests/*.cs"/>
     </ItemGroup>
     <ItemGroup>
-        <None Update="Chinook_PostgreSql_AutoIncrementPKs.sql">
+        <None Include="../Testcontainers.Xunit.Tests/Chinook_PostgreSql_AutoIncrementPKs.sql">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>

--- a/tests/Testcontainers.XunitV3.Tests/Testcontainers.XunitV3.Tests.csproj
+++ b/tests/Testcontainers.XunitV3.Tests/Testcontainers.XunitV3.Tests.csproj
@@ -9,21 +9,23 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
-        <PackageReference Include="Dapper"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
         <PackageReference Include="xunit.v3"/>
-        <PackageReference Include="StackExchange.Redis"/>
+        <PackageReference Include="Dapper"/>
         <PackageReference Include="Npgsql"/>
+        <PackageReference Include="StackExchange.Redis"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
-        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Redis/Testcontainers.Redis.csproj"/>
         <ProjectReference Include="../../src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Redis/Testcontainers.Redis.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
     <ItemGroup>
         <Compile Include="../Testcontainers.Xunit.Tests/*.cs"/>
-        <None Include="../Testcontainers.Xunit.Tests/Chinook_PostgreSql_AutoIncrementPKs.sql">
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="Chinook_PostgreSql_AutoIncrementPKs.sql">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>


### PR DESCRIPTION
## What does this PR do?

Add a new test-project "Testcontainers.XunitV3.Tests" to verify the "Testcontainers.XunitV3"-package. The test-project depends on the current xunit V3, to also proof, that it can be used alongside it.

## Why is it important?

Currently there is no test for the "Testcontainers.XunitV3"-package, which means, that runtime issues can not be detected. This should also ease verifying further development around "Testcontainers.XunitV3" and showcase the usage of the package.