### PR TITLE
fix: Send valid HTTP test responses

### DIFF
--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -9,7 +9,7 @@ public static class CommonImages
 
     public static readonly IImage Alpine = new DockerImage("alpine:3.17");
 
-    public static readonly IImage Socat = new DockerImage("alpine/socat:1.8.0.0");
+    public static readonly IImage Socat = new DockerImage("alpine/socat:1.8.0.3");
 
     public static readonly IImage Curl = new DockerImage("curlimages/curl:8.00.1");
 

--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -178,7 +178,7 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
             private readonly IContainer _container = new ContainerBuilder()
                 .WithImage(CommonImages.Socat)
                 .WithCommand("-v")
-                .WithCommand($"TCP-LISTEN:{HttpPort},reuseaddr,fork")
+                .WithCommand($"TCP-LISTEN:{HttpPort},crlf,reuseaddr,fork")
                 .WithCommand("SYSTEM:'echo -e \"HTTP/1.1 200 OK\\nContent-Length: 0\\n\\n\"'")
                 .WithPortBinding(HttpPort, true)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request))

--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -170,6 +170,7 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
             Assert.All(execResults, result => Assert.Equal(0, result.ExitCode));
         }
 
+        [UsedImplicitly]
         public sealed class HttpFixture : IAsyncLifetime
         {
             private const ushort HttpPort = 80;
@@ -177,8 +178,8 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
             private readonly IContainer _container = new ContainerBuilder()
                 .WithImage(CommonImages.Socat)
                 .WithCommand("-v")
-                .WithCommand($"TCP-LISTEN:{HttpPort},crlf,reuseaddr,fork")
-                .WithCommand("EXEC:\"echo -e 'HTTP/1.1 200 OK'\n\n\"")
+                .WithCommand($"TCP-LISTEN:{HttpPort},reuseaddr,fork")
+                .WithCommand("SYSTEM:'echo -e \"HTTP/1.1 200 OK\\nContent-Length: 0\\n\\n\"'")
                 .WithPortBinding(HttpPort, true)
                 .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request))
                 .Build();
@@ -186,10 +187,9 @@ public abstract class TarOutputMemoryStreamTest : IDisposable
             public string BaseAddress
                 => new UriBuilder(Uri.UriSchemeHttp, _container.Hostname, _container.GetMappedPublicPort(HttpPort)).ToString();
 
-            public async ValueTask InitializeAsync()
+            public ValueTask InitializeAsync()
             {
-                await _container.StartAsync()
-                    .ConfigureAwait(false);
+                return new ValueTask(_container.StartAsync());
             }
 
             public ValueTask DisposeAsync()

--- a/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/WaitUntilHttpRequestIsSucceededTest.cs
@@ -128,7 +128,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       public IContainer Container { get; } = new ContainerBuilder()
         .WithImage(CommonImages.Socat)
         .WithCommand("-v")
-        .WithCommand($"TCP-LISTEN:{HttpPort},reuseaddr,fork")
+        .WithCommand($"TCP-LISTEN:{HttpPort},crlf,reuseaddr,fork")
         .WithCommand("SYSTEM:'echo -e \"HTTP/1.1 200 OK\\nContent-Length: 0\\n\\n\"'")
         .WithPortBinding(HttpPort, true)
         .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request))


### PR DESCRIPTION
## What does this PR do?

Occasionally, the HTTP wait strategy tests fail. I did some testing using GitHub Codespaces and noticed that the HTTP response messages we use in our tests weren't being properly sent to the client. It looks like we are just sending `HTTP/1.1 200 OK` without the newlines.

I made a small adjustment to the `socat` container configuration we use to mimic an HTTP backend. It now sends a properly formatted HTTP-compliant response. I tested the changes for a while and the tests haven't failed since.

## Why is it important?

To keep the CI green.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
