### PR TITLE
chore: Remove obsolete wait strategy: `UntilPortIsAvailable(int)`

### DIFF
--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -76,7 +76,8 @@ Starting a container or creating a resource (such as a network or a volume) can 
 
 ```csharp title="Canceling container start after one minute"
 using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-await _container.StartAsync(timeoutCts.Token);
+await _container.StartAsync(timeoutCts.Token)
+  .ConfigureAwait(false);
 ```
 
 ## Getting log messages
@@ -86,7 +87,8 @@ Testcontainers for .NET provides two approaches for retrieving log messages from
 The `GetLogsAsync` method is available through the `IContainer` interface. It allows you to fetch logs from a container for a specific time range or from the beginning until the present. This approach is useful for retrieving logs after a test has run, especially when troubleshooting issues or failures.
 
 ```csharp title="Getting all log messages"
-var (stdout, stderr) = await _container.GetLogsAsync();
+var (stdout, stderr) = await _container.GetLogsAsync()
+  .ConfigureAwait(false);
 ```
 
 The `WithOutputConsumer` method is part of the `ContainerBuilder` class and is used to continuously forward container log messages to a specified output consumer. This approach provides real-time access to logs as the container runs.

--- a/examples/Flyway/Directory.Packages.props
+++ b/examples/Flyway/Directory.Packages.props
@@ -6,7 +6,7 @@
     <ItemGroup>
         <!-- Unit and integration test dependencies: -->
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.2.0"/>
+        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.7.0"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
         <PackageVersion Include="xunit" Version="2.9.2"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->

--- a/examples/Respawn/Directory.Packages.props
+++ b/examples/Respawn/Directory.Packages.props
@@ -6,7 +6,7 @@
     <ItemGroup>
         <!-- Unit and integration test dependencies: -->
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.2.0"/>
+        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.7.0"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
         <PackageVersion Include="xunit" Version="2.9.2"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->

--- a/examples/WeatherForecast/Directory.Packages.props
+++ b/examples/WeatherForecast/Directory.Packages.props
@@ -10,7 +10,7 @@
     <!-- Unit and integration test dependencies: -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13"/>
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.2.0"/>
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.7.0"/>
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
     <PackageVersion Include="xunit" Version="2.9.2"/>
     <!-- Third-party client dependencies to connect and interact with the containers: -->

--- a/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecastContainer.cs
+++ b/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecastContainer.cs
@@ -40,7 +40,7 @@ public sealed class WeatherForecastContainer : HttpClient, IAsyncLifetime
       .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Path", WeatherForecastImage.CertificateFilePath)
       .WithEnvironment("ASPNETCORE_Kestrel__Certificates__Default__Password", WeatherForecastImage.CertificatePassword)
       .WithEnvironment("ConnectionStrings__PostgreSQL", postgreSqlConnectionString)
-      .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(WeatherForecastImage.HttpsPort))
+      .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(WeatherForecastImage.HttpsPort))
       .Build();
   }
 

--- a/src/Testcontainers.Weaviate/WeaviateBuilder.cs
+++ b/src/Testcontainers.Weaviate/WeaviateBuilder.cs
@@ -42,8 +42,8 @@ public sealed class WeaviateBuilder : ContainerBuilder<WeaviateBuilder, Weaviate
             .WithEnvironment("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true")
             .WithEnvironment("PERSISTENCE_DATA_PATH", "/var/lib/weaviate")
             .WithWaitStrategy(Wait.ForUnixContainer()
-                .UntilPortIsAvailable(WeaviateHttpPort)
-                .UntilPortIsAvailable(WeaviateGrpcPort)
+                .UntilInternalTcpPortIsAvailable(WeaviateHttpPort)
+                .UntilInternalTcpPortIsAvailable(WeaviateGrpcPort)
                 .UntilHttpRequestIsSucceeded(request =>
                     request.ForPath("/v1/.well-known/ready").ForPort(WeaviateHttpPort)));
 

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitForContainerOS.cs
@@ -59,16 +59,6 @@ namespace DotNet.Testcontainers.Configurations
     IWaitForContainerOS UntilCommandIsCompleted(IEnumerable<string> command, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <summary>
-    /// Waits until the port is available.
-    /// </summary>
-    /// <param name="port">The port to be checked.</param>
-    /// <param name="waitStrategyModifier">The wait strategy modifier to cancel the readiness check.</param>
-    /// <returns>A configured instance of <see cref="IWaitForContainerOS" />.</returns>
-    [PublicAPI]
-    [Obsolete("Use UntilInternalTcpPortIsAvailable or UntilExternalTcpPortIsAvailable instead. This method corresponds to the internal variant.")]
-    IWaitForContainerOS UntilPortIsAvailable(int port, Action<IWaitStrategy> waitStrategyModifier = null);
-
-    /// <summary>
     /// Waits until a TCP port is available from within the container itself.
     /// This verifies that a service inside the container is listening on the specified port.
     /// </summary>

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
@@ -28,9 +28,6 @@ namespace DotNet.Testcontainers.Configurations
     public abstract IWaitForContainerOS UntilCommandIsCompleted(IEnumerable<string> command, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <inheritdoc />
-    public abstract IWaitForContainerOS UntilPortIsAvailable(int port, Action<IWaitStrategy> waitStrategyModifier = null);
-
-    /// <inheritdoc />
     public abstract IWaitForContainerOS UntilInternalTcpPortIsAvailable(int containerPort, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <inheritdoc />

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerUnix.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerUnix.cs
@@ -26,12 +26,6 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public override IWaitForContainerOS UntilPortIsAvailable(int port, Action<IWaitStrategy> waitStrategyModifier = null)
-    {
-      return UntilInternalTcpPortIsAvailable(port, waitStrategyModifier);
-    }
-
-    /// <inheritdoc />
     public override IWaitForContainerOS UntilInternalTcpPortIsAvailable(int containerPort, Action<IWaitStrategy> waitStrategyModifier = null)
     {
       return AddCustomWaitStrategy(new UntilInternalTcpPortIsAvailableOnUnix(containerPort), waitStrategyModifier);

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerWindows.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerWindows.cs
@@ -26,12 +26,6 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public override IWaitForContainerOS UntilPortIsAvailable(int port, Action<IWaitStrategy> waitStrategyModifier = null)
-    {
-      return UntilInternalTcpPortIsAvailable(port, waitStrategyModifier);
-    }
-
-    /// <inheritdoc />
     public override IWaitForContainerOS UntilInternalTcpPortIsAvailable(int containerPort, Action<IWaitStrategy> waitStrategyModifier = null)
     {
       return AddCustomWaitStrategy(new UntilInternalTcpPortIsAvailableOnWindows(containerPort), waitStrategyModifier);

--- a/src/Testcontainers/Containers/PortForwarding.cs
+++ b/src/Testcontainers/Containers/PortForwarding.cs
@@ -107,7 +107,9 @@ namespace DotNet.Testcontainers.Containers
           .WithPortBinding(SshdPort, true)
           .WithUsername("root")
           .WithPassword("root")
-          .WithWaitStrategy(Wait.ForUnixContainer().UntilPortIsAvailable(SshdPort));
+          .WithWaitStrategy(Wait.ForUnixContainer()
+            .UntilInternalTcpPortIsAvailable(SshdPort)
+            .UntilExternalTcpPortIsAvailable(SshdPort));
       }
 
       /// <inheritdoc />

--- a/src/Testcontainers/Containers/SocatBuilder.cs
+++ b/src/Testcontainers/Containers/SocatBuilder.cs
@@ -72,7 +72,9 @@ namespace DotNet.Testcontainers.Containers
         .Select(item => string.Format(argument, item.Key, item.Value)));
 
       var waitStrategy = DockerResourceConfiguration.Targets
-        .Aggregate(Wait.ForUnixContainer(), (waitStrategy, item) => waitStrategy.UntilPortIsAvailable(item.Key));
+        .Aggregate(Wait.ForUnixContainer(), (waitStrategy, item) => waitStrategy
+          .UntilInternalTcpPortIsAvailable(item.Key)
+          .UntilExternalTcpPortIsAvailable(item.Key));
 
       var socatBuilder = WithCommand(command).WithWaitStrategy(waitStrategy);
       return new SocatContainer(socatBuilder.DockerResourceConfiguration);

--- a/tests/Testcontainers.Platform.Windows.Tests/WindowsContainerTest.cs
+++ b/tests/Testcontainers.Platform.Windows.Tests/WindowsContainerTest.cs
@@ -57,7 +57,7 @@ public abstract class WindowsContainerTest : IAsyncLifetime
                 .WithImage(CommonImages.ServerCore)
                 .WithEntrypoint("PowerShell", "-NoLogo", "-Command")
                 .WithCommand("$tcpListener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Any, 8080); $tcpListener.Start(); Start-Sleep -Seconds 120")
-                .WithWaitStrategy(Wait.ForWindowsContainer().UntilPortIsAvailable(8080))
+                .WithWaitStrategy(Wait.ForWindowsContainer().UntilInternalTcpPortIsAvailable(8080))
                 .Build())
         {
         }

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/GetContainerLogsTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/GetContainerLogsTest.cs
@@ -10,8 +10,7 @@ namespace DotNet.Testcontainers.Tests.Unit
   {
     private readonly IContainer _container = new ContainerBuilder()
       .WithImage("amazon/dynamodb-local:1.20.0")
-      .WithWaitStrategy(Wait.ForUnixContainer()
-        .UntilPortIsAvailable(8000))
+      .WithWaitStrategy(Wait.ForUnixContainer().UntilInternalTcpPortIsAvailable(8000))
       .Build();
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

This PR removes the obsolete `UntilPortIsAvailable(int)` API. It's been replaced with:

* `UntilInternalTcpPortIsAvailable(int)`
* `UntilExternalTcpPortIsAvailable(int)`

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #1495

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
