### PR TITLE
fix: Dispose StringWriter

### DIFF
--- a/src/Testcontainers.Elasticsearch/ElasticsearchContainer.cs
+++ b/src/Testcontainers.Elasticsearch/ElasticsearchContainer.cs
@@ -34,11 +34,10 @@ public sealed class ElasticsearchContainer : DockerContainer
         var hasHttpSslEnabled = _configuration.Environments
             .TryGetValue("xpack.security.http.ssl.enabled", out var httpSslEnabled);
 
-        var httpsDisabled =
-            hasSecurityEnabled &&
-            hasHttpSslEnabled &&
-            "false".Equals(securityEnabled, StringComparison.OrdinalIgnoreCase) &&
-            "false".Equals(httpSslEnabled, StringComparison.OrdinalIgnoreCase);
+        var httpsDisabled = hasSecurityEnabled
+            && hasHttpSslEnabled
+            && "false".Equals(securityEnabled, StringComparison.OrdinalIgnoreCase)
+            && "false".Equals(httpSslEnabled, StringComparison.OrdinalIgnoreCase);
 
         var scheme = httpsDisabled ? Uri.UriSchemeHttp : Uri.UriSchemeHttps;
 

--- a/src/Testcontainers.MariaDb/MariaDbContainer.cs
+++ b/src/Testcontainers.MariaDb/MariaDbContainer.cs
@@ -57,7 +57,7 @@ public sealed class MariaDbContainer : DockerContainer, IDatabaseContainer
     /// <returns>Task that completes when the configuration file has been executed.</returns>
     internal Task WriteConfigurationFileAsync(CancellationToken ct = default)
     {
-        var config = new StringWriter();
+        using var config = new StringWriter();
         config.NewLine = "\n";
         config.WriteLine("[client]");
         config.WriteLine("protocol=TCP");

--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -71,7 +71,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
     /// <returns>A configured instance of <see cref="MongoDbBuilder" />.</returns>
     public MongoDbBuilder WithReplicaSet(string replicaSetName = "rs0")
     {
-        var initKeyFileScript = new StringWriter();
+        using var initKeyFileScript = new StringWriter();
         initKeyFileScript.NewLine = "\n";
         initKeyFileScript.WriteLine("#!/bin/bash");
         initKeyFileScript.WriteLine("openssl rand -base64 32 > \"" + KeyFileFilePath + "\"");

--- a/src/Testcontainers.MySql/MySqlContainer.cs
+++ b/src/Testcontainers.MySql/MySqlContainer.cs
@@ -71,7 +71,7 @@ public sealed class MySqlContainer : DockerContainer, IDatabaseContainer
     /// <returns>Task that completes when the configuration file has been executed.</returns>
     internal Task WriteConfigurationFileAsync(CancellationToken ct = default)
     {
-        var config = new StringWriter();
+        using var config = new StringWriter();
         config.NewLine = "\n";
         config.WriteLine("[client]");
         config.WriteLine("protocol=TCP");

--- a/src/Testcontainers.Pulsar/PulsarContainer.cs
+++ b/src/Testcontainers.Pulsar/PulsarContainer.cs
@@ -95,7 +95,7 @@ public sealed class PulsarContainer : DockerContainer
     /// <returns>A task that completes when the startup script has been copied.</returns>
     internal Task CopyStartupScriptAsync(CancellationToken ct = default)
     {
-        var startupScript = new StringWriter();
+        using var startupScript = new StringWriter();
         startupScript.NewLine = "\n";
         startupScript.WriteLine("#!/bin/bash");
 


### PR DESCRIPTION
## What does this PR do?

While reviewing the recent PR that adds KRaft support to the Kafka module, I noticed that we weren't disposing of the `StringWriter`. The PR fixes this and disposes of it now.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
