### PR TITLE
docs: Extend example copying files to a container

### DIFF
--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -45,7 +45,11 @@ _ = new ContainerBuilder()
 
 ```csharp title="Copying a file"
 _ = new ContainerBuilder()
-  .WithResourceMapping(new FileInfo("appsettings.json"), "/app/");
+  # copy to the `/app` directory
+  .WithResourceMapping(new FileInfo("appsettings.json"), "/app")
+
+  # copy to a specific file
+  .WithResourceMapping(new FileInfo("appsettings.Container.json"), new FileInfo("/app/appsettings.Developer.json"));
 ```
 
 Another overloaded member of the container builder API allows you to copy the contents of a byte array to a specific file path within the container. This can be useful when you already have the file content stored in memory or when you need to dynamically generate the file content before copying it.


### PR DESCRIPTION
## What does this PR do?

This change should make it more explicit that, when providing a string, the target is always a directory and never a file path. To specify a file path, a instance of `FileInfo` must be passed.

## Why is it important?

When coming from `docker-compose.yml`, it is unexpected that the second argument of `WithResourceMapping` is always a path to a directory, never a file.

Given `.WithResourceMapping(new FileInfo("file.txt"), "/file.txt");`, my expectation was a file at `/file.txt`, but it ends up at `/file.txt/file.txt` in the container.

## Related issues

Relates to #1486
