### PR TITLE
fix(ServiceBus): Remove container lifecycle overrides

### DIFF
--- a/src/Testcontainers.ServiceBus/ServiceBusContainer.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusContainer.cs
@@ -4,8 +4,6 @@ namespace Testcontainers.ServiceBus;
 [PublicAPI]
 public sealed class ServiceBusContainer : DockerContainer
 {
-    private readonly ServiceBusConfiguration _configuration;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="ServiceBusContainer" /> class.
     /// </summary>
@@ -13,7 +11,6 @@ public sealed class ServiceBusContainer : DockerContainer
     public ServiceBusContainer(ServiceBusConfiguration configuration)
         : base(configuration)
     {
-        _configuration = configuration;
     }
 
     /// <summary>
@@ -28,41 +25,5 @@ public sealed class ServiceBusContainer : DockerContainer
         properties.Add("SharedAccessKey", "SAS_KEY_VALUE");
         properties.Add("UseDevelopmentEmulator", "true");
         return string.Join(";", properties.Select(property => string.Join("=", property.Key, property.Value)));
-    }
-
-    /// <inheritdoc />
-    protected override async Task UnsafeCreateAsync(CancellationToken ct = default)
-    {
-        await _configuration.Networks.Single().CreateAsync(ct)
-            .ConfigureAwait(false);
-
-        await base.UnsafeCreateAsync(ct)
-            .ConfigureAwait(false);
-    }
-
-    /// <inheritdoc />
-    protected override Task UnsafeDeleteAsync(CancellationToken ct = default)
-    {
-        return Task.WhenAll(base.UnsafeDeleteAsync(ct), _configuration.DatabaseContainer.DisposeAsync().AsTask());
-    }
-
-    /// <inheritdoc />
-    protected override async Task UnsafeStartAsync(CancellationToken ct = default)
-    {
-        await _configuration.DatabaseContainer.StartAsync(ct)
-            .ConfigureAwait(false);
-
-        await base.UnsafeStartAsync(ct)
-            .ConfigureAwait(false);
-    }
-
-    /// <inheritdoc />
-    protected override async Task UnsafeStopAsync(CancellationToken ct = default)
-    {
-        await base.UnsafeStopAsync(ct)
-            .ConfigureAwait(false);
-
-        await _configuration.DatabaseContainer.StopAsync(ct)
-            .ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Due to a bug or regression in Docker Desktop, I noticed that we're calling `StartAsync()` for the database container in the Service Bus module twice. Normally, this wouldn't be a problem, but with the current Docker Desktop regression, it breaks the module.

Since our modules don't handle cleaning up dependent resources (because they don't know who owns them), I've decided to remove this special handling from the Service Bus module as well. Testcontainers can resolve the dependency graph and automatically create all necessary resources. There's no need to explicitly override `UnsafeCreateAsync(CancellationToken)` or `UnsafeStartAsync(CancellationToken)`.

Also, the current implementation is inconsistent. For example, it removes the dependent container but not the associated network.

To reliably remove dependent resources, we'd need to track which ones are created by our internal library and which are passed in to the builder configuration. Even then, reliably deleting orphaned resources within the **test process** isn't really feasible. Ryuk usually handles that. Resources only get leaked in environments that don't support Ryuk and aren't ephemeral.

The Docker Desktop regression is easy to reproduce: just call `docker start <container_id>` a second time, and it messes up the port bindings.

```console
PS C:\Users\andre.hofmeister> docker run -d -p 80 httpd
4d08a7c329b699feb515135ee3ad2f13aed3b9cc32b32e0188cdf114fd7f886c

PS C:\Users\andre.hofmeister> docker ps
CONTAINER ID   IMAGE     COMMAND              CREATED         STATUS        PORTS                                       NAMES
4d08a7c329b6   httpd     "httpd-foreground"   2 seconds ago   Up 1 second   0.0.0.0:52299->80/tcp, [::]:52299->80/tcp   musing_lamarr

PS C:\Users\andre.hofmeister> docker start 4d08a7c329b6
4d08a7c329b6

PS C:\Users\andre.hofmeister> docker ps
CONTAINER ID   IMAGE     COMMAND              CREATED         STATUS         PORTS     NAMES
4d08a7c329b6   httpd     "httpd-foreground"   9 seconds ago   Up 9 seconds   80/tcp    musing_lamarr
```

## Why is it important?

Workaround Docker Desktop regression.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
