### PR TITLE
Upgrade Azurite: 3.28.0 → 3.34.0 (latest)

### DIFF
--- a/src/Testcontainers.Azurite/AzuriteBuilder.cs
+++ b/src/Testcontainers.Azurite/AzuriteBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.Azurite;
 [PublicAPI]
 public sealed class AzuriteBuilder : ContainerBuilder<AzuriteBuilder, AzuriteContainer, AzuriteConfiguration>
 {
-    public const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.28.0";
+    public const string AzuriteImage = "mcr.microsoft.com/azure-storage/azurite:3.34.0";
 
     public const ushort BlobPort = 10000;
 


### PR DESCRIPTION
## What does this PR do?

Upgrades the Azurite image from 3.28.0 to 3.34.0 (the latest).

## Why is it important?

The older version of Azurite is not compatible with the latest Azure Storage client packages, so without this change, users (like me) are blocked from upgrading those packages.

## Related issues

N/A