### PR TITLE
fix(EventHubs): Change predicate that it does not always evaluate to true

### DIFF
--- a/src/Testcontainers.EventHubs/EventHubsServiceConfiguration.cs
+++ b/src/Testcontainers.EventHubs/EventHubsServiceConfiguration.cs
@@ -82,7 +82,7 @@ public sealed class EventHubsServiceConfiguration
     {
         // The emulator provides the usage quotas as described at:
         // https://learn.microsoft.com/en-us/azure/event-hubs/overview-emulator#usage-quotas.
-        Predicate<Entity> isValidEntity = entity => entity.PartitionCount > 0 && entity.PartitionCount <= 32 && entity.ConsumerGroups.Count >= 0 && entity.ConsumerGroups.Count <= 20;
+        Predicate<Entity> isValidEntity = entity => entity.PartitionCount > 0 && entity.PartitionCount <= 32 && entity.ConsumerGroups.Count > 0 && entity.ConsumerGroups.Count <= 20;
         return _namespaceConfig.Entities.Count > 0 && _namespaceConfig.Entities.Count <= 10 && _namespaceConfig.Entities.All(entity => isValidEntity(entity));
     }
 

--- a/src/Testcontainers/Images/IImageExtensions.cs
+++ b/src/Testcontainers/Images/IImageExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Images
+namespace DotNet.Testcontainers.Images
 {
   using DotNet.Testcontainers.Configurations;
 


### PR DESCRIPTION
## What does this PR do?

The Event Hubs service configuration validation had a predicate that always evaluated to true. This PR removes that incorrect check.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
