### PR TITLE
feat: Resolve `.slnx` (solution) file in common directory paths

### DIFF
--- a/src/Testcontainers/Builders/CommonDirectoryPath.cs
+++ b/src/Testcontainers/Builders/CommonDirectoryPath.cs
@@ -76,7 +76,7 @@ namespace DotNet.Testcontainers.Builders
     [PublicAPI]
     public static CommonDirectoryPath GetSolutionDirectory([CallerFilePath, NotNull] string filePath = "")
     {
-      return new CommonDirectoryPath(GetDirectoryPath(Path.GetDirectoryName(filePath), "*.sln"));
+      return new CommonDirectoryPath(GetDirectoryPath(Path.GetDirectoryName(filePath), "*.sln", "*.slnx"));
     }
 
     /// <summary>


### PR DESCRIPTION
## What does this PR do?

When searching up the directory tree for solution files, also consider *.slnx files that were [recently introduced](https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/).

## Why is it important?

Establishes compatibility with the future solution format.

## Related issues
Fixes #1491 
