### PR TITLE
feat(PostgreSql): Add WithSsl builder API

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -63,7 +63,7 @@ jobs:
 
     env:
       # Lowest API version that GitHub runners support.
-      DOCKER_API_VERSION: 1.52
+      DOCKER_API_VERSION: 1.44
 
     steps:
       - name: Checkout Repository

--- a/docs/modules/postgres.md
+++ b/docs/modules/postgres.md
@@ -23,6 +23,29 @@ The following example utilizes the [xUnit.net](/test_frameworks/xunit_net/) modu
     --8<-- "tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs:UsePostgreSqlContainer"
     ```
 
+## SSL
+
+Use `WithSsl` to enable TLS and map the server certificates. Configure the client connection string with `SslMode` and (for validation) the CA certificate.
+
+!!! note
+    When SSL is enabled, Testcontainers doesn't set the SSL mode for the connection string. You'll need to choose the `SslMode` and configure it yourself.
+
+```csharp
+--8<-- "tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs:PostgreSqlSslBuilder"
+```
+
+```csharp
+--8<-- "tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs:PostgreSqlSslConnectionString"
+```
+
+### VerifyFull and DNS SANs
+
+`SslMode=VerifyFull` validates DNS SANs. Use a DNS host like `localhost` if you need full verification.
+
+```csharp
+--8<-- "tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs:PostgreSqlSslVerifyFull"
+```
+
 The test example uses the following NuGet dependencies:
 
 === "Package References"

--- a/src/Testcontainers.PostgreSql/PostgreSqlBuilder.cs
+++ b/src/Testcontainers.PostgreSql/PostgreSqlBuilder.cs
@@ -15,6 +15,16 @@ public sealed class PostgreSqlBuilder : ContainerBuilder<PostgreSqlBuilder, Post
 
     public const string DefaultPassword = "postgres";
 
+    private const ushort PostgresUid = 999;
+
+    private const ushort PostgresGid = 999;
+
+    private const string CertificateFilePath = "/etc/ssl/postgresql/server.crt";
+
+    private const string CertificateKeyFilePath = "/etc/ssl/postgresql/server.key";
+
+    private const string CaCertificateFilePath = "/etc/ssl/postgresql/root.crt";
+
     /// <summary>
     /// Initializes a new instance of the <see cref="PostgreSqlBuilder" /> class.
     /// </summary>
@@ -100,6 +110,35 @@ public sealed class PostgreSqlBuilder : ContainerBuilder<PostgreSqlBuilder, Post
     {
         return Merge(DockerResourceConfiguration, new PostgreSqlConfiguration(password: password))
             .WithEnvironment("POSTGRES_PASSWORD", password);
+    }
+
+    /// <summary>
+    /// Enables SSL for PostgreSql.
+    /// </summary>
+    /// <param name="certificateFilePath">The SSL certificate file.</param>
+    /// <param name="certificateKeyFilePath">The SSL certificate private key file.</param>
+    /// <returns>A configured instance of <see cref="PostgreSqlBuilder" />.</returns>
+    public PostgreSqlBuilder WithSsl(string certificateFilePath, string certificateKeyFilePath)
+    {
+        return WithResourceMapping(new FileInfo(certificateFilePath), new FileInfo(CertificateFilePath), PostgresUid, PostgresGid, Unix.FileMode600)
+            .WithResourceMapping(new FileInfo(certificateKeyFilePath), new FileInfo(CertificateKeyFilePath), PostgresUid, PostgresGid, Unix.FileMode600)
+            .WithCommand("-c", "ssl=on")
+            .WithCommand("-c", "ssl_cert_file=" + CertificateFilePath)
+            .WithCommand("-c", "ssl_key_file=" + CertificateKeyFilePath);
+    }
+
+    /// <summary>
+    /// Enables SSL for PostgreSql.
+    /// </summary>
+    /// <param name="certificateFilePath">The SSL certificate file.</param>
+    /// <param name="certificateKeyFilePath">The SSL certificate private key file.</param>
+    /// <param name="caCertificateFilePath">The CA certificate file.</param>
+    /// <returns>A configured instance of <see cref="PostgreSqlBuilder" />.</returns>
+    public PostgreSqlBuilder WithSsl(string certificateFilePath, string certificateKeyFilePath, string caCertificateFilePath)
+    {
+        return WithSsl(certificateFilePath, certificateKeyFilePath)
+            .WithResourceMapping(new FileInfo(caCertificateFilePath), new FileInfo(CaCertificateFilePath), PostgresUid, PostgresGid, Unix.FileMode600)
+            .WithCommand("-c", "ssl_ca_file=" + CaCertificateFilePath);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Configurations/Unix.cs
+++ b/src/Testcontainers/Configurations/Unix.cs
@@ -11,6 +11,13 @@ namespace DotNet.Testcontainers.Configurations
   public sealed class Unix : IOperatingSystem
   {
     /// <summary>
+    /// Represents the Unix file mode 600, which grants read and write permissions to the user and no permissions to the group and others.
+    /// </summary>
+    public const UnixFileModes FileMode600 =
+      UnixFileModes.UserRead |
+      UnixFileModes.UserWrite;
+
+    /// <summary>
     /// Represents the Unix file mode 644, which grants read and write permissions to the user and read permissions to the group and others.
     /// </summary>
     public const UnixFileModes FileMode644 =

--- a/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
+++ b/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
@@ -114,8 +114,8 @@ public abstract class PostgreSqlContainerTest(PostgreSqlContainerTest.PostgreSql
     public class PostgreSqlSslVerifyCaFixture(IMessageSink messageSink)
         : PostgreSqlDefaultFixture(messageSink)
     {
-        protected override PostgreSqlBuilder Configure()
         // # --8<-- [start:PostgreSqlSslBuilder]
+        protected override PostgreSqlBuilder Configure()
             => base.Configure().WithSsl(ServerCertificateFilePath, ServerCertificateKeyFilePath, CaCertificateFilePath);
         // # --8<-- [end:PostgreSqlSslBuilder]
 

--- a/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
+++ b/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
@@ -146,7 +146,7 @@ public abstract class PostgreSqlContainerTest(PostgreSqlContainerTest.PostgreSql
             {
                 var connectionStringBuilder = new NpgsqlConnectionStringBuilder(base.ConnectionString);
                 // # --8<-- [start:PostgreSqlSslVerifyFull]
-                // Npgsql checks VerifyFull against DNS SANs, so it's necessary to use "localhost" instead of
+                // Npgsql checks VerifyFull against DNS SANs, it's necessary to use "localhost" instead of
                 // the IP address. Testcontainers defaults to using the IP because of an old Docker bug
                 // with IPv4/IPv6 port mapping, where "localhost" might resolve to a different public port.
                 connectionStringBuilder.Host = "localhost";

--- a/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
+++ b/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
@@ -2,6 +2,12 @@ namespace Testcontainers.PostgreSql;
 
 public abstract class PostgreSqlContainerTest(PostgreSqlContainerTest.PostgreSqlDefaultFixture fixture)
 {
+    private static readonly string ServerCertificateFilePath = Certificates.Instance.GetFilePath("server", "server.crt");
+
+    private static readonly string ServerCertificateKeyFilePath = Certificates.Instance.GetFilePath("server", "server.key");
+
+    private static readonly string CaCertificateFilePath = Certificates.Instance.GetFilePath("ca", "ca.crt");
+
     // # --8<-- [start:UsePostgreSqlContainer]
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
@@ -86,10 +92,89 @@ public abstract class PostgreSqlContainerTest(PostgreSqlContainerTest.PostgreSql
     }
 
     [UsedImplicitly]
+    public class PostgreSqlSslRequireFixture(IMessageSink messageSink)
+        : PostgreSqlDefaultFixture(messageSink)
+    {
+        protected override PostgreSqlBuilder Configure()
+            => base.Configure().WithSsl(ServerCertificateFilePath, ServerCertificateKeyFilePath);
+
+        public override string ConnectionString
+        {
+            get
+            {
+                var connectionStringBuilder = new NpgsqlConnectionStringBuilder(base.ConnectionString);
+                connectionStringBuilder.TrustServerCertificate = true;
+                connectionStringBuilder.SslMode = SslMode.Require;
+                return connectionStringBuilder.ConnectionString;
+            }
+        }
+    }
+
+    [UsedImplicitly]
+    public class PostgreSqlSslVerifyCaFixture(IMessageSink messageSink)
+        : PostgreSqlDefaultFixture(messageSink)
+    {
+        protected override PostgreSqlBuilder Configure()
+        // # --8<-- [start:PostgreSqlSslBuilder]
+            => base.Configure().WithSsl(ServerCertificateFilePath, ServerCertificateKeyFilePath, CaCertificateFilePath);
+        // # --8<-- [end:PostgreSqlSslBuilder]
+
+        public override string ConnectionString
+        {
+            get
+            {
+                // # --8<-- [start:PostgreSqlSslConnectionString]
+                var connectionStringBuilder = new NpgsqlConnectionStringBuilder(base.ConnectionString);
+                connectionStringBuilder.SslMode = SslMode.VerifyCA;
+                connectionStringBuilder.RootCertificate = CaCertificateFilePath;
+                return connectionStringBuilder.ConnectionString;
+                // # --8<-- [end:PostgreSqlSslConnectionString]
+            }
+        }
+    }
+
+    [UsedImplicitly]
+    public class PostgreSqlSslVerifyFullFixture(IMessageSink messageSink)
+        : PostgreSqlDefaultFixture(messageSink)
+    {
+        protected override PostgreSqlBuilder Configure()
+            => base.Configure().WithSsl(ServerCertificateFilePath, ServerCertificateKeyFilePath, CaCertificateFilePath);
+
+        public override string ConnectionString
+        {
+            get
+            {
+                var connectionStringBuilder = new NpgsqlConnectionStringBuilder(base.ConnectionString);
+                // # --8<-- [start:PostgreSqlSslVerifyFull]
+                // Npgsql checks VerifyFull against DNS SANs, so it's necessary to use "localhost" instead of
+                // the IP address. Testcontainers defaults to using the IP because of an old Docker bug
+                // with IPv4/IPv6 port mapping, where "localhost" might resolve to a different public port.
+                connectionStringBuilder.Host = "localhost";
+                connectionStringBuilder.SslMode = SslMode.VerifyFull;
+                // # --8<-- [end:PostgreSqlSslVerifyFull]
+                connectionStringBuilder.RootCertificate = CaCertificateFilePath;
+                return connectionStringBuilder.ConnectionString;
+            }
+        }
+    }
+
+    [UsedImplicitly]
     public sealed class PostgreSqlDefaultConfiguration(PostgreSqlDefaultFixture fixture)
         : PostgreSqlContainerTest(fixture), IClassFixture<PostgreSqlDefaultFixture>;
 
     [UsedImplicitly]
     public sealed class PostgreSqlWaitForDatabaseConfiguration(PostgreSqlWaitForDatabaseFixture fixture)
         : PostgreSqlContainerTest(fixture), IClassFixture<PostgreSqlWaitForDatabaseFixture>;
+
+    [UsedImplicitly]
+    public sealed class PostgreSqlSslRequireConfiguration(PostgreSqlSslRequireFixture fixture)
+        : PostgreSqlContainerTest(fixture), IClassFixture<PostgreSqlSslRequireFixture>;
+
+    [UsedImplicitly]
+    public sealed class PostgreSqlSslVerifyCaConfiguration(PostgreSqlSslVerifyCaFixture fixture)
+        : PostgreSqlContainerTest(fixture), IClassFixture<PostgreSqlSslVerifyCaFixture>;
+
+    [UsedImplicitly]
+    public sealed class PostgreSqlSslVerifyFullConfiguration(PostgreSqlSslVerifyFullFixture fixture)
+        : PostgreSqlContainerTest(fixture), IClassFixture<PostgreSqlSslVerifyFullFixture>;
 }


### PR DESCRIPTION
Includes:
- A new example demonstrating the use of the `WithSSLSettings` API for PostgreSQL with SSL/TLS.
- SSL configuration options, server-side and mutual TLS examples.
- Tests to validate SSL container setup and secure connection handling in PostgreSQL.

## What does this PR do?
deliver extra ssl cinfig for dotnet API 

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, etc.
-->

## Why is it important?
Go module had [this](https://github.com/testcontainers/testcontainers-go/blob/103149723ce3bed578c88ab84181d0a00d532b18/modules/postgres/postgres.go#L222) , better to have it in dotnet too
<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSL/TLS support for PostgreSQL containers with certificate-based authentication and optional CA validation.

* **Documentation**
  * Added guide on enabling TLS, configuring SslMode, and guidance for VerifyFull/DNS SANs.

* **Tests**
  * Added SSL test scenarios covering Require, VerifyCA, and VerifyFull connection modes.

* **Chores**
  * Updated CI workflow Docker API configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->