### PR TITLE
fix: Remove timeout that kills PID 1 when stopping a container

### DIFF
--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -88,7 +88,7 @@ namespace DotNet.Testcontainers.Clients
     public Task StopAsync(string id, CancellationToken ct = default)
     {
       Logger.StopDockerContainer(id);
-      return DockerClient.Containers.StopContainerAsync(id, new ContainerStopParameters { WaitBeforeKillSeconds = 15 }, ct);
+      return DockerClient.Containers.StopContainerAsync(id, new ContainerStopParameters(), ct);
     }
 
     public Task PauseAsync(string id, CancellationToken ct = default)


### PR DESCRIPTION
## What does this PR do?

This PR removes the `WaitBeforeKillSeconds` timeout that was used to kill PID 1 when stopping the container. It was a leftover from the early implementation of Testcontainers. Using a fixed timeout isn't ideal, as it can vary depending on the environment. If we still need this functionality, we should offer an overload that lets developers pass a custom timeout as an argument.

## Why is it important?

I believe this is why we're seeing flaky WebDriver tests and why the video isn't being fully written by the FFmpeg container.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
