### PR TITLE
chore: Add ExecResult serializable test data

### DIFF
--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -520,7 +520,7 @@ namespace DotNet.Testcontainers.Containers
 
       Logger.CompleteReadinessCheck(_container.ID);
 
-      StartedTime = DateTime.TryParse(_container.State.StartedAt, null, DateTimeStyles.AdjustToUniversal, out var startedTime) ? startedTime : DateTime.UtcNow;
+      StartedTime = DateTime.TryParse(_container.State.StartedAt, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var startedTime) ? startedTime : DateTime.UtcNow;
       Started?.Invoke(this, EventArgs.Empty);
     }
 
@@ -556,7 +556,7 @@ namespace DotNet.Testcontainers.Containers
         _container = new ContainerInspectResponse();
       }
 
-      StoppedTime = DateTime.TryParse(_container.State.FinishedAt, null, DateTimeStyles.AdjustToUniversal, out var stoppedTime) ? stoppedTime : DateTime.UtcNow;
+      StoppedTime = DateTime.TryParse(_container.State.FinishedAt, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var stoppedTime) ? stoppedTime : DateTime.UtcNow;
       Stopped?.Invoke(this, EventArgs.Empty);
     }
 

--- a/tests/Testcontainers.Platform.Linux.Tests/ExecFailedExceptionTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ExecFailedExceptionTest.cs
@@ -2,12 +2,11 @@ namespace Testcontainers.Tests;
 
 public sealed class ExecFailedExceptionTest
 {
-    public static readonly List<TheoryDataRow<ExecResult, string>> ExecResultTestData
-        = new List<TheoryDataRow<ExecResult, string>>
+    public static TheoryData<ExecResultSerializable, string> ExecResultTestData { get; }
+        = new TheoryData<ExecResultSerializable, string>
         {
-            new TheoryDataRow<ExecResult, string>
-            (
-                new ExecResult("Stdout\nStdout", "Stderr\nStderr", 1),
+            {
+                new ExecResultSerializable("Stdout\nStdout", "Stderr\nStderr", 1),
                 "Process exited with code 1." + Environment.NewLine +
                 "  Stdout: " + Environment.NewLine +
                 "    Stdout" + Environment.NewLine +
@@ -15,36 +14,79 @@ public sealed class ExecFailedExceptionTest
                 "  Stderr: " + Environment.NewLine +
                 "    Stderr" + Environment.NewLine +
                 "    Stderr"
-            ),
-            new TheoryDataRow<ExecResult, string>
-            (
-                new ExecResult("Stdout\nStdout", string.Empty, 1),
+            },
+            {
+                new ExecResultSerializable("Stdout\nStdout", string.Empty, 1),
                 "Process exited with code 1." + Environment.NewLine +
                 "  Stdout: " + Environment.NewLine +
                 "    Stdout" + Environment.NewLine +
                 "    Stdout"
-            ),
-            new TheoryDataRow<ExecResult, string>
-            (
-                new ExecResult(string.Empty, "Stderr\nStderr", 1),
+            },
+            {
+                new ExecResultSerializable(string.Empty, "Stderr\nStderr", 1),
                 "Process exited with code 1." + Environment.NewLine +
                 "  Stderr: " + Environment.NewLine +
                 "    Stderr" + Environment.NewLine +
                 "    Stderr"
-            ),
-            new TheoryDataRow<ExecResult, string>
-            (
-                new ExecResult(string.Empty, string.Empty, 1),
+            },
+            {
+                new ExecResultSerializable(string.Empty, string.Empty, 1),
                 "Process exited with code 1."
-            ),
+            },
         };
 
     [Theory]
     [MemberData(nameof(ExecResultTestData))]
-    public void ExecFailedExceptionCreatesExpectedMessage(ExecResult execResult, string message)
+    public void ExecFailedExceptionCreatesExpectedMessage(ExecResultSerializable serializable, string message)
     {
+        // Given
+        var execResult = serializable.ToExecResult();
+
+        // When
         var exception = new ExecFailedException(execResult);
+
+        // Then
         Assert.Equal(execResult, exception.ExecResult);
         Assert.Equal(message, exception.Message);
+    }
+
+    [PublicAPI]
+    public sealed class ExecResultSerializable : IXunitSerializable
+    {
+        private string _stdout;
+
+        private string _stderr;
+
+        private int _exitCode;
+
+        public ExecResultSerializable()
+        {
+        }
+
+        public ExecResultSerializable(string stdout, string stderr, int exitCode)
+        {
+            _stdout = stdout;
+            _stderr = stderr;
+            _exitCode = exitCode;
+        }
+
+        public ExecResult ToExecResult()
+        {
+            return new ExecResult(_stdout, _stderr, _exitCode);
+        }
+
+        public void Deserialize(IXunitSerializationInfo info)
+        {
+            _stdout = info.GetValue<string>(nameof(_stdout));
+            _stderr = info.GetValue<string>(nameof(_stderr));
+            _exitCode = info.GetValue<int>(nameof(_exitCode));
+        }
+
+        public void Serialize(IXunitSerializationInfo info)
+        {
+            info.AddValue(nameof(_stdout), _stdout);
+            info.AddValue(nameof(_stderr), _stderr);
+            info.AddValue(nameof(_exitCode), _exitCode);
+        }
     }
 }

--- a/tests/Testcontainers.Platform.Linux.Tests/Usings.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/Usings.cs
@@ -24,3 +24,4 @@ global using Microsoft.Extensions.Logging.Abstractions;
 global using Microsoft.Extensions.Logging.Testing;
 global using ReflectionMagic;
 global using Xunit;
+global using Xunit.Sdk;


### PR DESCRIPTION
## What does this PR do?

The PR adds the `IXunitSerializable` interface to the `ExecResult` test data.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
