### PR TITLE
Update NatsBuilder.cs

### DIFF
--- a/src/Testcontainers.Nats/NatsBuilder.cs
+++ b/src/Testcontainers.Nats/NatsBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.Nats;
 [PublicAPI]
 public sealed class NatsBuilder : ContainerBuilder<NatsBuilder, NatsContainer, NatsConfiguration>
 {
-    public const string NatsImage = "nats:2.9";
+    public const string NatsImage = "nats:2.11";
 
     public const ushort NatsClientPort = 4222;
 


### PR DESCRIPTION
## What does this PR do?

Update to the latest version of NATS due to the following CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-30215

## Why is it important?

CVE bad.

## Related issues
N/A
-

