### PR TITLE
chore: Bump Docker.DotNet version to 3.128.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.1"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="3.128.1"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.128.1"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="3.128.3"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.128.3"/>
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
         <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1"/>
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3"/>

--- a/src/Testcontainers/Clients/ContainerConfigurationConverter.cs
+++ b/src/Testcontainers/Clients/ContainerConfigurationConverter.cs
@@ -10,11 +10,13 @@ namespace DotNet.Testcontainers.Clients
 
   internal sealed class ContainerConfigurationConverter
   {
-    private const string UdpPortSuffix = "/udp";
+    private const string UdpProtocolSuffix = "/udp";
 
-    private const string TcpPortSuffix = "/tcp";
+    private const string TcpProtocolSuffix = "/tcp";
 
-    private const string SctpPortSuffix = "/sctp";
+    private const string SctpProtocolSuffix = "/sctp";
+
+    private static readonly string[] Protocols = new[] { UdpProtocolSuffix, TcpProtocolSuffix, SctpProtocolSuffix };
 
     public ContainerConfigurationConverter(IContainerConfiguration configuration)
     {
@@ -49,7 +51,8 @@ namespace DotNet.Testcontainers.Clients
 
     public static string GetQualifiedPort(string containerPort)
     {
-      return Array.Exists(new[] { UdpPortSuffix, TcpPortSuffix, SctpPortSuffix }, portSuffix => containerPort.EndsWith(portSuffix, StringComparison.OrdinalIgnoreCase)) ? containerPort.ToLowerInvariant() : containerPort + TcpPortSuffix;
+      return Array.Exists(Protocols, portSuffix => containerPort.EndsWith(portSuffix, StringComparison.OrdinalIgnoreCase))
+        ? containerPort.ToLowerInvariant() : containerPort + TcpProtocolSuffix;
     }
 
     private sealed class ToCollection : CollectionConverter<string, string>


### PR DESCRIPTION
## What does this PR do?

The PR bumps the Docker.DotNet version, which contains an important [fix](https://github.com/testcontainers/Docker.DotNet/releases/tag/v3.128.3) for Podman (and likely Docker) users.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
