### PR TITLE
fix: Add tooling to inherit XML docs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
+    <GlobalPackageReference Include="SauceControl.InheritDoc" VersionOverride="2.0.2" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)docs/banner.png" Visible="false" Pack="true" PackagePath="docs/" />
     <None Include="$(MSBuildThisFileDirectory)docs/logo.png" Visible="false" Pack="true" PackagePath="docs/" />
     <None Include="$(MSBuildThisFileDirectory)LICENSE" Visible="false" Pack="true" PackagePath="" />

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -45,10 +45,9 @@ _ = new ContainerBuilder()
 
 ```csharp title="Copying a file"
 _ = new ContainerBuilder()
-  # copy to the `/app` directory
-  .WithResourceMapping(new FileInfo("appsettings.json"), "/app")
-
-  # copy to a specific file
+  # Copy 'appsettings.json' into the '/app' directory.
+  .WithResourceMapping(new FileInfo("appsettings.json"), "/app/")
+  # Copy 'appsettings.Container.json' to '/app/appsettings.Developer.json'.
   .WithResourceMapping(new FileInfo("appsettings.Container.json"), new FileInfo("/app/appsettings.Developer.json"));
 ```
 

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitUntil.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitUntil.cs
@@ -4,9 +4,17 @@ namespace DotNet.Testcontainers.Configurations
   using DotNet.Testcontainers.Containers;
   using JetBrains.Annotations;
 
+  /// <summary>
+  /// Defines a condition that is repeatedly evaluated until it becomes true.
+  /// </summary>
   [PublicAPI]
   public interface IWaitUntil
   {
+    /// <summary>
+    /// Evaluates the condition asynchronously against the specified container.
+    /// </summary>
+    /// <param name="container">The container instance to check readiness against.</param>
+    /// <returns>A task that returns <c>true</c> when the condition is satisfied; otherwise, <c>false</c>.</returns>
     Task<bool> UntilAsync(IContainer container);
   }
 }

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitWhile.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitWhile.cs
@@ -4,9 +4,17 @@ namespace DotNet.Testcontainers.Configurations
   using DotNet.Testcontainers.Containers;
   using JetBrains.Annotations;
 
+  /// <summary>
+  /// Defines a condition that is repeatedly evaluated while it remains true.
+  /// </summary>
   [PublicAPI]
   public interface IWaitWhile
   {
+    /// <summary>
+    /// Evaluates the condition asynchronously against the specified container.
+    /// </summary>
+    /// <param name="container">The container instance to check readiness against.</param>
+    /// <returns>A task that returns <c>true</c> while the condition holds; otherwise, <c>false</c>.</returns>
     Task<bool> WhileAsync(IContainer container);
   }
 }


### PR DESCRIPTION
## What does this PR do?

This PR adds tooling to the build process to inherit XML documentation and include it in the NuGet package. The standard .NET tooling doesn't automatically inherit documentation.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
