### PR TITLE
chore: Bump CI .NET SDK and Cake version

### DIFF
--- a/.cake-scripts/version.cake
+++ b/.cake-scripts/version.cake
@@ -1,4 +1,4 @@
-#addin nuget:?package=Cake.Git&version=4.0.0
+#addin nuget:?package=Cake.Git&version=5.0.1
 
 internal sealed class BuildInformation
 {

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "4.2.0",
+      "version": "5.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/build.cake
+++ b/build.cake
@@ -1,8 +1,8 @@
-#tool nuget:?package=dotnet-sonarscanner&version=9.0.1
+#tool nuget:?package=dotnet-sonarscanner&version=10.1.2
 
-#addin nuget:?package=Cake.Sonar&version=1.1.33
+#addin nuget:?package=Cake.Sonar&version=5.0.0
 
-#addin nuget:?package=Cake.Git&version=4.0.0
+#addin nuget:?package=Cake.Git&version=5.0.1
 
 #load ".cake-scripts/parameters.cake"
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.200",
     "rollForward": "latestMinor"
   }
 }

--- a/src/Testcontainers.EventHubs/EventHubsServiceConfiguration.cs
+++ b/src/Testcontainers.EventHubs/EventHubsServiceConfiguration.cs
@@ -66,7 +66,7 @@ public sealed class EventHubsServiceConfiguration
     {
         // Filter out the consumer group name `$default` because the `$default` group
         // is created automatically by the container image.
-        var validConsumerGroupNames = consumerGroupNames.Where(consumerGroupName => !"$default".Equals(consumerGroupName, StringComparison.OrdinalIgnoreCase)).ToList();
+        var validConsumerGroupNames = consumerGroupNames.Where(consumerGroupName => !"$Default".Equals(consumerGroupName, StringComparison.OrdinalIgnoreCase)).ToList();
         return WithEntity(name, partitionCount, new ReadOnlyCollection<string>(validConsumerGroupNames));
     }
 
@@ -82,7 +82,7 @@ public sealed class EventHubsServiceConfiguration
     {
         // The emulator provides the usage quotas as described at:
         // https://learn.microsoft.com/en-us/azure/event-hubs/overview-emulator#usage-quotas.
-        Predicate<Entity> isValidEntity = entity => entity.PartitionCount > 0 && entity.PartitionCount <= 32 && entity.ConsumerGroups.Count > 0 && entity.ConsumerGroups.Count <= 20;
+        Predicate<Entity> isValidEntity = entity => entity.PartitionCount > 0 && entity.PartitionCount <= 32 && entity.ConsumerGroups.Count <= 20;
         return _namespaceConfig.Entities.Count > 0 && _namespaceConfig.Entities.Count <= 10 && _namespaceConfig.Entities.All(entity => isValidEntity(entity));
     }
 

--- a/tests/Testcontainers.EventHubs.Tests/EventHubsContainerTest.cs
+++ b/tests/Testcontainers.EventHubs.Tests/EventHubsContainerTest.cs
@@ -26,7 +26,7 @@ public abstract class EventHubsContainerTest : IAsyncLifetime
 
     private static EventHubsServiceConfiguration GetServiceConfiguration()
     {
-        return EventHubsServiceConfiguration.Create().WithEntity(EventHubsName, 2, [EventHubConsumerClient.DefaultConsumerGroupName, EventHubsConsumerGroupName]);
+        return EventHubsServiceConfiguration.Create().WithEntity(EventHubsName, 2, EventHubConsumerClient.DefaultConsumerGroupName, EventHubsConsumerGroupName);
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

The PR bumps the CI .NET SDK and Cake version. In addition, it addresses an issue configuring the Event Hub module with the default consumer group name, which failed the validation check.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
