### PR TITLE
fix(Pulsar): Wait until the consumer becomes connected

### DIFF
--- a/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
+++ b/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
@@ -63,6 +63,9 @@ public abstract class PulsarContainerTest : IAsyncLifetime
         _ = await consumer.OnStateChangeTo(ConsumerState.Active, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
+        _ = await producer.OnStateChangeTo(ProducerState.Connected, TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
         _ = await producer.Send(helloPulsar, cancellationToken: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 


### PR DESCRIPTION
## What does this PR do?

Occasionally, the Pulsar module tests fail. It seems like the consumer isn't ready to process incoming messages. This PR adds a check to wait until the consumer is connected and ready.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
