### PR TITLE
chore: Bump Docker.DotNet version to 3.128.5

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.1"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="3.128.3"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.128.3"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="3.128.5"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.128.5"/>
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
         <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1"/>
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3"/>


### PR DESCRIPTION
## What does this PR do?

This PR updates the Docker.DotNet version. Some users have noticed issues when Docker.DotNet hijacks the connection, for example when reading stdout or stderr from running (executed) processes. Occasionally, reading from the stream caused an IOException:

> Connection reset by peer.

## Why is it important?

Improve Testcontainers stability.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
