### PR TITLE
chore: Bump Docker.DotNet version to `3.128.1`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,8 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": true
     },
-    "ghcr.io/devcontainers/features/dotnet:2.1.3": {
-      "version": "8.0",
+    "ghcr.io/devcontainers/features/dotnet:2.2.2": {
+      "version": "9.0",
       "installUsingApt": false
     }
   },

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="BouncyCastle.Cryptography" Version="2.5.1"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="3.126.1"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.126.1"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="3.128.1"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.128.1"/>
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
         <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1"/>
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3"/>
@@ -26,7 +26,7 @@
         <PackageVersion Include="xunit.extensibility.execution" Version="2.9.3"/>
         <PackageVersion Include="xunit.v3.extensibility.core" Version="1.1.0"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->
-        <PackageVersion Include="Apache.NMS.ActiveMQ" Version="2.1.0"/>
+        <PackageVersion Include="Apache.NMS.ActiveMQ" Version="2.1.1"/>
         <PackageVersion Include="ArangoDBNetStandard" Version="2.0.1"/>
         <PackageVersion Include="AWSSDK.CloudWatchLogs" Version="3.7.104.14"/>
         <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.101.42"/>

--- a/docs/test_frameworks/xunit_net.md
+++ b/docs/test_frameworks/xunit_net.md
@@ -49,7 +49,7 @@ be115f3df138   redis:7.0                   "docker-entrypoint.s…"   3 seconds 
 
 ## Creating a shared test context
 
-Sometimes, creating and disposing of a test resource can be an expensive operation that you do not want to repeat for every test. By inheriting from the `ContainerFixture<TBuilderEntity, TContainerEntity>` class, you can share the test resource instance across all tests within the same test class, or even within the assembly, if you use xUnit.net V3 or a compatible V2 extension like [the one from the examples-repo](https://github.com/xunit/samples.xunit/tree/main/v2/AssemblyFixtureExample).
+Sometimes, creating and disposing of a test resource can be an expensive operation that you do not want to repeat for every test. By inheriting from the `ContainerFixture<TBuilderEntity, TContainerEntity>` class, you can share the test resource instance across all tests within the same test class, or even within the assembly, if you use xUnit.net v3 or a compatible v2 extension like the one from the [AssemblyFixtureExample](https://github.com/xunit/samples.xunit/tree/main/v2/AssemblyFixtureExample) repository.
 
 xUnit.net's fixture implementation does not rely on the `ITestOutputHelper` interface to capture and forward log messages; instead, it expects an implementation of `IMessageSink`. Make sure your fixture's default constructor accepts the interface implementation and forwards it to the base class.
 
@@ -81,7 +81,7 @@ d29a393816ce   redis:7.0                   "docker-entrypoint.s…"   3 seconds 
 e878f0b8f4bc   testcontainers/ryuk:0.9.0   "/bin/ryuk"              3 seconds ago
 ```
 
-To use a single container-fixture across all tests of a test-assembly (using xUnit.net V3 or an extension), add the `[assembly: AssemblyFixture(typeof(TContainerFixtureEntity))]` annotation referring to your subclass to the assembly. The fixture can then be injected into test class constructors (as shown above), or accessed using the `TestContext.Current.GetFixture<TContainerFixtureEntity>()` method (v3 only) in any test.
+To use a single container fixture across all tests of a test-assembly (using xUnit.net v3 or an extension), add the `[assembly: AssemblyFixture(typeof(TContainerFixtureEntity))]` annotation referring to your subclass to the assembly. The fixture can then be injected into test class constructors (as shown above), or accessed using the `TestContext.Current.GetFixture<TContainerFixtureEntity>()` method (v3 only) in any test.
 
 ## Testing ADO.NET services
 

--- a/src/Testcontainers/Builders/TlsCredentials.cs
+++ b/src/Testcontainers/Builders/TlsCredentials.cs
@@ -16,11 +16,11 @@ namespace DotNet.Testcontainers.Builders
       return true;
     }
 
-    public override HttpMessageHandler GetHandler(HttpMessageHandler innerHandler)
+    public override HttpMessageHandler GetHandler(HttpMessageHandler handler)
     {
-      var handler = (ManagedHandler)innerHandler;
-      handler.ServerCertificateValidationCallback = ServerCertificateValidationCallback;
-      return handler;
+      var managedHandler = (ManagedHandler)handler;
+      managedHandler.ServerCertificateValidationCallback = ServerCertificateValidationCallback;
+      return managedHandler;
     }
   }
 }

--- a/src/Testcontainers/Clients/ContainerConfigurationConverter.cs
+++ b/src/Testcontainers/Clients/ContainerConfigurationConverter.cs
@@ -3,7 +3,6 @@ namespace DotNet.Testcontainers.Clients
   using System;
   using System.Collections.Generic;
   using System.Linq;
-  using System.Net;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Networks;

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -71,7 +71,7 @@ namespace DotNet.Testcontainers.Clients
         Timestamps = timestampsEnabled,
       };
 
-      using (var stdOutAndErrStream = await DockerClient.Containers.GetContainerLogsAsync(id, false, logsParameters, ct)
+      using (var stdOutAndErrStream = await DockerClient.Containers.GetContainerLogsAsync(id, logsParameters, ct)
         .ConfigureAwait(false))
       {
         return await stdOutAndErrStream.ReadOutputToEndAsync(ct)
@@ -119,7 +119,7 @@ namespace DotNet.Testcontainers.Clients
     {
       Logger.ReadArchiveFromDockerContainer(id, path);
 
-      var tarResponse = await DockerClient.Containers.GetArchiveFromContainerAsync(id, new GetArchiveFromContainerParameters { Path = path }, false, ct)
+      var tarResponse = await DockerClient.Containers.GetArchiveFromContainerAsync(id, new ContainerPathStatParameters { Path = path }, false, ct)
         .ConfigureAwait(false);
 
       return tarResponse.Stream;
@@ -141,7 +141,7 @@ namespace DotNet.Testcontainers.Clients
         Stream = true,
       };
 
-      var stream = await DockerClient.Containers.AttachContainerAsync(id, false, attachParameters, ct)
+      var stream = await DockerClient.Containers.AttachContainerAsync(id, attachParameters, ct)
         .ConfigureAwait(false);
 
       _ = stream.CopyOutputToAsync(Stream.Null, outputConsumer.Stdout, outputConsumer.Stderr, ct)
@@ -159,10 +159,10 @@ namespace DotNet.Testcontainers.Clients
         AttachStderr = true,
       };
 
-      var execCreateResponse = await DockerClient.Exec.ExecCreateContainerAsync(id, execCreateParameters, ct)
+      var execCreateResponse = await DockerClient.Exec.CreateContainerExecAsync(id, execCreateParameters, ct)
         .ConfigureAwait(false);
 
-      using (var stdOutAndErrStream = await DockerClient.Exec.StartAndAttachContainerExecAsync(execCreateResponse.ID, false, ct)
+      using (var stdOutAndErrStream = await DockerClient.Exec.StartContainerExecAsync(execCreateResponse.ID, new ContainerExecStartParameters(), ct)
         .ConfigureAwait(false))
       {
         var (stdout, stderr) = await stdOutAndErrStream.ReadOutputToEndAsync(ct)

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilMessageIsLogged.cs
@@ -22,6 +22,7 @@ namespace DotNet.Testcontainers.Configurations
     public async Task<bool> UntilAsync(IContainer container)
     {
       var maxTime = container.StoppedTime > container.CreatedTime ? container.StoppedTime : container.CreatedTime;
+
       var (stdout, stderr) = await container.GetLogsAsync(since: maxTime, timestampsEnabled: false)
         .ConfigureAwait(false);
 

--- a/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
+++ b/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
@@ -55,6 +55,9 @@ public abstract class PulsarContainerTest : IAsyncLifetime
             .Create();
 
         // When
+        _ = await consumer.OnStateChangeTo(ConsumerState.Active, TimeSpan.FromSeconds(10))
+            .ConfigureAwait(true);
+
         _ = await producer.Send(helloPulsar)
             .ConfigureAwait(true);
 

--- a/tests/Testcontainers.Xunit.Tests/PostgreSqlContainer.cs
+++ b/tests/Testcontainers.Xunit.Tests/PostgreSqlContainer.cs
@@ -16,7 +16,8 @@ public sealed partial class PostgreSqlContainerTest(ITestOutputHelper testOutput
 public sealed partial class PostgreSqlContainerTest
 {
     // # --8<-- [start:ConfigureDbProviderFactory]
-    public override DbProviderFactory DbProviderFactory => NpgsqlFactory.Instance;
+    public override DbProviderFactory DbProviderFactory
+        => NpgsqlFactory.Instance;
     // # --8<-- [end:ConfigureDbProviderFactory]
 }
 


### PR DESCRIPTION
## What does this PR do?

The PR updates the Docker.DotNet version and includes some minor improvements.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
