### PR TITLE
feat(Elasticsearch): Return HTTP connection string if security is disabled

### DIFF
--- a/src/Testcontainers.Elasticsearch/ElasticsearchContainer.cs
+++ b/src/Testcontainers.Elasticsearch/ElasticsearchContainer.cs
@@ -20,14 +20,29 @@ public sealed class ElasticsearchContainer : DockerContainer
     /// Gets the Elasticsearch connection string.
     /// </summary>
     /// <remarks>
-    /// The Elasticsearch module does not export the SSL certificate from the container by default.
-    /// If you are trying to connect to the Elasticsearch service, you need to override the certificate validation callback to establish the connection.
+    /// The Elasticsearch module does not export the SSL certificate from the container
+    /// by default. If you are trying to connect to the Elasticsearch service, you need
+    /// to override the certificate validation callback to establish the connection.
     /// We will export the certificate and support trusted SSL connections in the future.
     /// </remarks>
     /// <returns>The Elasticsearch connection string.</returns>
     public string GetConnectionString()
     {
-        var endpoint = new UriBuilder(Uri.UriSchemeHttps, Hostname, GetMappedPublicPort(ElasticsearchBuilder.ElasticsearchHttpsPort));
+        var hasSecurityEnabled = _configuration.Environments
+            .TryGetValue("xpack.security.enabled", out var securityEnabled);
+
+        var hasHttpSslEnabled = _configuration.Environments
+            .TryGetValue("xpack.security.http.ssl.enabled", out var httpSslEnabled);
+
+        var httpsDisabled =
+            hasSecurityEnabled &&
+            hasHttpSslEnabled &&
+            "false".Equals(securityEnabled, StringComparison.OrdinalIgnoreCase) &&
+            "false".Equals(httpSslEnabled, StringComparison.OrdinalIgnoreCase);
+
+        var scheme = httpsDisabled ? Uri.UriSchemeHttp : Uri.UriSchemeHttps;
+
+        var endpoint = new UriBuilder(scheme, Hostname, GetMappedPublicPort(ElasticsearchBuilder.ElasticsearchHttpsPort));
         endpoint.UserName = _configuration.Username;
         endpoint.Password = _configuration.Password;
         return endpoint.ToString();

--- a/tests/Testcontainers.WebDriver.Tests/WebDriverContainerTest.cs
+++ b/tests/Testcontainers.WebDriver.Tests/WebDriverContainerTest.cs
@@ -79,6 +79,8 @@ public abstract class WebDriverContainerTest : IAsyncLifetime
             var videoFilePath = Path.Combine(TestSession.TempDirectoryPath, Path.GetRandomFileName());
 
             // When
+            HeadingElementReturnsHelloWorld();
+
             await _webDriverContainer.StopAsync(TestContext.Current.CancellationToken)
                 .ConfigureAwait(true);
 


### PR DESCRIPTION
## What does this PR do?

This PR updates the `ElasticsearchContainer` to take security configurations into account. If HTTPS (security) is disabled, the connection string method will now return an HTTP connection string instead of HTTPS. This change allows for more OOB configurations to be supported.

Nonetheless, it's still recommended to extract the certificate and set up proper certificate validation, rather than disabling security.

## Why is it important?

Support HTTP configuration OOB.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1461

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
