### PR TITLE
chore: Update test-framework to xUnit.net v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,12 +19,12 @@
         <PackageVersion Include="Dapper" Version="2.1.66"/>
         <PackageVersion Include="ReflectionMagic" Version="5.0.1"/>
         <PackageVersion Include="xunit.analyzers" Version="1.21.0"/>
-        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0"/>
         <PackageVersion Include="xunit" Version="2.9.3"/>
-        <PackageVersion Include="xunit.v3" Version="2.0.1"/>
+        <PackageVersion Include="xunit.v3" Version="2.0.2"/>
         <!-- xUnit.net extensibility for Testcontainers.Xunit and Testcontainers.XunitV3 packages: -->
         <PackageVersion Include="xunit.extensibility.execution" Version="2.9.3"/>
-        <PackageVersion Include="xunit.v3.extensibility.core" Version="1.1.0"/>
+        <PackageVersion Include="xunit.v3.extensibility.core" Version="2.0.2"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->
         <PackageVersion Include="Apache.NMS.ActiveMQ" Version="2.1.1"/>
         <PackageVersion Include="ArangoDBNetStandard" Version="2.0.1"/>

--- a/src/Testcontainers.FirebirdSql/FirebirdSqlConfiguration.cs
+++ b/src/Testcontainers.FirebirdSql/FirebirdSqlConfiguration.cs
@@ -68,7 +68,7 @@ public sealed class FirebirdSqlConfiguration : ContainerConfiguration
     /// <summary>
     /// Gets the FirebirdSql database.
     /// </summary>
-    public string Database => Image.Tag.StartsWith("2.5") || Image.Tag.StartsWith("v2.5") ? string.Join("/", "/firebird/data", _database) : _database;
+    public string Database => Image.Tag != null && (Image.Tag.StartsWith("2.5") || Image.Tag.StartsWith("v2.5")) ? string.Join("/", "/firebird/data", _database) : _database;
 
     /// <summary>
     /// Gets the FirebirdSql username.

--- a/src/Testcontainers.Xunit/Testcontainers.Xunit.csproj
+++ b/src/Testcontainers.Xunit/Testcontainers.Xunit.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" VersionOverride="2023.3.0" PrivateAssets="All"/>
-        <PackageReference Include="xunit.analyzers" PrivateAssets="all"/>
+        <PackageReference Include="xunit.analyzers" PrivateAssets="All"/>
         <PackageReference Include="xunit.extensibility.execution"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj
+++ b/src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" VersionOverride="2023.3.0" PrivateAssets="All"/>
-        <PackageReference Include="xunit.analyzers" PrivateAssets="all"/>
+        <PackageReference Include="xunit.analyzers" PrivateAssets="All"/>
         <PackageReference Include="xunit.v3.extensibility.core"/>
     </ItemGroup>
     <ItemGroup>

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -30,7 +30,7 @@ namespace DotNet.Testcontainers.Clients
 
     public const string TestcontainersReuseHashLabel = TestcontainersLabel + ".reuse-hash";
 
-    public static readonly string Version = typeof(TestcontainersClient).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+    public static readonly string Version = typeof(TestcontainersClient).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()!.InformationalVersion;
 
     private static readonly string OSRootDirectory = Path.GetPathRoot(Directory.GetCurrentDirectory());
 

--- a/tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs
+++ b/tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs
@@ -16,14 +16,14 @@ public abstract class ArtemisContainerTest : IAsyncLifetime
         _password = password;
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _artemisContainer.StartAsync();
+        await _artemisContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _artemisContainer.DisposeAsync().AsTask();
+        return _artemisContainer.DisposeAsync();
     }
     // # --8<-- [end:UseArtemisContainer]
 

--- a/tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs
+++ b/tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs
@@ -18,7 +18,8 @@ public abstract class ArtemisContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _artemisContainer.StartAsync();
+        await _artemisContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.ActiveMq.Tests/Testcontainers.ActiveMq.Tests.csproj
+++ b/tests/Testcontainers.ActiveMq.Tests/Testcontainers.ActiveMq.Tests.csproj
@@ -3,13 +3,14 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Apache.NMS.ActiveMQ"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>

--- a/tests/Testcontainers.ArangoDb.Tests/ArangoDbContainerTest.cs
+++ b/tests/Testcontainers.ArangoDb.Tests/ArangoDbContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class ArangoDbContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _arangoDbContainer.StartAsync();
+        await _arangoDbContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.ArangoDb.Tests/ArangoDbContainerTest.cs
+++ b/tests/Testcontainers.ArangoDb.Tests/ArangoDbContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class ArangoDbContainerTest : IAsyncLifetime
 {
     private readonly ArangoDbContainer _arangoDbContainer = new ArangoDbBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _arangoDbContainer.StartAsync();
+        await _arangoDbContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _arangoDbContainer.DisposeAsync().AsTask();
+        return _arangoDbContainer.DisposeAsync();
     }
 
     [Fact]
@@ -26,7 +26,7 @@ public sealed class ArangoDbContainerTest : IAsyncLifetime
         using var client = new ArangoDBClient(transport);
 
         // When
-        var response = await client.Database.GetDatabasesAsync()
+        var response = await client.Database.GetDatabasesAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.ArangoDb.Tests/Testcontainers.ArangoDb.Tests.csproj
+++ b/tests/Testcontainers.ArangoDb.Tests/Testcontainers.ArangoDb.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="ArangoDBNetStandard"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Azurite.Tests/AzuriteContainerTest.cs
+++ b/tests/Testcontainers.Azurite.Tests/AzuriteContainerTest.cs
@@ -9,14 +9,14 @@ public abstract class AzuriteContainerTest : IAsyncLifetime
         _azuriteContainer = azuriteContainer;
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _azuriteContainer.StartAsync();
+        await _azuriteContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _azuriteContainer.DisposeAsync().AsTask();
+        return _azuriteContainer.DisposeAsync();
     }
 
     [Fact]
@@ -27,7 +27,7 @@ public abstract class AzuriteContainerTest : IAsyncLifetime
         var client = new BlobServiceClient(_azuriteContainer.GetConnectionString());
 
         // When
-        var properties = await client.GetPropertiesAsync()
+        var properties = await client.GetPropertiesAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -42,7 +42,7 @@ public abstract class AzuriteContainerTest : IAsyncLifetime
         var client = new QueueServiceClient(_azuriteContainer.GetConnectionString());
 
         // When
-        var properties = await client.GetPropertiesAsync()
+        var properties = await client.GetPropertiesAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -57,7 +57,7 @@ public abstract class AzuriteContainerTest : IAsyncLifetime
         var client = new TableServiceClient(_azuriteContainer.GetConnectionString());
 
         // When
-        var properties = await client.GetPropertiesAsync()
+        var properties = await client.GetPropertiesAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -106,7 +106,7 @@ public abstract class AzuriteContainerTest : IAsyncLifetime
         public async Task MemoryLimitIsConfigured()
         {
             // Given
-            var (stdout, _) = await _azuriteContainer.GetLogsAsync(timestampsEnabled: false)
+            var (stdout, _) = await _azuriteContainer.GetLogsAsync(timestampsEnabled: false, ct: TestContext.Current.CancellationToken)
                 .ConfigureAwait(true);
 
             // When

--- a/tests/Testcontainers.Azurite.Tests/AzuriteContainerTest.cs
+++ b/tests/Testcontainers.Azurite.Tests/AzuriteContainerTest.cs
@@ -11,7 +11,8 @@ public abstract class AzuriteContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _azuriteContainer.StartAsync();
+        await _azuriteContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Azurite.Tests/Testcontainers.Azurite.Tests.csproj
+++ b/tests/Testcontainers.Azurite.Tests/Testcontainers.Azurite.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Azure.Data.Tables"/>
         <PackageReference Include="Azure.Storage.Blobs"/>
         <PackageReference Include="Azure.Storage.Queues"/>

--- a/tests/Testcontainers.BigQuery.Tests/BigQueryContainerTest.cs
+++ b/tests/Testcontainers.BigQuery.Tests/BigQueryContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class BigQueryContainerTest : IAsyncLifetime
 {
     private readonly BigQueryContainer _bigQueryContainer = new BigQueryBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _bigQueryContainer.StartAsync();
+        await _bigQueryContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _bigQueryContainer.DisposeAsync().AsTask();
+        return _bigQueryContainer.DisposeAsync();
     }
 
     [Fact]
@@ -41,20 +41,20 @@ public sealed class BigQueryContainerTest : IAsyncLifetime
         expectedRow.Add("gameStarted", utcNowWithoutMilliseconds);
         expectedRow.Add("score", 85L);
 
-        using var bigQueryClient = await bigQueryClientBuilder.BuildAsync()
+        using var bigQueryClient = await bigQueryClientBuilder.BuildAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var dataset = await bigQueryClient.GetOrCreateDatasetAsync("mydata")
+        var dataset = await bigQueryClient.GetOrCreateDatasetAsync("mydata", cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // When
-        var table = await dataset.CreateTableAsync("scores", tableSchema)
+        var table = await dataset.CreateTableAsync("scores", tableSchema, cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        _ = await table.InsertRowAsync(expectedRow)
+        _ = await table.InsertRowAsync(expectedRow, cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var results = await bigQueryClient.ExecuteQueryAsync($"SELECT * FROM {table}", null)
+        var results = await bigQueryClient.ExecuteQueryAsync($"SELECT * FROM {table}", null, cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.BigQuery.Tests/BigQueryContainerTest.cs
+++ b/tests/Testcontainers.BigQuery.Tests/BigQueryContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class BigQueryContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _bigQueryContainer.StartAsync();
+        await _bigQueryContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.BigQuery.Tests/Testcontainers.BigQuery.Tests.csproj
+++ b/tests/Testcontainers.BigQuery.Tests/Testcontainers.BigQuery.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Google.Cloud.BigQuery.V2"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Bigtable.Tests/BigtableContainerTest.cs
+++ b/tests/Testcontainers.Bigtable.Tests/BigtableContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class BigtableContainerTest : IAsyncLifetime
 {
     private readonly BigtableContainer _bigtableContainer = new BigtableBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _bigtableContainer.StartAsync();
+        await _bigtableContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _bigtableContainer.DisposeAsync().AsTask();
+        return _bigtableContainer.DisposeAsync();
     }
 
     [Fact]
@@ -42,7 +42,7 @@ public sealed class BigtableContainerTest : IAsyncLifetime
         bigtableClientBuilder.ChannelCredentials = ChannelCredentials.Insecure;
 
         // When
-        var bigtableClient = await bigtableClientBuilder.BuildAsync()
+        var bigtableClient = await bigtableClientBuilder.BuildAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         _ = await bigtableClient.CreateTableAsync(instanceName, tableName.TableId, table)

--- a/tests/Testcontainers.Bigtable.Tests/BigtableContainerTest.cs
+++ b/tests/Testcontainers.Bigtable.Tests/BigtableContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class BigtableContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _bigtableContainer.StartAsync();
+        await _bigtableContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Bigtable.Tests/Testcontainers.Bigtable.Tests.csproj
+++ b/tests/Testcontainers.Bigtable.Tests/Testcontainers.Bigtable.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Google.Cloud.Bigtable.Admin.V2"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Cassandra.Tests/CassandraContainerTest.cs
+++ b/tests/Testcontainers.Cassandra.Tests/CassandraContainerTest.cs
@@ -49,7 +49,7 @@ public abstract class CassandraContainerTest(CassandraContainerTest.CassandraDef
         const string selectFromSystemLocalStatement = "SELECT * FROM system.local;";
 
         // When
-        var execResult = await fixture.Container.ExecScriptAsync(selectFromSystemLocalStatement)
+        var execResult = await fixture.Container.ExecScriptAsync(selectFromSystemLocalStatement, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Cassandra.Tests/Testcontainers.Cassandra.Tests.csproj
+++ b/tests/Testcontainers.Cassandra.Tests/Testcontainers.Cassandra.Tests.csproj
@@ -3,19 +3,20 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="CassandraCSharpDriver"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.Cassandra/Testcontainers.Cassandra.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Cassandra.Tests/Usings.cs
+++ b/tests/Testcontainers.Cassandra.Tests/Usings.cs
@@ -9,4 +9,4 @@ global using DotNet.Testcontainers.Commons;
 global using JetBrains.Annotations;
 global using Testcontainers.Xunit;
 global using Xunit;
-global using Xunit.Abstractions;
+global using Xunit.Sdk;

--- a/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.cs
+++ b/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.cs
@@ -24,7 +24,7 @@ public abstract class ClickHouseContainerTest(ClickHouseContainerTest.ClickHouse
         const string scriptContent = "SELECT 1;";
 
         // When
-        var execResult = await fixture.Container.ExecScriptAsync(scriptContent)
+        var execResult = await fixture.Container.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.ClickHouse.Tests/Testcontainers.ClickHouse.Tests.csproj
+++ b/tests/Testcontainers.ClickHouse.Tests/Testcontainers.ClickHouse.Tests.csproj
@@ -3,17 +3,18 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="ClickHouse.Client"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.ClickHouse/Testcontainers.ClickHouse.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.ClickHouse.Tests/Usings.cs
+++ b/tests/Testcontainers.ClickHouse.Tests/Usings.cs
@@ -7,4 +7,4 @@ global using DotNet.Testcontainers.Commons;
 global using JetBrains.Annotations;
 global using Testcontainers.Xunit;
 global using Xunit;
-global using Xunit.Abstractions;
+global using Xunit.Sdk;

--- a/tests/Testcontainers.CockroachDb.Tests/CockroachDbContainerTest.cs
+++ b/tests/Testcontainers.CockroachDb.Tests/CockroachDbContainerTest.cs
@@ -24,7 +24,7 @@ public abstract class CockroachDbContainerTest(CockroachDbContainerTest.Cockroac
         const string scriptContent = "SELECT 1;";
 
         // When
-        var execResult = await fixture.Container.ExecScriptAsync(scriptContent)
+        var execResult = await fixture.Container.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.CockroachDb.Tests/Testcontainers.CockroachDb.Tests.csproj
+++ b/tests/Testcontainers.CockroachDb.Tests/Testcontainers.CockroachDb.Tests.csproj
@@ -3,17 +3,18 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Npgsql"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.CockroachDb/Testcontainers.CockroachDb.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.CockroachDb.Tests/Usings.cs
+++ b/tests/Testcontainers.CockroachDb.Tests/Usings.cs
@@ -7,4 +7,4 @@ global using JetBrains.Annotations;
 global using Npgsql;
 global using Testcontainers.Xunit;
 global using Xunit;
-global using Xunit.Abstractions;
+global using Xunit.Sdk;

--- a/tests/Testcontainers.Consul.Tests/ConsulContainerTest.cs
+++ b/tests/Testcontainers.Consul.Tests/ConsulContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class ConsulContainerTest : IAsyncLifetime
 {
     private readonly ConsulContainer _consulContainer = new ConsulBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _consulContainer.StartAsync();
+        await _consulContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _consulContainer.DisposeAsync().AsTask();
+        return _consulContainer.DisposeAsync();
     }
 
     [Fact]
@@ -32,10 +32,10 @@ public sealed class ConsulContainerTest : IAsyncLifetime
         using var consulClient = new ConsulClient(consulClientConfiguration);
 
         // When
-        _ = await consulClient.KV.Put(expected)
+        _ = await consulClient.KV.Put(expected, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var actual = await consulClient.KV.Get(key)
+        var actual = await consulClient.KV.Get(key, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Consul.Tests/ConsulContainerTest.cs
+++ b/tests/Testcontainers.Consul.Tests/ConsulContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class ConsulContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _consulContainer.StartAsync();
+        await _consulContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Consul.Tests/Testcontainers.Consul.Tests.csproj
+++ b/tests/Testcontainers.Consul.Tests/Testcontainers.Consul.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Consul"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.CosmosDb.Tests/CosmosDbContainerTest.cs
+++ b/tests/Testcontainers.CosmosDb.Tests/CosmosDbContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class CosmosDbContainerTest : IAsyncLifetime
 {
     private readonly CosmosDbContainer _cosmosDbContainer = new CosmosDbBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _cosmosDbContainer.StartAsync();
+        await _cosmosDbContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _cosmosDbContainer.DisposeAsync().AsTask();
+        return _cosmosDbContainer.DisposeAsync();
     }
 
     [Fact(Skip = "The Cosmos DB Linux Emulator Docker image does not run on Microsoft's CI environment (GitHub, Azure DevOps).")] // https://github.com/Azure/azure-cosmos-db-emulator-docker/issues/45.

--- a/tests/Testcontainers.CosmosDb.Tests/CosmosDbContainerTest.cs
+++ b/tests/Testcontainers.CosmosDb.Tests/CosmosDbContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class CosmosDbContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _cosmosDbContainer.StartAsync();
+        await _cosmosDbContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.CosmosDb.Tests/Testcontainers.CosmosDb.Tests.csproj
+++ b/tests/Testcontainers.CosmosDb.Tests/Testcontainers.CosmosDb.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Microsoft.Azure.Cosmos"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.CouchDb.Tests/CouchDbContainerTest.cs
+++ b/tests/Testcontainers.CouchDb.Tests/CouchDbContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class CouchDbContainerTest : IAsyncLifetime
 {
     private readonly CouchDbContainer _couchDbContainer = new CouchDbBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _couchDbContainer.StartAsync();
+        await _couchDbContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _couchDbContainer.DisposeAsync().AsTask();
+        return _couchDbContainer.DisposeAsync();
     }
 
     [Fact]
@@ -22,7 +22,7 @@ public sealed class CouchDbContainerTest : IAsyncLifetime
         using var client = new MyCouchClient(_couchDbContainer.GetConnectionString(), "db");
 
         // When
-        var database = await client.Database.PutAsync()
+        var database = await client.Database.PutAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.CouchDb.Tests/CouchDbContainerTest.cs
+++ b/tests/Testcontainers.CouchDb.Tests/CouchDbContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class CouchDbContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _couchDbContainer.StartAsync();
+        await _couchDbContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
+++ b/tests/Testcontainers.CouchDb.Tests/Testcontainers.CouchDb.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="MyCouch"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Couchbase.Tests/CouchbaseContainerTest.cs
+++ b/tests/Testcontainers.Couchbase.Tests/CouchbaseContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class CouchbaseContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _couchbaseContainer.StartAsync();
+        await _couchbaseContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Couchbase.Tests/CouchbaseContainerTest.cs
+++ b/tests/Testcontainers.Couchbase.Tests/CouchbaseContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class CouchbaseContainerTest : IAsyncLifetime
 {
     private readonly CouchbaseContainer _couchbaseContainer = new CouchbaseBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _couchbaseContainer.StartAsync();
+        await _couchbaseContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _couchbaseContainer.DisposeAsync().AsTask();
+        return _couchbaseContainer.DisposeAsync();
     }
 
     [Fact]

--- a/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
+++ b/tests/Testcontainers.Couchbase.Tests/Testcontainers.Couchbase.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="CouchbaseNetClient"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Databases.Tests/DatabasesContainerTest.cs
+++ b/tests/Testcontainers.Databases.Tests/DatabasesContainerTest.cs
@@ -3,14 +3,14 @@ namespace Testcontainers.Databases;
 public sealed class DatabaseContainersTest
 {
     [Theory]
-    [MemberData(nameof(GetContainerImplementations), parameters: true)]
+    [MemberData(nameof(GetContainerImplementations), arguments: true)]
     public void ShouldImplementIDatabaseContainer(Type type)
     {
         Assert.True(type.IsAssignableTo(typeof(IDatabaseContainer)), $"The type '{type.Name}' does not implement the database interface.");
     }
 
     [Theory]
-    [MemberData(nameof(GetContainerImplementations), parameters: false)]
+    [MemberData(nameof(GetContainerImplementations), arguments: false)]
     public void ShouldNotImplementIDatabaseContainer(Type type)
     {
         Assert.False(type.IsAssignableTo(typeof(IDatabaseContainer)), $"The type '{type.Name}' does implement the database interface.");
@@ -21,7 +21,6 @@ public sealed class DatabaseContainersTest
         var theoryData = new TheoryData<Type>();
 
         var testAssemblies = Directory.GetFiles(".", "Testcontainers.*.Tests.dll", SearchOption.TopDirectoryOnly)
-            .Where(fileName => !fileName.Contains("Testcontainers.Xunit.Tests"))
             .Select(Path.GetFullPath)
             .Select(Assembly.LoadFrom)
             .ToDictionary(assembly => assembly, assembly => assembly.GetReferencedAssemblies()

--- a/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
+++ b/tests/Testcontainers.Databases.Tests/Testcontainers.Databases.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../Testcontainers.*.Tests/Testcontainers.*.Tests.csproj"/>

--- a/tests/Testcontainers.Db2.Tests/Db2ContainerTest.cs
+++ b/tests/Testcontainers.Db2.Tests/Db2ContainerTest.cs
@@ -25,7 +25,7 @@ public abstract class Db2ContainerTest(Db2ContainerTest.Db2DefaultFixture fixtur
         const string scriptContent = "SELECT 1 FROM SYSIBM.SYSDUMMY1;";
 
         // When
-        var execResult = await fixture.Container.ExecScriptAsync(scriptContent)
+        var execResult = await fixture.Container.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Db2.Tests/Testcontainers.Db2.Tests.csproj
+++ b/tests/Testcontainers.Db2.Tests/Testcontainers.Db2.Tests.csproj
@@ -3,13 +3,14 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <!-- -8<- [start:PackageReferences] -->
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
     </ItemGroup>
     <ItemGroup Condition="$([MSBuild]::IsOSPlatform('Linux'))">
         <PackageReference Include="Net.IBM.Data.Db2-lnx"/>
@@ -23,7 +24,7 @@
     <!-- -8<- [end:PackageReferences] -->
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.Db2/Testcontainers.Db2.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
     <Import Project="Testcontainers.Db2.Tests.targets" Condition="$([MSBuild]::IsOSPlatform('Linux'))"/>

--- a/tests/Testcontainers.Db2.Tests/Usings.cs
+++ b/tests/Testcontainers.Db2.Tests/Usings.cs
@@ -9,4 +9,4 @@ global using IBM.Data.Db2;
 global using JetBrains.Annotations;
 global using Testcontainers.Xunit;
 global using Xunit;
-global using Xunit.Abstractions;
+global using Xunit.Sdk;

--- a/tests/Testcontainers.DynamoDb.Tests/DynamoDbContainerTest.cs
+++ b/tests/Testcontainers.DynamoDb.Tests/DynamoDbContainerTest.cs
@@ -12,7 +12,8 @@ public sealed class DynamoDbContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _dynamoDbContainer.StartAsync();
+        await _dynamoDbContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.DynamoDb.Tests/DynamoDbContainerTest.cs
+++ b/tests/Testcontainers.DynamoDb.Tests/DynamoDbContainerTest.cs
@@ -10,14 +10,14 @@ public sealed class DynamoDbContainerTest : IAsyncLifetime
         Environment.SetEnvironmentVariable("AWS_SECRET_ACCESS_KEY", CommonCredentials.AwsSecretKey);
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _dynamoDbContainer.StartAsync();
+        await _dynamoDbContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _dynamoDbContainer.DisposeAsync().AsTask();
+        return _dynamoDbContainer.DisposeAsync();
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public sealed class DynamoDbContainerTest : IAsyncLifetime
         using var client = new AmazonDynamoDBClient(config);
 
         // When
-        var tables = await client.ListTablesAsync()
+        var tables = await client.ListTablesAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -67,13 +67,13 @@ public sealed class DynamoDbContainerTest : IAsyncLifetime
         getItemRequest.Key = new Dictionary<string, AttributeValue> { { "Id", new AttributeValue { S = id } } };
 
         // When
-        _ = await client.CreateTableAsync(tableRequest)
+        _ = await client.CreateTableAsync(tableRequest, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        _ = await client.PutItemAsync(putItemRequest)
+        _ = await client.PutItemAsync(putItemRequest, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var itemResponse = await client.GetItemAsync(getItemRequest)
+        var itemResponse = await client.GetItemAsync(getItemRequest, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
+++ b/tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="AWSSDK.DynamoDBv2"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Elasticsearch.Tests/ElasticsearchContainerTest.cs
+++ b/tests/Testcontainers.Elasticsearch.Tests/ElasticsearchContainerTest.cs
@@ -5,14 +5,14 @@ public sealed class ElasticsearchContainerTest : IAsyncLifetime
     // # --8<-- [start:UseElasticsearchContainer]
     private readonly ElasticsearchContainer _elasticsearchContainer = new ElasticsearchBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _elasticsearchContainer.StartAsync();
+        await _elasticsearchContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _elasticsearchContainer.DisposeAsync().AsTask();
+        return _elasticsearchContainer.DisposeAsync();
     }
 
     [Fact]

--- a/tests/Testcontainers.Elasticsearch.Tests/ElasticsearchContainerTest.cs
+++ b/tests/Testcontainers.Elasticsearch.Tests/ElasticsearchContainerTest.cs
@@ -7,7 +7,8 @@ public sealed class ElasticsearchContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _elasticsearchContainer.StartAsync();
+        await _elasticsearchContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
+++ b/tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj
@@ -3,13 +3,14 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Elastic.Clients.Elasticsearch"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>

--- a/tests/Testcontainers.EventHubs.Tests/EventHubsContainerTest.cs
+++ b/tests/Testcontainers.EventHubs.Tests/EventHubsContainerTest.cs
@@ -16,7 +16,8 @@ public abstract class EventHubsContainerTest : IAsyncLifetime
     // # --8<-- [start:UseEventHubsContainer]
     public async ValueTask InitializeAsync()
     {
-        await _eventHubsContainer.StartAsync();
+        await _eventHubsContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.EventHubs.Tests/Testcontainers.EventHubs.Tests.csproj
+++ b/tests/Testcontainers.EventHubs.Tests/Testcontainers.EventHubs.Tests.csproj
@@ -3,13 +3,14 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Azure.Messaging.EventHubs"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>

--- a/tests/Testcontainers.EventStoreDb.Tests/EventStoreDbContainerTest.cs
+++ b/tests/Testcontainers.EventStoreDb.Tests/EventStoreDbContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class EventStoreDbContainerTest : IAsyncLifetime
 {
     private readonly EventStoreDbContainer _eventStoreDbContainer = new EventStoreDbBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _eventStoreDbContainer.StartAsync();
+        await _eventStoreDbContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _eventStoreDbContainer.DisposeAsync().AsTask();
+        return _eventStoreDbContainer.DisposeAsync();
     }
 
     [Fact]
@@ -30,12 +30,12 @@ public sealed class EventStoreDbContainerTest : IAsyncLifetime
         var eventData = new EventData(Uuid.NewUuid(), eventType, Array.Empty<byte>());
 
         // When
-        _ = await client.AppendToStreamAsync(streamName, StreamState.NoStream, new[] { eventData })
+        _ = await client.AppendToStreamAsync(streamName, StreamState.NoStream, new[] { eventData }, cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var resolvedEvents = client.ReadStreamAsync(Direction.Forwards, streamName, StreamPosition.Start);
+        var resolvedEvents = client.ReadStreamAsync(Direction.Forwards, streamName, StreamPosition.Start, cancellationToken: TestContext.Current.CancellationToken);
 
-        var resolvedEvent = await resolvedEvents.FirstAsync()
+        var resolvedEvent = await resolvedEvents.FirstAsync(cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.EventStoreDb.Tests/EventStoreDbContainerTest.cs
+++ b/tests/Testcontainers.EventStoreDb.Tests/EventStoreDbContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class EventStoreDbContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _eventStoreDbContainer.StartAsync();
+        await _eventStoreDbContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
+++ b/tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="EventStore.Client.Grpc.Streams"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.FakeGcsServer.Tests/FakeGcsServerContainerTest.cs
+++ b/tests/Testcontainers.FakeGcsServer.Tests/FakeGcsServerContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class FakeGcsServerContainerTest : IAsyncLifetime
 {
     private readonly FakeGcsServerContainer _fakeGcsServerContainer = new FakeGcsServerBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _fakeGcsServerContainer.StartAsync();
+        await _fakeGcsServerContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _fakeGcsServerContainer.DisposeAsync().AsTask();
+        return _fakeGcsServerContainer.DisposeAsync();
     }
 
     [Fact]
@@ -36,16 +36,16 @@ public sealed class FakeGcsServerContainerTest : IAsyncLifetime
         storageClientBuilder.BaseUri = _fakeGcsServerContainer.GetConnectionString();
 
         // When
-        var client = await storageClientBuilder.BuildAsync()
+        var client = await storageClientBuilder.BuildAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        _ = await client.CreateBucketAsync(project, bucket)
+        _ = await client.CreateBucketAsync(project, bucket, cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        _ = await client.UploadObjectAsync(bucket, fileName, "text/plain", writeStream)
+        _ = await client.UploadObjectAsync(bucket, fileName, "text/plain", writeStream, cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        _ = await client.DownloadObjectAsync(bucket, fileName, readStream)
+        _ = await client.DownloadObjectAsync(bucket, fileName, readStream, cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.FakeGcsServer.Tests/FakeGcsServerContainerTest.cs
+++ b/tests/Testcontainers.FakeGcsServer.Tests/FakeGcsServerContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class FakeGcsServerContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _fakeGcsServerContainer.StartAsync();
+        await _fakeGcsServerContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.FakeGcsServer.Tests/Testcontainers.FakeGcsServer.Tests.csproj
+++ b/tests/Testcontainers.FakeGcsServer.Tests/Testcontainers.FakeGcsServer.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Google.Cloud.Storage.V1"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.FirebirdSql.Tests/FirebirdSqlContainerTest.cs
+++ b/tests/Testcontainers.FirebirdSql.Tests/FirebirdSqlContainerTest.cs
@@ -24,7 +24,7 @@ public abstract class FirebirdSqlContainerTest(FirebirdSqlContainerTest.Firebird
         const string scriptContent = "SELECT 1 FROM RDB$DATABASE;";
 
         // When
-        var execResult = await fixture.Container.ExecScriptAsync(scriptContent)
+        var execResult = await fixture.Container.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.FirebirdSql.Tests/Testcontainers.FirebirdSql.Tests.csproj
+++ b/tests/Testcontainers.FirebirdSql.Tests/Testcontainers.FirebirdSql.Tests.csproj
@@ -3,17 +3,18 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="FirebirdSql.Data.FirebirdClient"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.FirebirdSql/Testcontainers.FirebirdSql.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.FirebirdSql.Tests/Usings.cs
+++ b/tests/Testcontainers.FirebirdSql.Tests/Usings.cs
@@ -7,4 +7,4 @@ global using FirebirdSql.Data.FirebirdClient;
 global using JetBrains.Annotations;
 global using Testcontainers.Xunit;
 global using Xunit;
-global using Xunit.Abstractions;
+global using Xunit.Sdk;

--- a/tests/Testcontainers.Firestore.Tests/FirestoreContainerTest.cs
+++ b/tests/Testcontainers.Firestore.Tests/FirestoreContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class FirestoreContainerTest : IAsyncLifetime
 {
     private readonly FirestoreContainer _firestoreContainer = new FirestoreBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _firestoreContainer.StartAsync();
+        await _firestoreContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _firestoreContainer.DisposeAsync().AsTask();
+        return _firestoreContainer.DisposeAsync();
     }
 
     [Fact]
@@ -33,14 +33,14 @@ public sealed class FirestoreContainerTest : IAsyncLifetime
         firestoreDbBuilder.Endpoint = _firestoreContainer.GetEmulatorEndpoint();
         firestoreDbBuilder.ChannelCredentials = ChannelCredentials.Insecure;
 
-        var firestoreDb = await firestoreDbBuilder.BuildAsync()
+        var firestoreDb = await firestoreDbBuilder.BuildAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // When
-        _ = await firestoreDb.Collection(collection).Document().SetAsync(documentData)
+        _ = await firestoreDb.Collection(collection).Document().SetAsync(documentData, cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var querySnapshot = await firestoreDb.Collection(collection).GetSnapshotAsync()
+        var querySnapshot = await firestoreDb.Collection(collection).GetSnapshotAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Firestore.Tests/FirestoreContainerTest.cs
+++ b/tests/Testcontainers.Firestore.Tests/FirestoreContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class FirestoreContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _firestoreContainer.StartAsync();
+        await _firestoreContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Firestore.Tests/Testcontainers.Firestore.Tests.csproj
+++ b/tests/Testcontainers.Firestore.Tests/Testcontainers.Firestore.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Google.Cloud.Firestore"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.InfluxDb.Tests/InfluxDbContainerTest.cs
+++ b/tests/Testcontainers.InfluxDb.Tests/InfluxDbContainerTest.cs
@@ -6,14 +6,14 @@ public sealed class InfluxDbContainerTest : IAsyncLifetime
 
     private readonly InfluxDbContainer _influxDbContainer = new InfluxDbBuilder().WithAdminToken(AdminToken).Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _influxDbContainer.StartAsync();
+        await _influxDbContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _influxDbContainer.DisposeAsync().AsTask();
+        return _influxDbContainer.DisposeAsync();
     }
 
     [Fact]
@@ -55,10 +55,10 @@ public sealed class InfluxDbContainerTest : IAsyncLifetime
             .Timestamp(DateTime.UtcNow, WritePrecision.Ns);
 
         // When
-        await writeApi.WritePointAsync(point, InfluxDbBuilder.DefaultBucket, InfluxDbBuilder.DefaultOrganization)
+        await writeApi.WritePointAsync(point, InfluxDbBuilder.DefaultBucket, InfluxDbBuilder.DefaultOrganization, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var fluxTables = await queryApi.QueryAsync(query, InfluxDbBuilder.DefaultOrganization)
+        var fluxTables = await queryApi.QueryAsync(query, InfluxDbBuilder.DefaultOrganization, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         var recordValues = fluxTables.Single().Records.Single().Values;

--- a/tests/Testcontainers.InfluxDb.Tests/InfluxDbContainerTest.cs
+++ b/tests/Testcontainers.InfluxDb.Tests/InfluxDbContainerTest.cs
@@ -8,7 +8,8 @@ public sealed class InfluxDbContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _influxDbContainer.StartAsync();
+        await _influxDbContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.InfluxDb.Tests/Testcontainers.InfluxDb.Tests.csproj
+++ b/tests/Testcontainers.InfluxDb.Tests/Testcontainers.InfluxDb.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="InfluxDB.Client"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.JanusGraph.Tests/JanusGraphContainerTest.cs
+++ b/tests/Testcontainers.JanusGraph.Tests/JanusGraphContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class JanusGraphContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _janusGraphContainer.StartAsync();
+        await _janusGraphContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.JanusGraph.Tests/JanusGraphContainerTest.cs
+++ b/tests/Testcontainers.JanusGraph.Tests/JanusGraphContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class JanusGraphContainerTest : IAsyncLifetime
 {
     private readonly JanusGraphContainer _janusGraphContainer = new JanusGraphBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _janusGraphContainer.StartAsync();
+        await _janusGraphContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _janusGraphContainer.DisposeAsync().AsTask();
+        return _janusGraphContainer.DisposeAsync();
     }
 
     [Fact]
@@ -28,10 +28,10 @@ public sealed class JanusGraphContainerTest : IAsyncLifetime
         var graphTraversalSource = AnonymousTraversalSource.Traversal().WithRemote(connection);
 
         // When
-        await graphTraversalSource.AddV(label).Promise(traversal => traversal.Iterate())
+        await graphTraversalSource.AddV(label).Promise(traversal => traversal.Iterate(), TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var count = await graphTraversalSource.V().HasLabel(label).Count().Promise(traversal => traversal.Next())
+        var count = await graphTraversalSource.V().HasLabel(label).Count().Promise(traversal => traversal.Next(), TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.JanusGraph.Tests/Testcontainers.JanusGraph.Tests.csproj
+++ b/tests/Testcontainers.JanusGraph.Tests/Testcontainers.JanusGraph.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="JanusGraph.Net"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.K3s.Tests/K3sContainerTest.cs
+++ b/tests/Testcontainers.K3s.Tests/K3sContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class K3sContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _k3sConainter.StartAsync();
+        await _k3sConainter.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.K3s.Tests/Testcontainers.K3s.Tests.csproj
+++ b/tests/Testcontainers.K3s.Tests/Testcontainers.K3s.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="KubernetesClient"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Kafka.Tests/KafkaContainerNetworkTest.cs
+++ b/tests/Testcontainers.Kafka.Tests/KafkaContainerNetworkTest.cs
@@ -33,7 +33,7 @@ public sealed class KafkaContainerNetworkTest : IAsyncLifetime
             .Build();
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _kafkaContainer.StartAsync()
             .ConfigureAwait(false);
@@ -42,7 +42,7 @@ public sealed class KafkaContainerNetworkTest : IAsyncLifetime
             .ConfigureAwait(false);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _kafkaContainer.StartAsync()
             .ConfigureAwait(false);
@@ -57,10 +57,10 @@ public sealed class KafkaContainerNetworkTest : IAsyncLifetime
     [Fact]
     public async Task ConsumesProducedKafkaMessage()
     {
-        _ = await _kCatContainer.ExecAsync(new[] { "kafkacat", "-b", Listener, "-t", "msgs", "-P", "-l", DataFilePath })
+        _ = await _kCatContainer.ExecAsync(new[] { "kafkacat", "-b", Listener, "-t", "msgs", "-P", "-l", DataFilePath }, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var execResult = await _kCatContainer.ExecAsync(new[] { "kafkacat", "-b", Listener, "-C", "-t", "msgs", "-c", "1" })
+        var execResult = await _kCatContainer.ExecAsync(new[] { "kafkacat", "-b", Listener, "-C", "-t", "msgs", "-c", "1" }, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         Assert.Equal(Message, execResult.Stdout.Trim());

--- a/tests/Testcontainers.Kafka.Tests/KafkaContainerRegistryTest.cs
+++ b/tests/Testcontainers.Kafka.Tests/KafkaContainerRegistryTest.cs
@@ -55,7 +55,7 @@ public sealed class KafkaContainerRegistryTest : IAsyncLifetime
             .Build();
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _kafkaContainer.StartAsync()
             .ConfigureAwait(false);
@@ -64,7 +64,7 @@ public sealed class KafkaContainerRegistryTest : IAsyncLifetime
             .ConfigureAwait(false);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _kafkaContainer.StartAsync()
             .ConfigureAwait(false);
@@ -109,7 +109,7 @@ public sealed class KafkaContainerRegistryTest : IAsyncLifetime
             .SetValueSerializer(new JsonSerializer<User>(schemaRegistry))
             .Build();
 
-        _ = await producer.ProduceAsync(topic, message)
+        _ = await producer.ProduceAsync(topic, message, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         using var consumer = new ConsumerBuilder<string, User>(consumerConfig)

--- a/tests/Testcontainers.Kafka.Tests/KafkaContainerRegistryTest.cs
+++ b/tests/Testcontainers.Kafka.Tests/KafkaContainerRegistryTest.cs
@@ -125,5 +125,6 @@ public sealed class KafkaContainerRegistryTest : IAsyncLifetime
         Assert.Equal(message.Value, result.Message.Value);
     }
 
+    [UsedImplicitly]
     private record User(string FirstName, string LastName);
 }

--- a/tests/Testcontainers.Kafka.Tests/KafkaContainerTest.cs
+++ b/tests/Testcontainers.Kafka.Tests/KafkaContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class KafkaContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _kafkaContainer.StartAsync();
+        await _kafkaContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Kafka.Tests/KafkaContainerTest.cs
+++ b/tests/Testcontainers.Kafka.Tests/KafkaContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class KafkaContainerTest : IAsyncLifetime
 {
     private readonly KafkaContainer _kafkaContainer = new KafkaBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _kafkaContainer.StartAsync();
+        await _kafkaContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _kafkaContainer.DisposeAsync().AsTask();
+        return _kafkaContainer.DisposeAsync();
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public sealed class KafkaContainerTest : IAsyncLifetime
 
         // When
         using var producer = new ProducerBuilder<string, string>(producerConfig).Build();
-        _ = await producer.ProduceAsync(topic, message)
+        _ = await producer.ProduceAsync(topic, message, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         using var consumer = new ConsumerBuilder<string, string>(consumerConfig).Build();

--- a/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
+++ b/tests/Testcontainers.Kafka.Tests/Testcontainers.Kafka.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Confluent.Kafka"/>
         <PackageReference Include="Confluent.SchemaRegistry.Serdes.Json"/>
         <PackageReference Include="Confluent.SchemaRegistry"/>

--- a/tests/Testcontainers.Kafka.Tests/Usings.cs
+++ b/tests/Testcontainers.Kafka.Tests/Usings.cs
@@ -9,4 +9,5 @@ global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
 global using DotNet.Testcontainers.Containers;
 global using DotNet.Testcontainers.Networks;
+global using JetBrains.Annotations;
 global using Xunit;

--- a/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
+++ b/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
@@ -9,14 +9,14 @@ public abstract class KeycloakContainerTest : IAsyncLifetime
         _keycloakContainer = keycloakContainer;
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _keycloakContainer.StartAsync();
+        await _keycloakContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _keycloakContainer.DisposeAsync().AsTask();
+        return _keycloakContainer.DisposeAsync();
     }
 
     [Fact]
@@ -27,7 +27,7 @@ public abstract class KeycloakContainerTest : IAsyncLifetime
         httpClient.BaseAddress = new Uri(_keycloakContainer.GetBaseAddress());
 
         // When
-        using var httpResponse = await httpClient.GetAsync("/realms/master/.well-known/openid-configuration")
+        using var httpResponse = await httpClient.GetAsync("/realms/master/.well-known/openid-configuration", TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -41,7 +41,7 @@ public abstract class KeycloakContainerTest : IAsyncLifetime
         var keycloakClient = new KeycloakClient(_keycloakContainer.GetBaseAddress(), KeycloakBuilder.DefaultUsername, KeycloakBuilder.DefaultPassword);
 
         // When
-        var masterRealm = await keycloakClient.GetRealmAsync("master")
+        var masterRealm = await keycloakClient.GetRealmAsync("master", TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
+++ b/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
@@ -11,7 +11,8 @@ public abstract class KeycloakContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _keycloakContainer.StartAsync();
+        await _keycloakContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
+++ b/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Keycloak.Net.Core"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Kusto.Tests/KustoContainerTest.cs
+++ b/tests/Testcontainers.Kusto.Tests/KustoContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class KustoContainerTest : IAsyncLifetime
 {
     private readonly KustoContainer _kustoContainer = new KustoBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _kustoContainer.StartAsync();
+        await _kustoContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _kustoContainer.DisposeAsync().AsTask();
+        return _kustoContainer.DisposeAsync();
     }
 
     [Fact]

--- a/tests/Testcontainers.Kusto.Tests/KustoContainerTest.cs
+++ b/tests/Testcontainers.Kusto.Tests/KustoContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class KustoContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _kustoContainer.StartAsync();
+        await _kustoContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Kusto.Tests/Testcontainers.Kusto.Tests.csproj
+++ b/tests/Testcontainers.Kusto.Tests/Testcontainers.Kusto.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Microsoft.Azure.Kusto.Data"/>
   </ItemGroup>
   <ItemGroup>

--- a/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTest.cs
+++ b/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTest.cs
@@ -19,7 +19,8 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _localStackContainer.StartAsync();
+        await _localStackContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTest.cs
+++ b/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTest.cs
@@ -17,14 +17,14 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
         _localStackContainer = localStackContainer;
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _localStackContainer.StartAsync();
+        await _localStackContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _localStackContainer.DisposeAsync().AsTask();
+        return _localStackContainer.DisposeAsync();
     }
 
     [Fact]
@@ -41,7 +41,7 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
         var logGroupRequest = new CreateLogGroupRequest(Guid.NewGuid().ToString("D"));
 
         // When
-        var logGroupResponse = await client.CreateLogGroupAsync(logGroupRequest)
+        var logGroupResponse = await client.CreateLogGroupAsync(logGroupRequest, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -78,13 +78,13 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
         getItemRequest.Key = new Dictionary<string, AttributeValue> { { "Id", new AttributeValue { S = id } } };
 
         // When
-        _ = await client.CreateTableAsync(tableRequest)
+        _ = await client.CreateTableAsync(tableRequest, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        _ = await client.PutItemAsync(putItemRequest)
+        _ = await client.PutItemAsync(putItemRequest, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var itemResponse = await client.GetItemAsync(getItemRequest)
+        var itemResponse = await client.GetItemAsync(getItemRequest, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -103,7 +103,7 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
         using var client = new AmazonS3Client(config);
 
         // When
-        var buckets = await client.ListBucketsAsync()
+        var buckets = await client.ListBucketsAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -122,7 +122,7 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
         using var client = new AmazonSimpleNotificationServiceClient(config);
 
         // When
-        var topicResponse = await client.CreateTopicAsync(Guid.NewGuid().ToString("D"))
+        var topicResponse = await client.CreateTopicAsync(Guid.NewGuid().ToString("D"), TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -141,7 +141,7 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
         using var client = new AmazonSQSClient(config);
 
         // When
-        var queueResponse = await client.CreateQueueAsync(Guid.NewGuid().ToString("D"))
+        var queueResponse = await client.CreateQueueAsync(Guid.NewGuid().ToString("D"), TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
+++ b/tests/Testcontainers.LocalStack.Tests/Testcontainers.LocalStack.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="AWSSDK.CloudWatchLogs"/>
         <PackageReference Include="AWSSDK.DynamoDBv2"/>
         <PackageReference Include="AWSSDK.S3"/>

--- a/tests/Testcontainers.LowkeyVault.Tests/LowkeyVaultContainerTest.cs
+++ b/tests/Testcontainers.LowkeyVault.Tests/LowkeyVaultContainerTest.cs
@@ -8,7 +8,8 @@ public abstract class LowkeyVaultContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _lowkeyVaultContainer.StartAsync();
+        await _lowkeyVaultContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.LowkeyVault.Tests/Testcontainers.LowkeyVault.Tests.csproj
+++ b/tests/Testcontainers.LowkeyVault.Tests/Testcontainers.LowkeyVault.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Azure.Identity"/>
         <PackageReference Include="Azure.Security.KeyVault.Certificates"/>
         <PackageReference Include="Azure.Security.KeyVault.Secrets"/>

--- a/tests/Testcontainers.MariaDb.Tests/MariaDbContainerTest.cs
+++ b/tests/Testcontainers.MariaDb.Tests/MariaDbContainerTest.cs
@@ -24,7 +24,7 @@ public abstract class MariaDbContainerTest(MariaDbContainerTest.MariaDbDefaultFi
         const string scriptContent = "SELECT 1;";
 
         // When
-        var execResult = await fixture.Container.ExecScriptAsync(scriptContent)
+        var execResult = await fixture.Container.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
+++ b/tests/Testcontainers.MariaDb.Tests/Testcontainers.MariaDb.Tests.csproj
@@ -3,17 +3,18 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="MySqlConnector"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.MariaDb/Testcontainers.MariaDb.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.MariaDb.Tests/Usings.cs
+++ b/tests/Testcontainers.MariaDb.Tests/Usings.cs
@@ -7,4 +7,4 @@ global using JetBrains.Annotations;
 global using MySqlConnector;
 global using Testcontainers.Xunit;
 global using Xunit;
-global using Xunit.Abstractions;
+global using Xunit.Sdk;

--- a/tests/Testcontainers.Milvus.Tests/MilvusContainerTest.cs
+++ b/tests/Testcontainers.Milvus.Tests/MilvusContainerTest.cs
@@ -13,7 +13,8 @@ public abstract class MilvusContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _milvusContainer.StartAsync();
+        await _milvusContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Milvus.Tests/MilvusContainerTest.cs
+++ b/tests/Testcontainers.Milvus.Tests/MilvusContainerTest.cs
@@ -11,14 +11,14 @@ public abstract class MilvusContainerTest : IAsyncLifetime
         _milvusContainer = milvusContainer;
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _milvusContainer.StartAsync();
+        await _milvusContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _milvusContainer.DisposeAsync().AsTask();
+        return _milvusContainer.DisposeAsync();
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public abstract class MilvusContainerTest : IAsyncLifetime
         using var client = new MilvusClient(_milvusContainer.GetEndpoint());
 
         // When
-        var version = await client.GetVersionAsync()
+        var version = await client.GetVersionAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Milvus.Tests/Testcontainers.Milvus.Tests.csproj
+++ b/tests/Testcontainers.Milvus.Tests/Testcontainers.Milvus.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Milvus.Client"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Minio.Tests/MinioContainerTest.cs
+++ b/tests/Testcontainers.Minio.Tests/MinioContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class MinioContainerTest : IAsyncLifetime
 {
     private readonly MinioContainer _minioContainer = new MinioBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _minioContainer.StartAsync();
+        await _minioContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _minioContainer.DisposeAsync().AsTask();
+        return _minioContainer.DisposeAsync();
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public sealed class MinioContainerTest : IAsyncLifetime
         using var client = new AmazonS3Client(_minioContainer.GetAccessKey(), _minioContainer.GetSecretKey(), config);
 
         // When
-        var buckets = await client.ListBucketsAsync()
+        var buckets = await client.ListBucketsAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -50,13 +50,13 @@ public sealed class MinioContainerTest : IAsyncLifetime
         objectRequest.InputStream = inputStream;
 
         // When
-        _ = await client.PutBucketAsync(objectRequest.BucketName)
+        _ = await client.PutBucketAsync(objectRequest.BucketName, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        _ = await client.PutObjectAsync(objectRequest)
+        _ = await client.PutObjectAsync(objectRequest, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var objectResponse = await client.GetObjectAsync(objectRequest.BucketName, objectRequest.Key)
+        var objectResponse = await client.GetObjectAsync(objectRequest.BucketName, objectRequest.Key, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Minio.Tests/MinioContainerTest.cs
+++ b/tests/Testcontainers.Minio.Tests/MinioContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class MinioContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _minioContainer.StartAsync();
+        await _minioContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
+++ b/tests/Testcontainers.Minio.Tests/Testcontainers.Minio.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="AWSSDK.S3"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.MongoDb.Tests/MongoDbContainerTest.cs
+++ b/tests/Testcontainers.MongoDb.Tests/MongoDbContainerTest.cs
@@ -15,7 +15,8 @@ public abstract class MongoDbContainerTest : IAsyncLifetime
     // # --8<-- [start:UseMongoDbContainer]
     public async ValueTask InitializeAsync()
     {
-        await _mongoDbContainer.StartAsync();
+        await _mongoDbContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
+++ b/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
@@ -3,13 +3,14 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="MongoDB.Driver"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -25,7 +25,7 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
         const string scriptContent = "SELECT 1;";
 
         // When
-        var execResult = await fixture.Container.ExecScriptAsync(scriptContent)
+        var execResult = await fixture.Container.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
+++ b/tests/Testcontainers.MsSql.Tests/Testcontainers.MsSql.Tests.csproj
@@ -3,19 +3,20 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Microsoft.Data.SqlClient"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.MsSql/Testcontainers.MsSql.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.MsSql.Tests/Usings.cs
+++ b/tests/Testcontainers.MsSql.Tests/Usings.cs
@@ -7,4 +7,4 @@ global using JetBrains.Annotations;
 global using Microsoft.Data.SqlClient;
 global using Testcontainers.Xunit;
 global using Xunit;
-global using Xunit.Abstractions;
+global using Xunit.Sdk;

--- a/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
+++ b/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
@@ -24,7 +24,7 @@ public abstract class MySqlContainerTest(MySqlContainerTest.MySqlDefaultFixture 
         const string scriptContent = "SELECT 1;";
 
         // When
-        var execResult = await fixture.Container.ExecScriptAsync(scriptContent)
+        var execResult = await fixture.Container.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
+++ b/tests/Testcontainers.MySql.Tests/Testcontainers.MySql.Tests.csproj
@@ -3,17 +3,18 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="MySqlConnector"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.MySql/Testcontainers.MySql.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.MySql.Tests/Usings.cs
+++ b/tests/Testcontainers.MySql.Tests/Usings.cs
@@ -7,4 +7,4 @@ global using JetBrains.Annotations;
 global using MySqlConnector;
 global using Testcontainers.Xunit;
 global using Xunit;
-global using Xunit.Abstractions;
+global using Xunit.Sdk;

--- a/tests/Testcontainers.Nats.Tests/NatsContainerTest.cs
+++ b/tests/Testcontainers.Nats.Tests/NatsContainerTest.cs
@@ -11,7 +11,8 @@ public abstract class NatsContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _natsContainer.StartAsync();
+        await _natsContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Nats.Tests/NatsContainerTest.cs
+++ b/tests/Testcontainers.Nats.Tests/NatsContainerTest.cs
@@ -9,14 +9,14 @@ public abstract class NatsContainerTest : IAsyncLifetime
         _natsContainer = natsContainer;
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _natsContainer.StartAsync();
+        await _natsContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _natsContainer.DisposeAsync().AsTask();
+        return _natsContainer.DisposeAsync();
     }
 
     [Fact]
@@ -28,10 +28,10 @@ public abstract class NatsContainerTest : IAsyncLifetime
         httpClient.BaseAddress = new Uri(_natsContainer.GetManagementEndpoint());
 
         // When
-        using var httpResponse = await httpClient.GetAsync("/healthz")
+        using var httpResponse = await httpClient.GetAsync("/healthz", TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var jsonStatusString = await httpResponse.Content.ReadAsStringAsync()
+        var jsonStatusString = await httpResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Nats.Tests/Testcontainers.Nats.Tests.csproj
+++ b/tests/Testcontainers.Nats.Tests/Testcontainers.Nats.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="NATS.Client"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Neo4j.Tests/Neo4jContainerTest.cs
+++ b/tests/Testcontainers.Neo4j.Tests/Neo4jContainerTest.cs
@@ -14,7 +14,8 @@ public abstract class Neo4jContainerTest : IAsyncLifetime
     // # --8<-- [start:UseNeo4jContainer]
     public async ValueTask InitializeAsync()
     {
-        await _neo4jContainer.StartAsync();
+        await _neo4jContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Neo4j.Tests/Neo4jContainerTest.cs
+++ b/tests/Testcontainers.Neo4j.Tests/Neo4jContainerTest.cs
@@ -12,14 +12,14 @@ public abstract class Neo4jContainerTest : IAsyncLifetime
     public abstract string Edition { get; }
 
     // # --8<-- [start:UseNeo4jContainer]
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _neo4jContainer.StartAsync();
+        await _neo4jContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _neo4jContainer.DisposeAsync().AsTask();
+        return _neo4jContainer.DisposeAsync();
     }
 
     [Fact]

--- a/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
+++ b/tests/Testcontainers.Neo4j.Tests/Testcontainers.Neo4j.Tests.csproj
@@ -3,13 +3,14 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Neo4j.Driver"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>

--- a/tests/Testcontainers.Ollama.Tests/OllamaContainerTest.cs
+++ b/tests/Testcontainers.Ollama.Tests/OllamaContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class OllamaContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _ollamaContainer.StartAsync();
+        await _ollamaContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Ollama.Tests/OllamaContainerTests.cs
+++ b/tests/Testcontainers.Ollama.Tests/OllamaContainerTests.cs
@@ -4,14 +4,14 @@ public sealed class OllamaContainerTest : IAsyncLifetime
 {
     private readonly OllamaContainer _ollamaContainer = new OllamaBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _ollamaContainer.StartAsync();
+        await _ollamaContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _ollamaContainer.DisposeAsync().AsTask();
+        return _ollamaContainer.DisposeAsync();
     }
 
     [Fact]
@@ -27,10 +27,10 @@ public sealed class OllamaContainerTest : IAsyncLifetime
         embedRequest.Input = new List<string> { "Hello, World!" };
 
         // When
-        await foreach (var _ in ollamaClient.PullModelAsync(model)
+        await foreach (var _ in ollamaClient.PullModelAsync(model, TestContext.Current.CancellationToken)
             .ConfigureAwait(true));
 
-        var embedResponse = await ollamaClient.EmbedAsync(embedRequest)
+        var embedResponse = await ollamaClient.EmbedAsync(embedRequest, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Ollama.Tests/Testcontainers.Ollama.Tests.csproj
+++ b/tests/Testcontainers.Ollama.Tests/Testcontainers.Ollama.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="OllamaSharp"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Oracle.Tests/OracleContainerTest.cs
+++ b/tests/Testcontainers.Oracle.Tests/OracleContainerTest.cs
@@ -24,7 +24,7 @@ public abstract class OracleContainerTest(OracleContainerTest.OracleFixture fixt
         const string scriptContent = "SELECT 1 FROM DUAL;";
 
         // When
-        var execResult = await fixture.Container.ExecScriptAsync(scriptContent)
+        var execResult = await fixture.Container.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
+++ b/tests/Testcontainers.Oracle.Tests/Testcontainers.Oracle.Tests.csproj
@@ -3,18 +3,19 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
         <DefineConstants>$(DefineConstants);ORACLE_DEFAULT</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Oracle.ManagedDataAccess.Core"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.Oracle/Testcontainers.Oracle.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Oracle.Tests/Usings.cs
+++ b/tests/Testcontainers.Oracle.Tests/Usings.cs
@@ -8,4 +8,4 @@ global using JetBrains.Annotations;
 global using Oracle.ManagedDataAccess.Client;
 global using Testcontainers.Xunit;
 global using Xunit;
-global using Xunit.Abstractions;
+global using Xunit.Sdk;

--- a/tests/Testcontainers.Oracle11.Tests/Testcontainers.Oracle11.Tests.csproj
+++ b/tests/Testcontainers.Oracle11.Tests/Testcontainers.Oracle11.Tests.csproj
@@ -3,18 +3,19 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
         <DefineConstants>$(DefineConstants);ORACLE_11</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Oracle.ManagedDataAccess.Core"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.Oracle/Testcontainers.Oracle.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Oracle18.Tests/Testcontainers.Oracle18.Tests.csproj
+++ b/tests/Testcontainers.Oracle18.Tests/Testcontainers.Oracle18.Tests.csproj
@@ -3,18 +3,19 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
         <DefineConstants>$(DefineConstants);ORACLE_18</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Oracle.ManagedDataAccess.Core"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.Oracle/Testcontainers.Oracle.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Oracle21.Tests/Testcontainers.Oracle21.Tests.csproj
+++ b/tests/Testcontainers.Oracle21.Tests/Testcontainers.Oracle21.Tests.csproj
@@ -3,18 +3,19 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
         <DefineConstants>$(DefineConstants);ORACLE_21</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Oracle.ManagedDataAccess.Core"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.Oracle/Testcontainers.Oracle.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Oracle23.Tests/Testcontainers.Oracle23.Tests.csproj
+++ b/tests/Testcontainers.Oracle23.Tests/Testcontainers.Oracle23.Tests.csproj
@@ -3,18 +3,19 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
         <DefineConstants>$(DefineConstants);ORACLE_23</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Oracle.ManagedDataAccess.Core"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.Oracle/Testcontainers.Oracle.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Papercut.Tests/PapercutContainerTest.cs
+++ b/tests/Testcontainers.Papercut.Tests/PapercutContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class PapercutContainerTest : IAsyncLifetime
 {
     private readonly PapercutContainer _papercutContainer = new PapercutBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _papercutContainer.StartAsync();
+        await _papercutContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _papercutContainer.DisposeAsync().AsTask();
+        return _papercutContainer.DisposeAsync();
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public sealed class PapercutContainerTest : IAsyncLifetime
         // When
         smtpClient.Send("from@example.com", "to@example.com", subject, "A test message");
 
-        var messagesJson = await httpClient.GetStringAsync("/api/messages")
+        var messagesJson = await httpClient.GetStringAsync("/api/messages", TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         var jsonDocument = JsonDocument.Parse(messagesJson);

--- a/tests/Testcontainers.Papercut.Tests/PapercutContainerTest.cs
+++ b/tests/Testcontainers.Papercut.Tests/PapercutContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class PapercutContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _papercutContainer.StartAsync();
+        await _papercutContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Papercut.Tests/Testcontainers.Papercut.Tests.csproj
+++ b/tests/Testcontainers.Papercut.Tests/Testcontainers.Papercut.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.Papercut/Testcontainers.Papercut.csproj"/>

--- a/tests/Testcontainers.Platform.Linux.Tests/DependsOnTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/DependsOnTest.cs
@@ -56,7 +56,8 @@ public sealed class DependsOnTest : IAsyncLifetime
 
     public async ValueTask DisposeAsync()
     {
-        await Task.WhenAll(_disposables.Select(disposable => disposable.DisposeAsync().AsTask()));
+        await Task.WhenAll(_disposables.Select(disposable => disposable.DisposeAsync().AsTask()))
+            .ConfigureAwait(false);
     }
 
     [Fact]

--- a/tests/Testcontainers.Platform.Linux.Tests/DependsOnTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/DependsOnTest.cs
@@ -15,7 +15,7 @@ public sealed class DependsOnTest : IAsyncLifetime
         _filters.Add("label", string.Join("=", _labelKey, _labelValue));
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         var childContainer1 = new ContainerBuilder()
             .WithImage(CommonImages.Alpine)
@@ -54,9 +54,9 @@ public sealed class DependsOnTest : IAsyncLifetime
         _disposables.Add(volume);
     }
 
-    public Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        return Task.WhenAll(_disposables.Select(disposable => disposable.DisposeAsync().AsTask()));
+        await Task.WhenAll(_disposables.Select(disposable => disposable.DisposeAsync().AsTask()));
     }
 
     [Fact]
@@ -75,13 +75,13 @@ public sealed class DependsOnTest : IAsyncLifetime
         var volumesListParameters = new VolumesListParameters { Filters = _filters };
 
         // When
-        var containers = await client.Containers.ListContainersAsync(containersListParameters)
+        var containers = await client.Containers.ListContainersAsync(containersListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var networks = await client.Networks.ListNetworksAsync(networksListParameters)
+        var networks = await client.Networks.ListNetworksAsync(networksListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var response = await client.Volumes.ListAsync(volumesListParameters)
+        var response = await client.Volumes.ListAsync(volumesListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Platform.Linux.Tests/LoggerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/LoggerTest.cs
@@ -9,9 +9,9 @@ public abstract class LoggerTest : IAsyncLifetime
         _fakeLogger = fakeLogger;
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return new ContainerBuilder()
+        await new ContainerBuilder()
             .WithImage(CommonImages.Alpine)
             .WithCommand(CommonCommands.SleepInfinity)
             .WithLogger(_fakeLogger)
@@ -19,9 +19,9 @@ public abstract class LoggerTest : IAsyncLifetime
             .StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     [Theory]

--- a/tests/Testcontainers.Platform.Linux.Tests/LoggerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/LoggerTest.cs
@@ -16,7 +16,8 @@ public abstract class LoggerTest : IAsyncLifetime
             .WithCommand(CommonCommands.SleepInfinity)
             .WithLogger(_fakeLogger)
             .Build()
-            .StartAsync();
+            .StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
@@ -7,24 +7,24 @@ public sealed class PauseUnpauseTest : IAsyncLifetime
         .WithCommand(CommonCommands.SleepInfinity)
         .Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _container.StartAsync();
+        await _container.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _container.DisposeAsync().AsTask();
+        return _container.DisposeAsync();
     }
 
     [Fact]
     public async Task PausesAndUnpausesContainerSuccessfully()
     {
-        await _container.PauseAsync()
+        await _container.PauseAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
         Assert.Equal(TestcontainersStates.Paused, _container.State);
 
-        await _container.UnpauseAsync()
+        await _container.UnpauseAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
         Assert.Equal(TestcontainersStates.Running, _container.State);
     }
@@ -32,6 +32,6 @@ public sealed class PauseUnpauseTest : IAsyncLifetime
     [Fact]
     public Task UnpausingRunningContainerThrowsDockerApiException()
     {
-        return Assert.ThrowsAsync<DockerApiException>(() => _container.UnpauseAsync());
+        return Assert.ThrowsAsync<DockerApiException>(() => _container.UnpauseAsync(TestContext.Current.CancellationToken));
     }
 }

--- a/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/PauseUnpauseTest.cs
@@ -9,7 +9,8 @@ public sealed class PauseUnpauseTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _container.StartAsync();
+        await _container.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Platform.Linux.Tests/PortForwardingTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/PortForwardingTest.cs
@@ -11,7 +11,8 @@ public abstract class PortForwardingTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _container.StartAsync();
+        await _container.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()
@@ -82,7 +83,8 @@ public abstract class PortForwardingTest : IAsyncLifetime
 
         public async ValueTask InitializeAsync()
         {
-            await Task.WhenAny(TestcontainersSettings.ExposeHostPortsAsync(Port), AcceptSocketAsync());
+            await Task.WhenAny(TestcontainersSettings.ExposeHostPortsAsync(Port), AcceptSocketAsync())
+                .ConfigureAwait(false);
         }
 
         public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Platform.Linux.Tests/PortForwardingTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/PortForwardingTest.cs
@@ -9,24 +9,24 @@ public abstract class PortForwardingTest : IAsyncLifetime
         _container = container;
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _container.StartAsync();
+        await _container.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _container.DisposeAsync().AsTask();
+        return _container.DisposeAsync();
     }
 
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task EstablishesHostConnection()
     {
-        var exitCode = await _container.GetExitCodeAsync()
+        var exitCode = await _container.GetExitCodeAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var (stdout, _) = await _container.GetLogsAsync(timestampsEnabled: false)
+        var (stdout, _) = await _container.GetLogsAsync(timestampsEnabled: false, ct: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         Assert.Equal(0, exitCode);
@@ -80,18 +80,18 @@ public abstract class PortForwardingTest : IAsyncLifetime
 
         public ushort Port => Convert.ToUInt16(((IPEndPoint)_tcpListener.LocalEndpoint).Port);
 
-        public Task InitializeAsync()
+        public async ValueTask InitializeAsync()
         {
-            return Task.WhenAny(TestcontainersSettings.ExposeHostPortsAsync(Port), AcceptSocketAsync());
+            await Task.WhenAny(TestcontainersSettings.ExposeHostPortsAsync(Port), AcceptSocketAsync());
         }
 
-        public Task DisposeAsync()
+        public ValueTask DisposeAsync()
         {
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource.Dispose();
             _tcpListener.Stop();
 
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         }
 
         private async Task AcceptSocketAsync()

--- a/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
@@ -24,7 +24,7 @@ public sealed class ReusableResourceTest : IAsyncLifetime
         _filters.Add("label", string.Join("=", _labelKey, _labelValue));
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         for (var _ = 0; _ < 3; _++)
         {
@@ -56,9 +56,9 @@ public sealed class ReusableResourceTest : IAsyncLifetime
         }
     }
 
-    public Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-        return Task.WhenAll(_disposables
+        await Task.WhenAll(_disposables
             .Take(3)
             .Select(disposable =>
             {
@@ -83,13 +83,13 @@ public sealed class ReusableResourceTest : IAsyncLifetime
 
         var volumesListParameters = new VolumesListParameters { Filters = _filters };
 
-        var containers = await client.Containers.ListContainersAsync(containersListParameters)
+        var containers = await client.Containers.ListContainersAsync(containersListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var networks = await client.Networks.ListNetworksAsync(networksListParameters)
+        var networks = await client.Networks.ListNetworksAsync(networksListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var response = await client.Volumes.ListAsync(volumesListParameters)
+        var response = await client.Volumes.ListAsync(volumesListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         Assert.Single(containers);

--- a/tests/Testcontainers.Platform.Linux.Tests/SocatContainerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/SocatContainerTest.cs
@@ -28,7 +28,7 @@ public sealed class SocatContainerTest : IAsyncLifetime
             .Build();
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _helloWorldContainer.StartAsync()
             .ConfigureAwait(false);
@@ -37,7 +37,7 @@ public sealed class SocatContainerTest : IAsyncLifetime
             .ConfigureAwait(false);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _socatContainer.DisposeAsync()
             .ConfigureAwait(false);
@@ -59,10 +59,10 @@ public sealed class SocatContainerTest : IAsyncLifetime
         httpClient.BaseAddress = new UriBuilder(Uri.UriSchemeHttp, _socatContainer.Hostname, _socatContainer.GetMappedPublicPort(containerPort)).Uri;
 
         // When
-        using var httpResponse = await httpClient.GetAsync("/ping")
+        using var httpResponse = await httpClient.GetAsync("/ping", TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var response = await httpResponse.Content.ReadAsStringAsync()
+        var response = await httpResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -88,7 +88,8 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
 
         public async ValueTask InitializeAsync()
         {
-            await _tarOutputMemoryStream.AddAsync(this);
+            await _tarOutputMemoryStream.AddAsync(this)
+                .ConfigureAwait(false);
         }
 
         public ValueTask DisposeAsync()
@@ -161,7 +162,7 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
                 .ConfigureAwait(true);
 
             // Then
-            var execResults = await Task.WhenAll(targetFilePaths.Select(containerFilePath => container.ExecAsync(new[] { "test", "-f", containerFilePath })))
+            var execResults = await Task.WhenAll(targetFilePaths.Select(containerFilePath => container.ExecAsync(new[] { "test", "-f", containerFilePath }, TestContext.Current.CancellationToken)))
                 .ConfigureAwait(true);
 
             Assert.All(execResults, result => Assert.Equal(0, result.ExitCode));
@@ -185,7 +186,8 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
 
             public async ValueTask InitializeAsync()
             {
-                await _container.StartAsync();
+                await _container.StartAsync()
+                    .ConfigureAwait(false);
             }
 
             public ValueTask DisposeAsync()
@@ -200,7 +202,8 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
     {
         public async ValueTask InitializeAsync()
         {
-            await _tarOutputMemoryStream.AddAsync(_testFile, Unix.FileMode644);
+            await _tarOutputMemoryStream.AddAsync(_testFile, Unix.FileMode644)
+                .ConfigureAwait(false);
         }
 
         public ValueTask DisposeAsync()
@@ -214,7 +217,8 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
     {
         public async ValueTask InitializeAsync()
         {
-            await _tarOutputMemoryStream.AddAsync(_testFile.Directory, true, Unix.FileMode644);
+            await _tarOutputMemoryStream.AddAsync(_testFile.Directory, true, Unix.FileMode644)
+                .ConfigureAwait(false);
         }
 
         public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -86,14 +86,14 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
         public UnixFileModes FileMode
             => Unix.FileMode644;
 
-        public Task InitializeAsync()
+        public async ValueTask InitializeAsync()
         {
-            return _tarOutputMemoryStream.AddAsync(this);
+            await _tarOutputMemoryStream.AddAsync(this);
         }
 
-        public Task DisposeAsync()
+        public ValueTask DisposeAsync()
         {
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         }
 
         Task IFutureResource.CreateAsync(CancellationToken ct)
@@ -145,19 +145,19 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
                 .Build();
 
             // When
-            var fileContent = await GetAllBytesAsync()
+            var fileContent = await GetAllBytesAsync(TestContext.Current.CancellationToken)
                 .ConfigureAwait(true);
 
-            await container.StartAsync()
+            await container.StartAsync(TestContext.Current.CancellationToken)
                 .ConfigureAwait(true);
 
-            await container.CopyAsync(fileContent, targetFilePath3)
+            await container.CopyAsync(fileContent, targetFilePath3, ct: TestContext.Current.CancellationToken)
                 .ConfigureAwait(true);
 
-            await container.CopyAsync(_testFile.FullName, targetDirectoryPath4)
+            await container.CopyAsync(_testFile.FullName, targetDirectoryPath4, ct: TestContext.Current.CancellationToken)
                 .ConfigureAwait(true);
 
-            await container.CopyAsync(_testFile.Directory!.FullName, targetDirectoryPath5)
+            await container.CopyAsync(_testFile.Directory!.FullName, targetDirectoryPath5, ct: TestContext.Current.CancellationToken)
                 .ConfigureAwait(true);
 
             // Then
@@ -183,14 +183,14 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
             public string BaseAddress
                 => new UriBuilder(Uri.UriSchemeHttp, _container.Hostname, _container.GetMappedPublicPort(HttpPort)).ToString();
 
-            public Task InitializeAsync()
+            public async ValueTask InitializeAsync()
             {
-                return _container.StartAsync();
+                await _container.StartAsync();
             }
 
-            public Task DisposeAsync()
+            public ValueTask DisposeAsync()
             {
-                return _container.DisposeAsync().AsTask();
+                return _container.DisposeAsync();
             }
         }
     }
@@ -198,28 +198,28 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
     [UsedImplicitly]
     public sealed class FromFile : TarOutputMemoryStreamTest, IAsyncLifetime
     {
-        public Task InitializeAsync()
+        public async ValueTask InitializeAsync()
         {
-            return _tarOutputMemoryStream.AddAsync(_testFile, Unix.FileMode644);
+            await _tarOutputMemoryStream.AddAsync(_testFile, Unix.FileMode644);
         }
 
-        public Task DisposeAsync()
+        public ValueTask DisposeAsync()
         {
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         }
     }
 
     [UsedImplicitly]
     public sealed class FromDirectory : TarOutputMemoryStreamTest, IAsyncLifetime
     {
-        public Task InitializeAsync()
+        public async ValueTask InitializeAsync()
         {
-            return _tarOutputMemoryStream.AddAsync(_testFile.Directory, true, Unix.FileMode644);
+            await _tarOutputMemoryStream.AddAsync(_testFile.Directory, true, Unix.FileMode644);
         }
 
-        public Task DisposeAsync()
+        public ValueTask DisposeAsync()
         {
-            return Task.CompletedTask;
+            return ValueTask.CompletedTask;
         }
     }
 

--- a/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
+++ b/tests/Testcontainers.Platform.Linux.Tests/Testcontainers.Platform.Linux.Tests.csproj
@@ -3,6 +3,7 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
@@ -10,7 +11,7 @@
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="ReflectionMagic"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>

--- a/tests/Testcontainers.Platform.Linux.Tests/WaitStrategyTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/WaitStrategyTest.cs
@@ -10,7 +10,7 @@ public sealed class WaitStrategyTest
             .WithEntrypoint(CommonCommands.SleepInfinity)
             .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(FailingWaitStrategy.Instance, o => o.WithTimeout(TimeSpan.FromSeconds(1))))
             .Build()
-            .StartAsync());
+            .StartAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -21,7 +21,7 @@ public sealed class WaitStrategyTest
             .WithEntrypoint(CommonCommands.SleepInfinity)
             .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(FailingWaitStrategy.Instance, o => o.WithRetries(1)))
             .Build()
-            .StartAsync());
+            .StartAsync(TestContext.Current.CancellationToken));
     }
 
     private sealed class FailingWaitStrategy : IWaitUntil

--- a/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
+++ b/tests/Testcontainers.Platform.Windows.Tests/Testcontainers.Platform.Windows.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>

--- a/tests/Testcontainers.Platform.Windows.Tests/WindowsContainerTest.cs
+++ b/tests/Testcontainers.Platform.Windows.Tests/WindowsContainerTest.cs
@@ -9,14 +9,14 @@ public abstract class WindowsContainerTest : IAsyncLifetime
         _container = container;
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _container.StartAsync();
+        await _container.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _container.DisposeAsync().AsTask();
+        return _container.DisposeAsync();
     }
 
     [SkipOnLinuxEngine]

--- a/tests/Testcontainers.Platform.Windows.Tests/WindowsContainerTest.cs
+++ b/tests/Testcontainers.Platform.Windows.Tests/WindowsContainerTest.cs
@@ -11,7 +11,8 @@ public abstract class WindowsContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _container.StartAsync();
+        await _container.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
+++ b/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
@@ -25,7 +25,7 @@ public abstract class PostgreSqlContainerTest(PostgreSqlContainerTest.PostgreSql
         const string scriptContent = "SELECT 1;";
 
         // When
-        var execResult = await fixture.Container.ExecScriptAsync(scriptContent)
+        var execResult = await fixture.Container.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
+++ b/tests/Testcontainers.PostgreSql.Tests/Testcontainers.PostgreSql.Tests.csproj
@@ -3,19 +3,20 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Npgsql"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.PostgreSql/Testcontainers.PostgreSql.csproj"/>
-        <ProjectReference Include="../../src/Testcontainers.Xunit/Testcontainers.Xunit.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.XunitV3/Testcontainers.XunitV3.csproj"/>
         <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.PostgreSql.Tests/Usings.cs
+++ b/tests/Testcontainers.PostgreSql.Tests/Usings.cs
@@ -9,4 +9,4 @@ global using JetBrains.Annotations;
 global using Npgsql;
 global using Testcontainers.Xunit;
 global using Xunit;
-global using Xunit.Abstractions;
+global using Xunit.Sdk;

--- a/tests/Testcontainers.PubSub.Tests/PubSubContainerTest.cs
+++ b/tests/Testcontainers.PubSub.Tests/PubSubContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class PubSubContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _pubSubContainer.StartAsync();
+        await _pubSubContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.PubSub.Tests/PubSubContainerTest.cs
+++ b/tests/Testcontainers.PubSub.Tests/PubSubContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class PubSubContainerTest : IAsyncLifetime
 {
     private readonly PubSubContainer _pubSubContainer = new PubSubBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _pubSubContainer.StartAsync();
+        await _pubSubContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _pubSubContainer.DisposeAsync().AsTask();
+        return _pubSubContainer.DisposeAsync();
     }
 
     [Fact]
@@ -43,13 +43,13 @@ public sealed class PubSubContainerTest : IAsyncLifetime
         subscriberClientBuilder.ChannelCredentials = ChannelCredentials.Insecure;
 
         // When
-        var publisher = await publisherClientBuilder.BuildAsync()
+        var publisher = await publisherClientBuilder.BuildAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         _ = await publisher.CreateTopicAsync(topicName)
             .ConfigureAwait(true);
 
-        var subscriber = await subscriberClientBuilder.BuildAsync()
+        var subscriber = await subscriberClientBuilder.BuildAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         _ = await subscriber.CreateSubscriptionAsync(subscriptionName, topicName, null, 60)

--- a/tests/Testcontainers.PubSub.Tests/Testcontainers.PubSub.Tests.csproj
+++ b/tests/Testcontainers.PubSub.Tests/Testcontainers.PubSub.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Google.Cloud.PubSub.V1"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
+++ b/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
@@ -17,7 +17,8 @@ public abstract class PulsarContainerTest : IAsyncLifetime
     // # --8<-- [start:UsePulsarContainer]
     public async ValueTask InitializeAsync()
     {
-        await _pulsarContainer.StartAsync();
+        await _pulsarContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
+++ b/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
@@ -15,14 +15,14 @@ public abstract class PulsarContainerTest : IAsyncLifetime
     }
 
     // # --8<-- [start:UsePulsarContainer]
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _pulsarContainer.StartAsync();
+        await _pulsarContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _pulsarContainer.DisposeAsync().AsTask();
+        return _pulsarContainer.DisposeAsync();
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public abstract class PulsarContainerTest : IAsyncLifetime
 
         if (_authenticationEnabled)
         {
-            var authToken = await _pulsarContainer.CreateAuthenticationTokenAsync(Timeout.InfiniteTimeSpan);
+            var authToken = await _pulsarContainer.CreateAuthenticationTokenAsync(Timeout.InfiniteTimeSpan, TestContext.Current.CancellationToken);
             _ = clientBuilder.Authentication(new TokenAuthentication(authToken));
         }
 
@@ -55,13 +55,13 @@ public abstract class PulsarContainerTest : IAsyncLifetime
             .Create();
 
         // When
-        _ = await consumer.OnStateChangeTo(ConsumerState.Active, TimeSpan.FromSeconds(10))
+        _ = await consumer.OnStateChangeTo(ConsumerState.Active, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        _ = await producer.Send(helloPulsar)
+        _ = await producer.Send(helloPulsar, cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var message = await consumer.Receive()
+        var message = await consumer.Receive(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Pulsar.Tests/Testcontainers.Pulsar.Tests.csproj
+++ b/tests/Testcontainers.Pulsar.Tests/Testcontainers.Pulsar.Tests.csproj
@@ -3,13 +3,14 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="DotPulsar"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>

--- a/tests/Testcontainers.Qdrant.Tests/QdrantDefaultContainerTest.cs
+++ b/tests/Testcontainers.Qdrant.Tests/QdrantDefaultContainerTest.cs
@@ -7,7 +7,8 @@ public sealed class QdrantDefaultContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _qdrantContainer.StartAsync();
+        await _qdrantContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Qdrant.Tests/QdrantDefaultContainerTest.cs
+++ b/tests/Testcontainers.Qdrant.Tests/QdrantDefaultContainerTest.cs
@@ -5,14 +5,14 @@ public sealed class QdrantDefaultContainerTest : IAsyncLifetime
     // # --8<-- [start:UseQdrantContainer]
     private readonly QdrantContainer _qdrantContainer = new QdrantBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _qdrantContainer.StartAsync();
+        await _qdrantContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _qdrantContainer.DisposeAsync().AsTask();
+        return _qdrantContainer.DisposeAsync();
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public sealed class QdrantDefaultContainerTest : IAsyncLifetime
         using var client = new QdrantClient(new Uri(_qdrantContainer.GetGrpcConnectionString()));
 
         // When
-        var response = await client.HealthAsync()
+        var response = await client.HealthAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -40,7 +40,7 @@ public sealed class QdrantDefaultContainerTest : IAsyncLifetime
         httpClient.BaseAddress = new Uri(_qdrantContainer.GetHttpConnectionString());
 
         // When
-        using var httpResponse = await httpClient.GetAsync("/")
+        using var httpResponse = await httpClient.GetAsync("/", TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Qdrant.Tests/QdrantSecureContainerTest.cs
+++ b/tests/Testcontainers.Qdrant.Tests/QdrantSecureContainerTest.cs
@@ -22,14 +22,14 @@ public sealed class QdrantSecureContainerTest : IAsyncLifetime
         // # --8<-- [end:ConfigureQdrantContainerCertificate]
         .Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _qdrantContainer.StartAsync();
+        await _qdrantContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _qdrantContainer.DisposeAsync().AsTask();
+        return _qdrantContainer.DisposeAsync();
     }
 
     [Fact]
@@ -61,7 +61,7 @@ public sealed class QdrantSecureContainerTest : IAsyncLifetime
         // # --8<-- [end:ConfigureQdrantClientCertificate-2]
 
         // When
-        var response = await client.HealthAsync()
+        var response = await client.HealthAsync(TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
@@ -89,7 +89,7 @@ public sealed class QdrantSecureContainerTest : IAsyncLifetime
         using var client = new QdrantClient(grpcClient);
 
         // When
-        var exception = await Assert.ThrowsAsync<RpcException>(() => client.HealthAsync())
+        var exception = await Assert.ThrowsAsync<RpcException>(() => client.HealthAsync(TestContext.Current.CancellationToken))
             .ConfigureAwait(true);
 
         // Then
@@ -107,7 +107,7 @@ public sealed class QdrantSecureContainerTest : IAsyncLifetime
         httpClient.DefaultRequestHeaders.Add("api-key", ApiKey);
 
         // When
-        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetAsync("/"))
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetAsync("/", TestContext.Current.CancellationToken))
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Qdrant.Tests/QdrantSecureContainerTest.cs
+++ b/tests/Testcontainers.Qdrant.Tests/QdrantSecureContainerTest.cs
@@ -24,7 +24,8 @@ public sealed class QdrantSecureContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _qdrantContainer.StartAsync();
+        await _qdrantContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Qdrant.Tests/Testcontainers.Qdrant.Tests.csproj
+++ b/tests/Testcontainers.Qdrant.Tests/Testcontainers.Qdrant.Tests.csproj
@@ -3,13 +3,14 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Qdrant.Client"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>

--- a/tests/Testcontainers.RabbitMq.Tests/RabbitMqContainerTest.cs
+++ b/tests/Testcontainers.RabbitMq.Tests/RabbitMqContainerTest.cs
@@ -5,14 +5,14 @@ public sealed class RabbitMqContainerTest : IAsyncLifetime
     // # --8<-- [start:UseRabbitMqContainer]
     private readonly RabbitMqContainer _rabbitMqContainer = new RabbitMqBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _rabbitMqContainer.StartAsync();
+        await _rabbitMqContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _rabbitMqContainer.DisposeAsync().AsTask();
+        return _rabbitMqContainer.DisposeAsync();
     }
 
     [Fact]

--- a/tests/Testcontainers.RabbitMq.Tests/RabbitMqContainerTest.cs
+++ b/tests/Testcontainers.RabbitMq.Tests/RabbitMqContainerTest.cs
@@ -7,7 +7,8 @@ public sealed class RabbitMqContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _rabbitMqContainer.StartAsync();
+        await _rabbitMqContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
+++ b/tests/Testcontainers.RabbitMq.Tests/Testcontainers.RabbitMq.Tests.csproj
@@ -3,13 +3,14 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="RabbitMQ.Client"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>

--- a/tests/Testcontainers.RavenDb.Tests/RavenDbContainerTest.cs
+++ b/tests/Testcontainers.RavenDb.Tests/RavenDbContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class RavenDbContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _ravenDbContainer.StartAsync();
+        await _ravenDbContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.RavenDb.Tests/RavenDbContainerTest.cs
+++ b/tests/Testcontainers.RavenDb.Tests/RavenDbContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class RavenDbContainerTest : IAsyncLifetime
 {
     private readonly RavenDbContainer _ravenDbContainer = new RavenDbBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _ravenDbContainer.StartAsync();
+        await _ravenDbContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _ravenDbContainer.DisposeAsync().AsTask();
+        return _ravenDbContainer.DisposeAsync();
     }
 
     [Fact]

--- a/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
+++ b/tests/Testcontainers.RavenDb.Tests/Testcontainers.RavenDb.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="RavenDB.Client"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Redis.Tests/RedisContainerTest.cs
+++ b/tests/Testcontainers.Redis.Tests/RedisContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class RedisContainerTest : IAsyncLifetime
 {
     private readonly RedisContainer _redisContainer = new RedisBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _redisContainer.StartAsync();
+        await _redisContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _redisContainer.DisposeAsync().AsTask();
+        return _redisContainer.DisposeAsync();
     }
 
     [Fact]
@@ -30,7 +30,7 @@ public sealed class RedisContainerTest : IAsyncLifetime
         const string scriptContent = "return 'Hello, scripting!'";
 
         // When
-        var execResult = await _redisContainer.ExecScriptAsync(scriptContent)
+        var execResult = await _redisContainer.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Redis.Tests/RedisContainerTest.cs
+++ b/tests/Testcontainers.Redis.Tests/RedisContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class RedisContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _redisContainer.StartAsync();
+        await _redisContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
+++ b/tests/Testcontainers.Redis.Tests/Testcontainers.Redis.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="StackExchange.Redis"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.Redpanda.Tests/RedpandaContainerTest.cs
+++ b/tests/Testcontainers.Redpanda.Tests/RedpandaContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class RedpandaContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _redpandaContainer.StartAsync();
+        await _redpandaContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Redpanda.Tests/RedpandaContainerTest.cs
+++ b/tests/Testcontainers.Redpanda.Tests/RedpandaContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class RedpandaContainerTest : IAsyncLifetime
 {
     private readonly RedpandaContainer _redpandaContainer = new RedpandaBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _redpandaContainer.StartAsync();
+        await _redpandaContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _redpandaContainer.DisposeAsync().AsTask();
+        return _redpandaContainer.DisposeAsync();
     }
 
     [Fact]
@@ -36,7 +36,7 @@ public sealed class RedpandaContainerTest : IAsyncLifetime
 
         // When
         using var producer = new ProducerBuilder<string, string>(producerConfig).Build();
-        _ = await producer.ProduceAsync(topic, message)
+        _ = await producer.ProduceAsync(topic, message, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         using var consumer = new ConsumerBuilder<string, string>(consumerConfig).Build();

--- a/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
+++ b/tests/Testcontainers.Redpanda.Tests/Testcontainers.Redpanda.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Confluent.Kafka"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.ResourceReaper.Tests/DefaultResourceReaperTest.cs
+++ b/tests/Testcontainers.ResourceReaper.Tests/DefaultResourceReaperTest.cs
@@ -9,7 +9,7 @@ namespace DotNet.Testcontainers.ResourceReaper.Tests
 
   public sealed class DefaultResourceReaperTest : IAsyncLifetime
   {
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
       var resourceReaper = await ResourceReaper.GetAndStartDefaultAsync(TestcontainersSettings.OS.DockerEndpointAuthConfig, ConsoleLogger.Instance)
         .ConfigureAwait(false);
@@ -18,9 +18,9 @@ namespace DotNet.Testcontainers.ResourceReaper.Tests
         .ConfigureAwait(false);
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-      return Task.CompletedTask;
+      return ValueTask.CompletedTask;
     }
 
     [Theory]
@@ -38,10 +38,10 @@ namespace DotNet.Testcontainers.ResourceReaper.Tests
         .Build();
 
       // When
-      await container.StartAsync()
+      await container.StartAsync(TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
-      await container.StopAsync()
+      await container.StopAsync(TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // Then

--- a/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
+++ b/tests/Testcontainers.ResourceReaper.Tests/Testcontainers.ResourceReaper.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
+    <OutputType>Exe</OutputType>
     <Configurations>Debug;Release</Configurations>
     <RootNamespace>DotNet.Testcontainers.ResourceReaper.Tests</RootNamespace>
   </PropertyGroup>
@@ -10,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="coverlet.collector"/>
     <PackageReference Include="xunit.runner.visualstudio"/>
-    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.v3"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusContainerTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusContainerTest.cs
@@ -14,7 +14,8 @@ public abstract class ServiceBusContainerTest : IAsyncLifetime
     // # --8<-- [start:UseServiceBusContainer]
     public async ValueTask InitializeAsync()
     {
-        await _serviceBusContainer.StartAsync();
+        await _serviceBusContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusContainerTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusContainerTest.cs
@@ -12,14 +12,14 @@ public abstract class ServiceBusContainerTest : IAsyncLifetime
     protected virtual string QueueName => "queue.1";
 
     // # --8<-- [start:UseServiceBusContainer]
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _serviceBusContainer.StartAsync();
+        await _serviceBusContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _serviceBusContainer.DisposeAsync().AsTask();
+        return _serviceBusContainer.DisposeAsync();
     }
 
     [Fact]
@@ -45,10 +45,10 @@ public abstract class ServiceBusContainerTest : IAsyncLifetime
         var receiver = client.CreateReceiver(QueueName);
 
         // When
-        await sender.SendMessageAsync(message)
+        await sender.SendMessageAsync(message, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var receivedMessage = await receiver.ReceiveMessageAsync()
+        var receivedMessage = await receiver.ReceiveMessageAsync(cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.ServiceBus.Tests/Testcontainers.ServiceBus.Tests.csproj
+++ b/tests/Testcontainers.ServiceBus.Tests/Testcontainers.ServiceBus.Tests.csproj
@@ -3,13 +3,14 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Azure.Messaging.ServiceBus"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>

--- a/tests/Testcontainers.Sftp.Tests/SftpContainerTest.cs
+++ b/tests/Testcontainers.Sftp.Tests/SftpContainerTest.cs
@@ -6,7 +6,8 @@ public sealed class SftpContainerTest : IAsyncLifetime
 
     public async ValueTask InitializeAsync()
     {
-        await _sftpContainer.StartAsync();
+        await _sftpContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Sftp.Tests/SftpContainerTest.cs
+++ b/tests/Testcontainers.Sftp.Tests/SftpContainerTest.cs
@@ -4,14 +4,14 @@ public sealed class SftpContainerTest : IAsyncLifetime
 {
     private readonly SftpContainer _sftpContainer = new SftpBuilder().Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return _sftpContainer.StartAsync();
+        await _sftpContainer.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        return _sftpContainer.DisposeAsync().AsTask();
+        return _sftpContainer.DisposeAsync();
     }
 
     [Fact]

--- a/tests/Testcontainers.Sftp.Tests/Testcontainers.Sftp.Tests.csproj
+++ b/tests/Testcontainers.Sftp.Tests/Testcontainers.Sftp.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.Sftp/Testcontainers.Sftp.csproj"/>

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/AlpineFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/AlpineFixture.cs
@@ -18,14 +18,14 @@ namespace DotNet.Testcontainers.Tests.Fixtures
         .WithStartupCallback((_, ct) => Task.Delay(TimeSpan.FromMinutes(1), ct))
         .Build();
 
-    public Task InitializeAsync()
+    public ValueTask InitializeAsync()
     {
-      return Task.CompletedTask;
+      return ValueTask.CompletedTask;
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-      return Container.DisposeAsync().AsTask();
+      return Container.DisposeAsync();
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/NetworkFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/NetworkFixture.cs
@@ -17,14 +17,14 @@ namespace DotNet.Testcontainers.Tests.Fixtures
         .WithName(Guid.NewGuid().ToString("D"))
         .Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-      return Network.CreateAsync();
+      await Network.CreateAsync();
     }
 
-    public Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-      return Network.DeleteAsync();
+      await Network.DeleteAsync();
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/NetworkFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/NetworkFixture.cs
@@ -19,12 +19,14 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
     public async ValueTask InitializeAsync()
     {
-      await Network.CreateAsync();
+      await Network.CreateAsync()
+        .ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()
     {
-      await Network.DeleteAsync();
+      await Network.DeleteAsync()
+        .ConfigureAwait(false);
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
@@ -67,7 +67,9 @@ namespace DotNet.Testcontainers.Tests.Fixtures
     public async ValueTask InitializeAsync()
     {
       _ = Directory.CreateDirectory(_hostCertsDirectoryPath);
-      await _container.StartAsync();
+
+      await _container.StartAsync()
+        .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
@@ -64,15 +64,15 @@ namespace DotNet.Testcontainers.Tests.Fixtures
       }
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
       _ = Directory.CreateDirectory(_hostCertsDirectoryPath);
-      return _container.StartAsync();
+      await _container.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-      return _container.DisposeAsync().AsTask();
+      return _container.DisposeAsync();
     }
 
     private sealed class UntilListenOn : IWaitUntil

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/VolumeFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/VolumeFixture.cs
@@ -15,14 +15,14 @@ namespace DotNet.Testcontainers.Tests.Fixtures
         .WithName(Guid.NewGuid().ToString("D"))
         .Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-      return Volume.CreateAsync();
+      await Volume.CreateAsync();
     }
 
-    public Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-      return Volume.DeleteAsync();
+      await Volume.DeleteAsync();
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/VolumeFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/VolumeFixture.cs
@@ -17,12 +17,14 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
     public async ValueTask InitializeAsync()
     {
-      await Volume.CreateAsync();
+      await Volume.CreateAsync()
+        .ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()
     {
-      await Volume.DeleteAsync();
+      await Volume.DeleteAsync()
+        .ConfigureAwait(false);
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixtureSerializable.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixtureSerializable.cs
@@ -1,7 +1,7 @@
 namespace DotNet.Testcontainers.Tests.Fixtures
 {
   using DotNet.Testcontainers.Images;
-  using Xunit.Abstractions;
+  using Xunit.Sdk;
 
   public sealed class DockerImageFixtureSerializable : IXunitSerializable
   {

--- a/tests/Testcontainers.Tests/Fixtures/Images/HealthCheckFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/HealthCheckFixture.cs
@@ -45,14 +45,14 @@ namespace DotNet.Testcontainers.Tests.Fixtures
       return _image.MatchVersion(predicate);
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-      return _image.CreateAsync();
+      await _image.CreateAsync();
     }
 
-    public Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-      return _image.DeleteAsync();
+      await _image.DeleteAsync();
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Images/HealthCheckFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/HealthCheckFixture.cs
@@ -47,12 +47,14 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
     public async ValueTask InitializeAsync()
     {
-      await _image.CreateAsync();
+      await _image.CreateAsync()
+        .ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()
     {
-      await _image.DeleteAsync();
+      await _image.DeleteAsync()
+        .ConfigureAwait(false);
     }
   }
 }

--- a/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
+++ b/tests/Testcontainers.Tests/Testcontainers.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
+    <OutputType>Exe</OutputType>
     <Configurations>Debug;Release</Configurations>
     <RootNamespace>DotNet.Testcontainers.Tests</RootNamespace>
   </PropertyGroup>
@@ -14,7 +15,7 @@
     <PackageReference Include="BouncyCastle.Cryptography"/>
     <PackageReference Include="coverlet.collector"/>
     <PackageReference Include="xunit.runner.visualstudio"/>
-    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.v3"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>

--- a/tests/Testcontainers.Tests/Unit/Configurations/ResourcePropertiesTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/ResourcePropertiesTest.cs
@@ -19,28 +19,28 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public async Task QueryNotExistingDockerContainerById()
     {
-      Assert.False(await Client.Container.ExistsWithIdAsync(ResourceIdOrName)
+      Assert.False(await Client.Container.ExistsWithIdAsync(ResourceIdOrName, TestContext.Current.CancellationToken)
         .ConfigureAwait(true));
     }
 
     [Fact]
     public async Task QueryNotExistingDockerImageById()
     {
-      Assert.False(await Client.Image.ExistsWithIdAsync(ResourceIdOrName)
+      Assert.False(await Client.Image.ExistsWithIdAsync(ResourceIdOrName, TestContext.Current.CancellationToken)
         .ConfigureAwait(true));
     }
 
     [Fact]
     public async Task QueryNotExistingDockerNetworkById()
     {
-      Assert.False(await Client.Network.ExistsWithIdAsync(ResourceIdOrName)
+      Assert.False(await Client.Network.ExistsWithIdAsync(ResourceIdOrName, TestContext.Current.CancellationToken)
         .ConfigureAwait(true));
     }
 
     [Fact]
     public async Task QueryNotExistingDockerVolumeById()
     {
-      Assert.False(await Client.Volume.ExistsWithIdAsync(ResourceIdOrName)
+      Assert.False(await Client.Volume.ExistsWithIdAsync(ResourceIdOrName, TestContext.Current.CancellationToken)
         .ConfigureAwait(true));
     }
 
@@ -53,7 +53,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         .Build();
 
       // When
-      await container.StartAsync()
+      await container.StartAsync(TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // Then

--- a/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersWaitStrategyTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/TestcontainersWaitStrategyTest.cs
@@ -13,7 +13,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       [Fact]
       public async Task ImmediatelyUntil()
       {
-        var exception = await Record.ExceptionAsync(() => WaitStrategy.WaitUntilAsync(() => UntilAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100)))
+        var exception = await Record.ExceptionAsync(() => WaitStrategy.WaitUntilAsync(() => UntilAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100), ct: TestContext.Current.CancellationToken))
           .ConfigureAwait(true);
 
         Assert.Null(exception);
@@ -22,7 +22,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       [Fact]
       public async Task ImmediatelyWhile()
       {
-        var exception = await Record.ExceptionAsync(() => WaitStrategy.WaitWhileAsync(() => WhileAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100)))
+        var exception = await Record.ExceptionAsync(() => WaitStrategy.WaitWhileAsync(() => WhileAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100), ct: TestContext.Current.CancellationToken))
           .ConfigureAwait(true);
 
         Assert.Null(exception);
@@ -44,13 +44,13 @@ namespace DotNet.Testcontainers.Tests.Unit
       [Fact]
       public Task After100MsUntil()
       {
-        return Assert.ThrowsAsync<TimeoutException>(() => WaitStrategy.WaitUntilAsync(() => UntilAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100)));
+        return Assert.ThrowsAsync<TimeoutException>(() => WaitStrategy.WaitUntilAsync(() => UntilAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100), ct: TestContext.Current.CancellationToken));
       }
 
       [Fact]
       public Task After100MsWhile()
       {
-        return Assert.ThrowsAsync<TimeoutException>(() => WaitStrategy.WaitWhileAsync(() => WhileAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100)));
+        return Assert.ThrowsAsync<TimeoutException>(() => WaitStrategy.WaitWhileAsync(() => WhileAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100), ct: TestContext.Current.CancellationToken));
       }
 
       public Task<bool> UntilAsync(IContainer container)
@@ -69,13 +69,13 @@ namespace DotNet.Testcontainers.Tests.Unit
       [Fact]
       public Task RethrowUntil()
       {
-        return Assert.ThrowsAsync<NotImplementedException>(() => WaitStrategy.WaitUntilAsync(() => UntilAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100)));
+        return Assert.ThrowsAsync<NotImplementedException>(() => WaitStrategy.WaitUntilAsync(() => UntilAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100), ct: TestContext.Current.CancellationToken));
       }
 
       [Fact]
       public Task RethrowWhile()
       {
-        return Assert.ThrowsAsync<NotImplementedException>(() => WaitStrategy.WaitWhileAsync(() => WhileAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100)));
+        return Assert.ThrowsAsync<NotImplementedException>(() => WaitStrategy.WaitWhileAsync(() => WhileAsync(null), TimeSpan.FromMilliseconds(25), TimeSpan.FromMilliseconds(100), ct: TestContext.Current.CancellationToken));
       }
 
       public Task<bool> UntilAsync(IContainer container)

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilContainerIsHealthyTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilContainerIsHealthyTest.cs
@@ -27,7 +27,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         .Build();
 
       // When
-      await container.StartAsync()
+      await container.StartAsync(TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // Then
@@ -45,7 +45,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         .Build();
 
       // When
-      _ = await Record.ExceptionAsync(() => container.StartAsync())
+      _ = await Record.ExceptionAsync(() => container.StartAsync(TestContext.Current.CancellationToken))
         .ConfigureAwait(true);
 
       // Then

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilFileExistsInContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilFileExistsInContainerTest.cs
@@ -23,14 +23,14 @@ namespace DotNet.Testcontainers.Tests.Unit
       .WithWaitStrategy(Wait.ForUnixContainer().UntilFileExists(ContainerFilePath, FileSystem.Container))
       .Build();
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-      return _container.StartAsync(_cts.Token);
+      await _container.StartAsync(_cts.Token);
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-      return _container.DisposeAsync().AsTask();
+      return _container.DisposeAsync();
     }
 
     public void Dispose()
@@ -41,7 +41,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public async Task ContainerIsRunning()
     {
-      var execResult = await _container.ExecAsync(new List<string> { "test", "-f", ContainerFilePath })
+      var execResult = await _container.ExecAsync(new List<string> { "test", "-f", ContainerFilePath }, TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       Assert.Equal(0, execResult.ExitCode);

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilFileExistsInContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilFileExistsInContainerTest.cs
@@ -25,7 +25,8 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     public async ValueTask InitializeAsync()
     {
-      await _container.StartAsync(_cts.Token);
+      await _container.StartAsync(_cts.Token)
+        .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
@@ -39,7 +39,8 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     public async ValueTask InitializeAsync()
     {
-      await _container.StartAsync();
+      await _container.StartAsync()
+        .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
@@ -37,14 +37,14 @@ namespace DotNet.Testcontainers.Tests.Unit
       return theoryData;
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-      return _container.StartAsync();
+      await _container.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-      return _container.DisposeAsync().AsTask();
+      return _container.DisposeAsync();
     }
 
     [Theory]
@@ -73,10 +73,10 @@ namespace DotNet.Testcontainers.Tests.Unit
       var succeeded = await httpWaitStrategy.UntilAsync(_container)
         .ConfigureAwait(true);
 
-      await Task.Delay(TimeSpan.FromSeconds(1))
+      await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
-      var (_, stderr) = await _container.GetLogsAsync()
+      var (_, stderr) = await _container.GetLogsAsync(ct: TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // Then
@@ -103,10 +103,10 @@ namespace DotNet.Testcontainers.Tests.Unit
       var succeeded = await httpWaitStrategy.UntilAsync(_container)
         .ConfigureAwait(true);
 
-      await Task.Delay(TimeSpan.FromSeconds(1))
+      await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
-      var (_, stderr) = await _container.GetLogsAsync()
+      var (_, stderr) = await _container.GetLogsAsync(ct: TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // Then

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilMessageIsLoggedTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilMessageIsLoggedTest.cs
@@ -26,7 +26,8 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     public async ValueTask InitializeAsync()
     {
-      await _container.StartAsync(_cts.Token);
+      await _container.StartAsync(_cts.Token)
+        .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilMessageIsLoggedTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilMessageIsLoggedTest.cs
@@ -24,14 +24,14 @@ namespace DotNet.Testcontainers.Tests.Unit
         .Build();
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-      return _container.StartAsync(_cts.Token);
+      await _container.StartAsync(_cts.Token);
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-      return _container.StartAsync();
+      return _container.DisposeAsync();
     }
 
     public void Dispose()

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/GetContainerLogsTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/GetContainerLogsTest.cs
@@ -45,7 +45,8 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     public async ValueTask InitializeAsync()
     {
-      await _container.StartAsync();
+      await _container.StartAsync()
+        .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/GetContainerLogsTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/GetContainerLogsTest.cs
@@ -17,7 +17,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public async Task GetLogsShouldNotBeEmpty()
     {
-      var (stdout, _) = await _container.GetLogsAsync()
+      var (stdout, _) = await _container.GetLogsAsync(ct: TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       Assert.NotEmpty(stdout);
@@ -26,7 +26,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public async Task GetLogsShouldBeEmptyWhenSinceIsOutOfDateRage()
     {
-      var (stdout, stderr) = await _container.GetLogsAsync(since: DateTime.Now.AddDays(1))
+      var (stdout, stderr) = await _container.GetLogsAsync(since: DateTime.Now.AddDays(1), ct: TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       Assert.Empty(stdout);
@@ -36,21 +36,21 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public async Task GetLogsShouldBeEmptyWhenUntilIsOutOfDateRage()
     {
-      var (stdout, stderr) = await _container.GetLogsAsync(until: DateTime.Now.AddDays(-1))
+      var (stdout, stderr) = await _container.GetLogsAsync(until: DateTime.Now.AddDays(-1), ct: TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       Assert.Empty(stdout);
       Assert.Empty(stderr);
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-      return _container.StartAsync();
+      await _container.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-      return _container.DisposeAsync().AsTask();
+      return _container.DisposeAsync();
     }
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/ProtectDockerDaemonSocketTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/ProtectDockerDaemonSocketTest.cs
@@ -39,7 +39,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         var client = new TestcontainersClient(Guid.Empty, _authConfig, NullLogger.Instance);
 
         // When
-        var version = await client.System.GetVersionAsync()
+        var version = await client.System.GetVersionAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -67,7 +67,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         var client = new TestcontainersClient(Guid.Empty, _authConfig, NullLogger.Instance);
 
         // When
-        var version = await client.System.GetVersionAsync()
+        var version = await client.System.GetVersionAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -95,7 +95,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         var client = new TestcontainersClient(Guid.Empty, _authConfig, NullLogger.Instance);
 
         // When
-        var version = await client.System.GetVersionAsync()
+        var version = await client.System.GetVersionAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/ReadFileFromContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/ReadFileFromContainerTest.cs
@@ -49,7 +49,8 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     public async ValueTask InitializeAsync()
     {
-      await _container.StartAsync();
+      await _container.StartAsync()
+          .ConfigureAwait(false);
     }
 
     public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/ReadFileFromContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/ReadFileFromContainerTest.cs
@@ -25,10 +25,10 @@ namespace DotNet.Testcontainers.Tests.Unit
       var dayOfWeek = DateTime.UtcNow.DayOfWeek.ToString();
 
       // When
-      _ = await _container.ExecAsync(new[] { "/bin/sh", "-c", $"echo {dayOfWeek} > {dayOfWeekFilePath}" })
+      _ = await _container.ExecAsync(new[] { "/bin/sh", "-c", $"echo {dayOfWeek} > {dayOfWeekFilePath}" }, TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
-      var fileContent = await _container.ReadFileAsync(dayOfWeekFilePath)
+      var fileContent = await _container.ReadFileAsync(dayOfWeekFilePath, TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // Then
@@ -38,23 +38,23 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public Task AccessNotExistingFileThrowsFileNotFoundException()
     {
-      return Assert.ThrowsAsync<FileNotFoundException>(() => _container.ReadFileAsync("/tmp/fileNotFound"));
+      return Assert.ThrowsAsync<FileNotFoundException>(() => _container.ReadFileAsync("/tmp/fileNotFound", TestContext.Current.CancellationToken));
     }
 
     [Fact]
     public Task AccessDirectoryThrowsInvalidOperationException()
     {
-      return Assert.ThrowsAsync<InvalidOperationException>(() => _container.ReadFileAsync("/tmp"));
+      return Assert.ThrowsAsync<InvalidOperationException>(() => _container.ReadFileAsync("/tmp", TestContext.Current.CancellationToken));
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-      return _container.StartAsync();
+      await _container.StartAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-      return _container.DisposeAsync().AsTask();
+      return _container.DisposeAsync();
     }
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -34,7 +34,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -54,7 +54,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -74,10 +74,10 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
-        var exitCode = await container.GetExitCodeAsync()
+        var exitCode = await container.GetExitCodeAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -97,7 +97,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -115,10 +115,10 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
-        var exitCode = await container.GetExitCodeAsync()
+        var exitCode = await container.GetExitCodeAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -135,10 +135,10 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
-        var exitCode = await container.GetExitCodeAsync()
+        var exitCode = await container.GetExitCodeAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -163,7 +163,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -185,7 +185,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -206,7 +206,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -224,7 +224,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -248,7 +248,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -277,7 +277,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -296,7 +296,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        var exception = await Record.ExceptionAsync(() => container.StartAsync())
+        var exception = await Record.ExceptionAsync(() => container.StartAsync(TestContext.Current.CancellationToken))
           .ConfigureAwait(true);
 
         // Then
@@ -339,18 +339,18 @@ namespace DotNet.Testcontainers.Tests.Unit
           .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(unixTimeInMilliseconds))
           .Build();
 
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         consumer.Stdout.Seek(0, SeekOrigin.Begin);
         consumer.Stderr.Seek(0, SeekOrigin.Begin);
 
         using var stdoutReader = new StreamReader(consumer.Stdout, leaveOpen: true);
-        var stdout = await stdoutReader.ReadToEndAsync()
+        var stdout = await stdoutReader.ReadToEndAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         using var stderrReader = new StreamReader(consumer.Stderr, leaveOpen: true);
-        var stderr = await stderrReader.ReadToEndAsync()
+        var stderr = await stderrReader.ReadToEndAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -369,7 +369,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        var exception = await Record.ExceptionAsync(() => container.StartAsync())
+        var exception = await Record.ExceptionAsync(() => container.StartAsync(TestContext.Current.CancellationToken))
           .ConfigureAwait(true);
 
         // Then
@@ -386,10 +386,10 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
-        var execResult = await container.ExecAsync(new[] { "/bin/sh", "-c", "exit 255" })
+        var execResult = await container.ExecAsync(new[] { "/bin/sh", "-c", "exit 255" }, TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -406,10 +406,10 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
-        var execResult = await container.ExecAsync(new[] { "ping", "-c", "1", "google.com" })
+        var execResult = await container.ExecAsync(new[] { "ping", "-c", "1", "google.com" }, TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -426,10 +426,10 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
-        var execResult = await container.ExecAsync(new[] { "ping", "-c", "1", "google.invalid" })
+        var execResult = await container.ExecAsync(new[] { "ping", "-c", "1", "google.invalid" }, TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -450,13 +450,13 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
-        await container.CopyAsync(Encoding.Default.GetBytes(dayOfWeek), dayOfWeekFilePath)
+        await container.CopyAsync(Encoding.Default.GetBytes(dayOfWeek), dayOfWeekFilePath, ct: TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
-        var execResult = await container.ExecAsync(new[] { "test", "-f", dayOfWeekFilePath })
+        var execResult = await container.ExecAsync(new[] { "test", "-f", dayOfWeekFilePath }, TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -475,12 +475,12 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         var id = container.Id;
 
-        await Task.Delay(TimeSpan.FromSeconds(1))
+        await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -499,15 +499,15 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         var id = container.Id;
 
-        await container.StopAsync()
+        await container.StopAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
-        await Task.Delay(TimeSpan.FromSeconds(1))
+        await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -528,7 +528,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        await container.StartAsync()
+        await container.StartAsync(TestContext.Current.CancellationToken)
           .ConfigureAwait(true);
 
         // Then
@@ -545,7 +545,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .Build();
 
         // When
-        var exception = await Record.ExceptionAsync(() => container.StartAsync())
+        var exception = await Record.ExceptionAsync(() => container.StartAsync(TestContext.Current.CancellationToken))
           .ConfigureAwait(true);
 
         // Then
@@ -561,7 +561,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .WithImagePullPolicy(PullPolicy.Never)
           .Build();
 
-        await Assert.ThrowsAnyAsync<Exception>(() => container.StartAsync())
+        await Assert.ThrowsAnyAsync<Exception>(() => container.StartAsync(TestContext.Current.CancellationToken))
           .ConfigureAwait(true);
       }
     }

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -46,7 +46,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       var dockerfileArchive = new DockerfileArchive("Assets/", "Dockerfile", image, NullLogger.Instance);
 
-      var dockerfileArchiveFilePath = await dockerfileArchive.Tar()
+      var dockerfileArchiveFilePath = await dockerfileArchive.Tar(TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // When
@@ -75,7 +75,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         .Build();
 
       // When
-      var exception = await Assert.ThrowsAsync<ArgumentException>(() => imageFromDockerfileBuilder.CreateAsync())
+      var exception = await Assert.ThrowsAsync<ArgumentException>(() => imageFromDockerfileBuilder.CreateAsync(TestContext.Current.CancellationToken))
         .ConfigureAwait(true);
 
       // Then
@@ -93,7 +93,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         .Build();
 
       // When
-      var exception = await Assert.ThrowsAsync<ArgumentException>(() => imageFromDockerfileBuilder.CreateAsync())
+      var exception = await Assert.ThrowsAsync<ArgumentException>(() => imageFromDockerfileBuilder.CreateAsync(TestContext.Current.CancellationToken))
         .ConfigureAwait(true);
 
       // Then
@@ -109,7 +109,7 @@ namespace DotNet.Testcontainers.Tests.Unit
         .Build();
 
       // When
-      var exception = await Record.ExceptionAsync(() => imageFromDockerfileBuilder.CreateAsync())
+      var exception = await Record.ExceptionAsync(() => imageFromDockerfileBuilder.CreateAsync(TestContext.Current.CancellationToken))
         .ConfigureAwait(true);
 
       // Then
@@ -140,10 +140,10 @@ namespace DotNet.Testcontainers.Tests.Unit
         .Build();
 
       // When
-      await imageFromDockerfileBuilder.CreateAsync()
+      await imageFromDockerfileBuilder.CreateAsync(TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
-      await imageFromDockerfileBuilder.CreateAsync()
+      await imageFromDockerfileBuilder.CreateAsync(TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // Then

--- a/tests/Testcontainers.Tests/Unit/Networks/TestcontainerNetworkBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Networks/TestcontainerNetworkBuilderTest.cs
@@ -52,7 +52,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var client = new TestcontainersClient(ResourceReaper.DefaultSessionId, TestcontainersSettings.OS.DockerEndpointAuthConfig, NullLogger.Instance);
 
       // When
-      var networkResponse = await client.Network.ByIdAsync(_network.Name)
+      var networkResponse = await client.Network.ByIdAsync(_network.Name, TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // Then
@@ -66,7 +66,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var client = new TestcontainersClient(ResourceReaper.DefaultSessionId, TestcontainersSettings.OS.DockerEndpointAuthConfig, NullLogger.Instance);
 
       // When
-      var networkResponse = await client.Network.ByIdAsync(_network.Name)
+      var networkResponse = await client.Network.ByIdAsync(_network.Name, TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // Then
@@ -86,15 +86,14 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       public string Name => _network.Name;
 
-      public Task InitializeAsync()
+      public async ValueTask InitializeAsync()
       {
-        return CreateAsync();
+        await CreateAsync();
       }
 
-      public Task DisposeAsync()
+      public ValueTask DisposeAsync()
       {
-        IAsyncDisposable asyncDisposable = this;
-        return asyncDisposable.DisposeAsync().AsTask();
+        return _network.DisposeAsync();
       }
 
       public Task CreateAsync(CancellationToken ct = default)
@@ -105,11 +104,6 @@ namespace DotNet.Testcontainers.Tests.Unit
       public Task DeleteAsync(CancellationToken ct = default)
       {
         return _network.DeleteAsync(ct);
-      }
-
-      ValueTask IAsyncDisposable.DisposeAsync()
-      {
-        return _network.DisposeAsync();
       }
     }
   }

--- a/tests/Testcontainers.Tests/Unit/Networks/TestcontainerNetworkBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Networks/TestcontainerNetworkBuilderTest.cs
@@ -88,7 +88,8 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       public async ValueTask InitializeAsync()
       {
-        await CreateAsync();
+        await CreateAsync()
+          .ConfigureAwait(false);
       }
 
       public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Tests/Unit/Networks/TestcontainersNetworkTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Networks/TestcontainersNetworkTest.cs
@@ -31,14 +31,14 @@ namespace DotNet.Testcontainers.Tests.Unit
         .Build();
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-      return Task.WhenAll(_container1.StartAsync(), _container2.StartAsync());
+      await Task.WhenAll(_container1.StartAsync(), _container2.StartAsync());
     }
 
-    public Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-      return Task.WhenAll(_container1.DisposeAsync().AsTask(), _container2.DisposeAsync().AsTask());
+      await Task.WhenAll(_container1.DisposeAsync().AsTask(), _container2.DisposeAsync().AsTask());
     }
 
     [Fact]
@@ -48,7 +48,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       const string destination = nameof(_container2) + AliasSuffix;
 
       // When
-      var execResult = await _container1.ExecAsync(new[] { "ping", "-c", "1", destination })
+      var execResult = await _container1.ExecAsync(new[] { "ping", "-c", "1", destination }, TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // Then

--- a/tests/Testcontainers.Tests/Unit/Networks/TestcontainersNetworkTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Networks/TestcontainersNetworkTest.cs
@@ -33,12 +33,14 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     public async ValueTask InitializeAsync()
     {
-      await Task.WhenAll(_container1.StartAsync(), _container2.StartAsync());
+      await Task.WhenAll(_container1.StartAsync(), _container2.StartAsync())
+        .ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()
     {
-      await Task.WhenAll(_container1.DisposeAsync().AsTask(), _container2.DisposeAsync().AsTask());
+      await Task.WhenAll(_container1.DisposeAsync().AsTask(), _container2.DisposeAsync().AsTask())
+        .ConfigureAwait(false);
     }
 
     [Fact]

--- a/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeBuilderTest.cs
@@ -50,7 +50,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var client = new TestcontainersClient(ResourceReaper.DefaultSessionId, TestcontainersSettings.OS.DockerEndpointAuthConfig, NullLogger.Instance);
 
       // When
-      var volumeResponse = await client.Volume.ByIdAsync(_volume.Name)
+      var volumeResponse = await client.Volume.ByIdAsync(_volume.Name, TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
 
       // Then
@@ -69,15 +69,14 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       public string Name => _volume.Name;
 
-      public Task InitializeAsync()
+      public async ValueTask InitializeAsync()
       {
-        return CreateAsync();
+        await CreateAsync();
       }
 
-      public Task DisposeAsync()
+      public ValueTask DisposeAsync()
       {
-        IAsyncDisposable asyncDisposable = this;
-        return asyncDisposable.DisposeAsync().AsTask();
+        return _volume.DisposeAsync();
       }
 
       public Task CreateAsync(CancellationToken ct = default)
@@ -88,11 +87,6 @@ namespace DotNet.Testcontainers.Tests.Unit
       public Task DeleteAsync(CancellationToken ct = default)
       {
         return _volume.DeleteAsync(ct);
-      }
-
-      ValueTask IAsyncDisposable.DisposeAsync()
-      {
-        return _volume.DisposeAsync();
       }
     }
   }

--- a/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeBuilderTest.cs
@@ -71,7 +71,8 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       public async ValueTask InitializeAsync()
       {
-        await CreateAsync();
+        await CreateAsync()
+          .ConfigureAwait(false);
       }
 
       public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeTest.cs
@@ -36,28 +36,28 @@ namespace DotNet.Testcontainers.Tests.Unit
         .Build();
     }
 
-    public Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-      return Task.WhenAll(_testcontainer1.StartAsync(), _testcontainer2.StartAsync());
+      await Task.WhenAll(_testcontainer1.StartAsync(), _testcontainer2.StartAsync());
     }
 
-    public Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
-      return Task.WhenAll(_testcontainer1.DisposeAsync().AsTask(), _testcontainer2.DisposeAsync().AsTask());
+      await Task.WhenAll(_testcontainer1.DisposeAsync().AsTask(), _testcontainer2.DisposeAsync().AsTask());
     }
 
     [Fact]
     public async Task WithVolumeMount()
     {
-      Assert.Equal(0, (await _testcontainer1.ExecAsync(new[] { "test", "-f", Path.Combine(Destination, nameof(_testcontainer2)) })).ExitCode);
-      Assert.Equal(0, (await _testcontainer2.ExecAsync(new[] { "test", "-f", Path.Combine(Destination, nameof(_testcontainer1)) })).ExitCode);
+      Assert.Equal(0, (await _testcontainer1.ExecAsync(new[] { "test", "-f", Path.Combine(Destination, nameof(_testcontainer2)) }, TestContext.Current.CancellationToken)).ExitCode);
+      Assert.Equal(0, (await _testcontainer2.ExecAsync(new[] { "test", "-f", Path.Combine(Destination, nameof(_testcontainer1)) }, TestContext.Current.CancellationToken)).ExitCode);
     }
 
     [Fact]
     public async Task WithTmpfsVolumeMount()
     {
-      Assert.Equal(0, (await _testcontainer1.ExecAsync(new[] { "test", "-d", TmpfsDestination })).ExitCode);
-      Assert.Equal(0, (await _testcontainer2.ExecAsync(new[] { "test", "-d", TmpfsDestination })).ExitCode);
+      Assert.Equal(0, (await _testcontainer1.ExecAsync(new[] { "test", "-d", TmpfsDestination }, TestContext.Current.CancellationToken)).ExitCode);
+      Assert.Equal(0, (await _testcontainer2.ExecAsync(new[] { "test", "-d", TmpfsDestination }, TestContext.Current.CancellationToken)).ExitCode);
     }
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Volumes/TestcontainersVolumeTest.cs
@@ -38,12 +38,14 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     public async ValueTask InitializeAsync()
     {
-      await Task.WhenAll(_testcontainer1.StartAsync(), _testcontainer2.StartAsync());
+      await Task.WhenAll(_testcontainer1.StartAsync(), _testcontainer2.StartAsync())
+        .ConfigureAwait(false);
     }
 
     public async ValueTask DisposeAsync()
     {
-      await Task.WhenAll(_testcontainer1.DisposeAsync().AsTask(), _testcontainer2.DisposeAsync().AsTask());
+      await Task.WhenAll(_testcontainer1.DisposeAsync().AsTask(), _testcontainer2.DisposeAsync().AsTask())
+        .ConfigureAwait(false);
     }
 
     [Fact]

--- a/tests/Testcontainers.Weaviate.Tests/Testcontainers.Weaviate.Tests.csproj
+++ b/tests/Testcontainers.Weaviate.Tests/Testcontainers.Weaviate.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="../../src/Testcontainers.Weaviate/Testcontainers.Weaviate.csproj"/>

--- a/tests/Testcontainers.Weaviate.Tests/WeaviateContainerTest.cs
+++ b/tests/Testcontainers.Weaviate.Tests/WeaviateContainerTest.cs
@@ -4,9 +4,16 @@ public sealed class WeaviateContainerTest : IAsyncLifetime
 {
     private readonly WeaviateContainer _weaviateContainer = new WeaviateBuilder().Build();
 
-    public async ValueTask InitializeAsync() => await _weaviateContainer.StartAsync();
+    public async ValueTask InitializeAsync()
+    {
+        await _weaviateContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
 
-    public ValueTask DisposeAsync() => _weaviateContainer.DisposeAsync();
+    public ValueTask DisposeAsync()
+    {
+        return _weaviateContainer.DisposeAsync();
+    }
 
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]

--- a/tests/Testcontainers.Weaviate.Tests/WeaviateContainerTest.cs
+++ b/tests/Testcontainers.Weaviate.Tests/WeaviateContainerTest.cs
@@ -4,9 +4,9 @@ public sealed class WeaviateContainerTest : IAsyncLifetime
 {
     private readonly WeaviateContainer _weaviateContainer = new WeaviateBuilder().Build();
 
-    public Task InitializeAsync() => _weaviateContainer.StartAsync();
+    public async ValueTask InitializeAsync() => await _weaviateContainer.StartAsync();
 
-    public Task DisposeAsync() => _weaviateContainer.DisposeAsync().AsTask();
+    public ValueTask DisposeAsync() => _weaviateContainer.DisposeAsync();
 
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
@@ -17,7 +17,7 @@ public sealed class WeaviateContainerTest : IAsyncLifetime
         httpClient.BaseAddress = new Uri(_weaviateContainer.GetBaseAddress());
 
         // When
-        using var httpResponse = await httpClient.GetAsync("v1/schema")
+        using var httpResponse = await httpClient.GetAsync("v1/schema", TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.WebDriver.Tests/Testcontainers.WebDriver.Tests.csproj
+++ b/tests/Testcontainers.WebDriver.Tests/Testcontainers.WebDriver.Tests.csproj
@@ -3,12 +3,13 @@
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <IsPublishable>false</IsPublishable>
+        <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.v3"/>
         <PackageReference Include="Selenium.WebDriver"/>
     </ItemGroup>
     <ItemGroup>

--- a/tests/Testcontainers.WebDriver.Tests/WebDriverContainerTest.cs
+++ b/tests/Testcontainers.WebDriver.Tests/WebDriverContainerTest.cs
@@ -22,7 +22,7 @@ public abstract class WebDriverContainerTest : IAsyncLifetime
         _webDriverContainer = webDriverContainer;
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         await _webDriverContainer.StartAsync()
             .ConfigureAwait(false);
@@ -31,7 +31,7 @@ public abstract class WebDriverContainerTest : IAsyncLifetime
             .ConfigureAwait(false);
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         await _helloWorldContainer.DisposeAsync()
             .ConfigureAwait(false);
@@ -69,10 +69,10 @@ public abstract class WebDriverContainerTest : IAsyncLifetime
             var videoFilePath = Path.Combine(TestSession.TempDirectoryPath, Path.GetRandomFileName());
 
             // When
-            await _webDriverContainer.StopAsync()
+            await _webDriverContainer.StopAsync(TestContext.Current.CancellationToken)
                 .ConfigureAwait(true);
 
-            await _webDriverContainer.ExportVideoAsync(videoFilePath)
+            await _webDriverContainer.ExportVideoAsync(videoFilePath, TestContext.Current.CancellationToken)
                 .ConfigureAwait(true);
 
             // Then
@@ -82,7 +82,7 @@ public abstract class WebDriverContainerTest : IAsyncLifetime
         [Fact]
         public Task ExportVideoThrowsInvalidOperationException()
         {
-            return Assert.ThrowsAsync<InvalidOperationException>(() => _webDriverContainer.ExportVideoAsync(string.Empty));
+            return Assert.ThrowsAsync<InvalidOperationException>(() => _webDriverContainer.ExportVideoAsync(string.Empty, TestContext.Current.CancellationToken));
         }
     }
 
@@ -97,7 +97,7 @@ public abstract class WebDriverContainerTest : IAsyncLifetime
         [Fact]
         public Task ExportVideoThrowsInvalidOperationException()
         {
-            return Assert.ThrowsAsync<InvalidOperationException>(() => _webDriverContainer.ExportVideoAsync(string.Empty));
+            return Assert.ThrowsAsync<InvalidOperationException>(() => _webDriverContainer.ExportVideoAsync(string.Empty, TestContext.Current.CancellationToken));
         }
     }
 }

--- a/tests/Testcontainers.Xunit.Tests/Usings.cs
+++ b/tests/Testcontainers.Xunit.Tests/Usings.cs
@@ -10,9 +10,9 @@ global using StackExchange.Redis;
 global using Testcontainers.PostgreSql;
 global using Testcontainers.Redis;
 global using Xunit;
+global using Xunit.Sdk;
 #if XUNIT_V3
 global using Xunit.v3;
 #else
 global using Xunit.Abstractions;
 #endif
-global using Xunit.Sdk;


### PR DESCRIPTION
## What does this PR do?

Currently all test-projects except `Testcontainers.XunitV3.Tests` use Xunit.Net v2. After this PR all test-projects except `Testcontainers.Xunit.Tests` use Xunit.Net v3

## Why is it important?

I would expect that some day in the future Xunit.Net v2 will be discontinued. Also switching to Xunit.Net v3 means, that we can use all the new features like further Asserts and better test-cancellation. See also https://xunit.net/docs/getting-started/v3/whats-new for details

While I do think, that this should be done one day, it does not necessarily need to be today. On the other hand, I did not have problems using v3 so far (in other projects), and it will probably never be easier to switch anyway.