### PR TITLE
feat(Keycloak): Add API to import a realm configuration file

### DIFF
--- a/src/Testcontainers.Keycloak/KeycloakBuilder.cs
+++ b/src/Testcontainers.Keycloak/KeycloakBuilder.cs
@@ -61,14 +61,19 @@ public sealed class KeycloakBuilder : ContainerBuilder<KeycloakBuilder, Keycloak
     }
 
     /// <summary>
-    /// Sets the Keycloak to Import Realm file.
+    /// Configures Keycloak to import a realm configuration file during startup.
     /// </summary>
-    /// <param name="path">The path to realm-export.json</param>
+    /// <remarks>
+    /// The file will be copied to the <c>/opt/keycloak/data/import/</c> directory
+    /// inside the container:
+    /// https://www.keycloak.org/server/importExport#_importing_a_realm_during_startup.
+    /// </remarks>
+    /// <param name="realmConfigurationFilePath">The local path to the realm configuration file (JSON).</param>
     /// <returns>A configured instance of <see cref="KeycloakBuilder" />.</returns>
-    public KeycloakBuilder WithRealm(string path)
+    public KeycloakBuilder WithRealm(string realmConfigurationFilePath)
     {
-        return Clone(new ContainerConfiguration(command: new AppendEnumerable<string>(["--import-realm"])))
-            .WithBindMount(path, "/opt/keycloak/data/import/realm-export.json");
+        return WithCommand("--import-realm")
+            .WithResourceMapping(realmConfigurationFilePath, "/opt/keycloak/data/import/");
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Keycloak/KeycloakBuilder.cs
+++ b/src/Testcontainers.Keycloak/KeycloakBuilder.cs
@@ -60,6 +60,17 @@ public sealed class KeycloakBuilder : ContainerBuilder<KeycloakBuilder, Keycloak
             .WithEnvironment("KEYCLOAK_ADMIN_PASSWORD", password);
     }
 
+    /// <summary>
+    /// Sets the Keycloak to Import Realm file.
+    /// </summary>
+    /// <param name="path">The path to realm-export.json</param>
+    /// <returns>A configured instance of <see cref="KeycloakBuilder" />.</returns>
+    public KeycloakBuilder WithRealm(string path)
+    {
+        return Clone(new ContainerConfiguration(command: new AppendEnumerable<string>(["--import-realm"])))
+            .WithBindMount(path, "/opt/keycloak/data/import/realm-export.json");
+    }
+
     /// <inheritdoc />
     public override KeycloakContainer Build()
     {

--- a/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
+++ b/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
@@ -1,6 +1,3 @@
-using System.IO;
-using System.Linq;
-
 namespace Testcontainers.Keycloak;
 
 public abstract class KeycloakContainerTest : IAsyncLifetime
@@ -93,13 +90,13 @@ public abstract class KeycloakContainerTest : IAsyncLifetime
     public sealed class KeycloakRealmConfiguration : KeycloakContainerTest
     {
         public KeycloakRealmConfiguration()
-            : base(new KeycloakBuilder().WithRealm(Path.GetFullPath("realm-export.json")).Build())
+            : base(new KeycloakBuilder().WithRealm("realm-export.json").Build())
         {
         }
 
         [Fact]
         [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
-        public async Task RealmIsImported()
+        public async Task AllRealmsAreEnabled()
         {
             // Given
             var keycloakClient = new KeycloakClient(_keycloakContainer.GetBaseAddress(), KeycloakBuilder.DefaultUsername, KeycloakBuilder.DefaultPassword);
@@ -109,7 +106,7 @@ public abstract class KeycloakContainerTest : IAsyncLifetime
                 .ConfigureAwait(true);
 
             // Then
-            Assert.True(realms.Count() == 2);
+            Assert.Collection(realms, realm => Assert.True(realm.Enabled), realm => Assert.True(realm.Enabled));
         }
     }
 }

--- a/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
+++ b/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
@@ -6,19 +6,19 @@
         <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="coverlet.collector" />
-        <PackageReference Include="xunit.runner.visualstudio" />
-        <PackageReference Include="xunit.v3" />
-        <PackageReference Include="Keycloak.Net.Core" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="xunit.runner.visualstudio"/>
+        <PackageReference Include="xunit.v3"/>
+        <PackageReference Include="Keycloak.Net.Core"/>
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="../../src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj" />
-        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj" />
+        <ProjectReference Include="../../src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj"/>
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
     </ItemGroup>
     <ItemGroup>
-      <None Update="realm-export.json">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
+        <None Update="realm-export.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
+++ b/tests/Testcontainers.Keycloak.Tests/Testcontainers.Keycloak.Tests.csproj
@@ -6,14 +6,19 @@
         <OutputType>Exe</OutputType>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="coverlet.collector"/>
-        <PackageReference Include="xunit.runner.visualstudio"/>
-        <PackageReference Include="xunit.v3"/>
-        <PackageReference Include="Keycloak.Net.Core"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="coverlet.collector" />
+        <PackageReference Include="xunit.runner.visualstudio" />
+        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="Keycloak.Net.Core" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="../../src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj"/>
-        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj"/>
+        <ProjectReference Include="../../src/Testcontainers.Keycloak/Testcontainers.Keycloak.csproj" />
+        <ProjectReference Include="../Testcontainers.Commons/Testcontainers.Commons.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+      <None Update="realm-export.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 </Project>

--- a/tests/Testcontainers.Keycloak.Tests/realm-export.json
+++ b/tests/Testcontainers.Keycloak.Tests/realm-export.json
@@ -1,0 +1,47 @@
+{
+  "realm": "test-realm",
+  "enabled": true,
+  "clients": [
+    {
+      "clientId": "test-client",
+      "secret": "secret",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "name": "Test Client",
+      "attributes": {
+        "jwt.client.claims": "true"
+      },
+      "protocolMappers": [
+        {
+          "name": "audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "test-client",
+            "id.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "admin",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "admin",
+          "temporary": false
+        }
+      ],
+      "email": "admin@example.com"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->
Enables importing a Keycloak realm from a JSON file.

This feature allows users to pre-configure Keycloak instances with specific realm settings, clients, and users, simplifying the setup and configuration process. A new test has been added to verify the import functionality.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1527

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->