### PR TITLE
fix: Set container created, started, stopped time from inspect response

### DIFF
--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -458,7 +458,7 @@ namespace DotNet.Testcontainers.Containers
       _container = await _client.Container.ByIdAsync(id, ct)
         .ConfigureAwait(false);
 
-      CreatedTime = DateTime.UtcNow;
+      CreatedTime = _container.Created;
       Created?.Invoke(this, EventArgs.Empty);
     }
 
@@ -520,7 +520,7 @@ namespace DotNet.Testcontainers.Containers
 
       Logger.CompleteReadinessCheck(_container.ID);
 
-      StartedTime = DateTime.UtcNow;
+      StartedTime = DateTime.TryParse(_container.State.StartedAt, null, DateTimeStyles.AdjustToUniversal, out var startedTime) ? startedTime : DateTime.UtcNow;
       Started?.Invoke(this, EventArgs.Empty);
     }
 
@@ -556,7 +556,7 @@ namespace DotNet.Testcontainers.Containers
         _container = new ContainerInspectResponse();
       }
 
-      StoppedTime = DateTime.UtcNow;
+      StoppedTime = DateTime.TryParse(_container.State.FinishedAt, null, DateTimeStyles.AdjustToUniversal, out var stoppedTime) ? stoppedTime : DateTime.UtcNow;
       Stopped?.Invoke(this, EventArgs.Empty);
     }
 


### PR DESCRIPTION
## What does this PR do?

The PR fixes an issue where the _wait for log messages_ strategy failed to indicate readiness for a reuse configuration. When the container is **not** stopped before reusing it in a new test process, the wait strategy fails to detect readiness. The _wait for log messages_ strategy filters the wrong time range of log messages, which leads to missing the log messages it checks for.

The PR sets the properties `CreatedTime`, `StartedTime`, and `StoppedTime` to the values included in the container inspect response, which now filters the correct time range.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1453

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
