### PR TITLE
feat: Resolve Dockerfile ARGs pulling base images

### DIFF
--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -371,7 +371,12 @@ namespace DotNet.Testcontainers.Clients
 
       if (configuration.ImageBuildPolicy(cachedImage))
       {
-        var dockerfileArchive = new DockerfileArchive(configuration.DockerfileDirectory, configuration.Dockerfile, configuration.Image, _logger);
+        var dockerfileArchive = new DockerfileArchive(
+          configuration.DockerfileDirectory,
+          configuration.Dockerfile,
+          configuration.Image,
+          configuration.BuildArguments,
+          _logger);
 
         var baseImages = dockerfileArchive.GetBaseImages().ToArray();
 

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -39,7 +39,7 @@ namespace DotNet.Testcontainers.Images
     /// <param name="dockerfileDirectory">Directory to Docker configuration files.</param>
     /// <param name="dockerfile">Name of the Dockerfile, which is necessary to start the Docker build.</param>
     /// <param name="image">Docker image information to create the tar archive for.</param>
-    /// <param name="buildArguments"></param>
+    /// <param name="buildArguments">Docker build arguments.</param>
     /// <param name="logger">The logger.</param>
     /// <exception cref="ArgumentException">Thrown when the Dockerfile directory does not exist or the directory does not contain a Dockerfile.</exception>
     public DockerfileArchive(
@@ -63,7 +63,7 @@ namespace DotNet.Testcontainers.Images
     /// <param name="dockerfileDirectory">Directory to Docker configuration files.</param>
     /// <param name="dockerfile">Name of the Dockerfile, which is necessary to start the Docker build.</param>
     /// <param name="image">Docker image information to create the tar archive for.</param>
-    /// <param name="buildArguments"></param>
+    /// <param name="buildArguments">Docker build arguments.</param>
     /// <param name="logger">The logger.</param>
     /// <exception cref="ArgumentException">Thrown when the Dockerfile directory does not exist or the directory does not contain a Dockerfile.</exception>
     public DockerfileArchive(
@@ -248,7 +248,7 @@ namespace DotNet.Testcontainers.Images
 
     /// <summary>
     /// Replaces placeholders in the Dockerfile <c>FROM</c> image string with the values
-    /// provided in <paramref name="variables"/>. Each placeholder is replaced with the
+    /// provided in <paramref name="variables" />. Each placeholder is replaced with the
     /// corresponding build argument if present; otherwise, the default value in the
     /// Dockerfile is preserved.
     /// </summary>

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -17,13 +17,21 @@ namespace DotNet.Testcontainers.Images
   /// </summary>
   internal sealed class DockerfileArchive : ITarArchive
   {
-    private static readonly Regex FromLinePattern = new Regex("FROM (?<arg>--\\S+\\s)*(?<image>\\S+).*", RegexOptions.None, TimeSpan.FromSeconds(1));
+    private const RegexOptions DefaultRegexOptions = RegexOptions.Compiled | RegexOptions.IgnoreCase;
+
+    private static readonly Regex ArgLinePattern = new Regex("ARG (?<name>[A-Za-z_][A-Za-z0-9_]*)=(?<value>\\S+)", DefaultRegexOptions, TimeSpan.FromSeconds(1));
+
+    private static readonly Regex FromLinePattern = new Regex("FROM (?<arg>--\\S+\\s)*(?<image>\\S+).*", DefaultRegexOptions, TimeSpan.FromSeconds(1));
+
+    private static readonly Regex VariablePattern = new Regex("\\$(\\{(?<name>[A-Za-z_][A-Za-z0-9_]*)\\}|(?<name>[A-Za-z_][A-Za-z0-9_]*))", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
     private readonly DirectoryInfo _dockerfileDirectory;
 
     private readonly FileInfo _dockerfile;
 
     private readonly IImage _image;
+
+    private readonly IReadOnlyDictionary<string, string> _buildArguments;
 
     private readonly ILogger _logger;
 
@@ -33,10 +41,21 @@ namespace DotNet.Testcontainers.Images
     /// <param name="dockerfileDirectory">Directory to Docker configuration files.</param>
     /// <param name="dockerfile">Name of the Dockerfile, which is necessary to start the Docker build.</param>
     /// <param name="image">Docker image information to create the tar archive for.</param>
+    /// <param name="buildArguments"></param>
     /// <param name="logger">The logger.</param>
     /// <exception cref="ArgumentException">Thrown when the Dockerfile directory does not exist or the directory does not contain a Dockerfile.</exception>
-    public DockerfileArchive(string dockerfileDirectory, string dockerfile, IImage image, ILogger logger)
-      : this(new DirectoryInfo(dockerfileDirectory), new FileInfo(dockerfile), image, logger)
+    public DockerfileArchive(
+      string dockerfileDirectory,
+      string dockerfile,
+      IImage image,
+      IReadOnlyDictionary<string, string> buildArguments,
+      ILogger logger)
+      : this(
+        new DirectoryInfo(dockerfileDirectory),
+        new FileInfo(dockerfile),
+        image,
+        buildArguments,
+        logger)
     {
     }
 
@@ -46,9 +65,15 @@ namespace DotNet.Testcontainers.Images
     /// <param name="dockerfileDirectory">Directory to Docker configuration files.</param>
     /// <param name="dockerfile">Name of the Dockerfile, which is necessary to start the Docker build.</param>
     /// <param name="image">Docker image information to create the tar archive for.</param>
+    /// <param name="buildArguments"></param>
     /// <param name="logger">The logger.</param>
     /// <exception cref="ArgumentException">Thrown when the Dockerfile directory does not exist or the directory does not contain a Dockerfile.</exception>
-    public DockerfileArchive(DirectoryInfo dockerfileDirectory, FileInfo dockerfile, IImage image, ILogger logger)
+    public DockerfileArchive(
+      DirectoryInfo dockerfileDirectory,
+      FileInfo dockerfile,
+      IImage image,
+      IReadOnlyDictionary<string, string> buildArguments,
+      ILogger logger)
     {
       if (!dockerfileDirectory.Exists)
       {
@@ -63,6 +88,7 @@ namespace DotNet.Testcontainers.Images
       _dockerfileDirectory = dockerfileDirectory;
       _dockerfile = dockerfile;
       _image = image;
+      _buildArguments = buildArguments;
       _logger = logger;
     }
 
@@ -83,15 +109,36 @@ namespace DotNet.Testcontainers.Images
     {
       const string imageGroup = "image";
 
+      const string nameGroup = "name";
+
+      const string valueGroup = "value";
+
       var lines = File.ReadAllLines(Path.Combine(_dockerfileDirectory.FullName, _dockerfile.ToString()))
         .Select(line => line.Trim())
         .Where(line => !string.IsNullOrEmpty(line))
         .Where(line => !line.StartsWith("#", StringComparison.Ordinal))
+        .ToArray();
+
+      var argMatches = lines
+        .Select(line => ArgLinePattern.Match(line))
+        .Where(match => match.Success)
+        .ToArray();
+
+      var fromMatches = lines
         .Select(line => FromLinePattern.Match(line))
         .Where(match => match.Success)
         .ToArray();
 
-      var stages = lines
+      var args = argMatches
+        .ToDictionary(match => match.Groups[nameGroup].Value, match => match.Groups[valueGroup].Value);
+
+      // Overwrite the default value using the configuration provided by the builder.
+      foreach (var buildArgument in _buildArguments)
+      {
+        args[buildArgument.Key] = buildArgument.Value;
+      }
+
+      var stages = fromMatches
         .Select(line => line.Value)
         .Select(line => line.Split(new[] { " AS ", " As ", " aS ", " as " }, StringSplitOptions.RemoveEmptyEntries))
         .Where(substrings => substrings.Length > 1)
@@ -99,12 +146,10 @@ namespace DotNet.Testcontainers.Images
         .Distinct()
         .ToArray();
 
-      var images = lines
+      var images = fromMatches
         .Select(match => match.Groups[imageGroup])
         .Select(match => match.Value)
-        // Until now, we are unable to resolve variables within Dockerfiles. Ignore base
-        // images that utilize variables. Expect them to exist on the host.
-        .Where(line => !line.Contains('$'))
+        .Select(line => ReplaceVariables(line, args))
         .Where(line => !line.Any(char.IsUpper))
         .Where(value => !stages.Contains(value))
         .Distinct()
@@ -204,6 +249,31 @@ namespace DotNet.Testcontainers.Images
       // is not available.
       _ = filePath;
       return (int)Unix.FileMode755;
+    }
+
+    /// <summary>
+    /// Replaces placeholders in the Dockerfile <c>FROM</c> image string with the values
+    /// provided in <paramref name="variables"/>. Each placeholder is replaced with the
+    /// corresponding build argument if present; otherwise, the default value in the
+    /// Dockerfile is preserved.
+    /// </summary>
+    /// <param name="image">The image string from a Dockerfile <c>FROM</c> statement.</param>
+    /// <param name="variables">A dictionary containing variable names as keys and their replacement values as values.</param>
+    /// <returns>A new image string where placeholders are replaced with their corresponding values.</returns>
+    private static string ReplaceVariables(string image, IDictionary<string, string> variables)
+    {
+      const string nameGroup = "name";
+
+      if (variables.Count == 0)
+      {
+        return image;
+      }
+
+      return VariablePattern.Replace(image, match =>
+      {
+        var name = match.Groups[nameGroup].Value;
+        return variables.TryGetValue(name, out var value) ? value : match.Value;
+      });
     }
   }
 }

--- a/tests/Testcontainers.Tests/Assets/pullBaseImages/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/pullBaseImages/Dockerfile
@@ -1,15 +1,15 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
-FROM $REPO:6.0.21-jammy-amd64
-FROM ${REPO}:6.0.21-jammy-amd64
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
-FROM mcr.microsoft.com/dotnet/runtime:6.0 AS runtime
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/runtime:8.0 AS runtime
 FROM build
 FROM build AS publish
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.22-jammy-amd64
+FROM $REPO:8.0-jammy
+FROM ${REPO}:8.0-noble
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
 
 # https://github.com/testcontainers/testcontainers-dotnet/issues/993.
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:6.0.23-jammy-amd64
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0
 
 # https://github.com/testcontainers/testcontainers-dotnet/issues/1030.
-FROM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION_6_0 AS build_sdk_6_0
-FROM build_sdk_6_0 AS publish_sdk_6_0
+FROM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION_8_0 AS build_sdk_8_0
+FROM build_sdk_8_0 AS publish_sdk_8_0

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -2,6 +2,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 {
   using System;
   using System.Collections.Generic;
+  using System.Collections.ObjectModel;
   using System.IO;
   using System.Linq;
   using System.Text;
@@ -19,19 +20,30 @@ namespace DotNet.Testcontainers.Tests.Unit
     public void DockerfileArchiveGetBaseImages()
     {
       // Given
+      var expected = new[]
+      {
+        "mcr.microsoft.com/dotnet/sdk:8.0",
+        "mcr.microsoft.com/dotnet/runtime:8.0",
+        "mcr.microsoft.com/dotnet/aspnet:8.0-jammy",
+        "mcr.microsoft.com/dotnet/aspnet:8.0-noble",
+        "mcr.microsoft.com/dotnet/aspnet:8.0-alpine",
+        "mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0",
+        "mcr.microsoft.com/dotnet/sdk:8.0.414",
+      };
+
       IImage image = new DockerImage("localhost/testcontainers", Guid.NewGuid().ToString("D"), string.Empty);
 
-      var dockerfileArchive = new DockerfileArchive("Assets/pullBaseImages/", "Dockerfile", image, NullLogger.Instance);
+      // The Dockerfile does not contain a default value.
+      var buildArguments = new Dictionary<string, string>();
+      buildArguments.Add("SDK_VERSION_8_0", "8.0.414");
+
+      var dockerfileArchive = new DockerfileArchive("Assets/pullBaseImages/", "Dockerfile", image, buildArguments, NullLogger.Instance);
 
       // When
-      var baseImages = dockerfileArchive.GetBaseImages().ToArray();
+      var actual = dockerfileArchive.GetBaseImages();
 
       // Then
-      Assert.Equal(4, baseImages.Length);
-      Assert.Contains(baseImages, item => "mcr.microsoft.com/dotnet/sdk:6.0".Equals(item.FullName));
-      Assert.Contains(baseImages, item => "mcr.microsoft.com/dotnet/runtime:6.0".Equals(item.FullName));
-      Assert.Contains(baseImages, item => "mcr.microsoft.com/dotnet/aspnet:6.0.22-jammy-amd64".Equals(item.FullName));
-      Assert.Contains(baseImages, item => "mcr.microsoft.com/dotnet/aspnet:6.0.23-jammy-amd64".Equals(item.FullName));
+      Assert.Equal(expected, actual.Select(baseImage => baseImage.FullName));
     }
 
     [Fact]
@@ -44,7 +56,9 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       var actual = new SortedSet<string>();
 
-      var dockerfileArchive = new DockerfileArchive("Assets/", "Dockerfile", image, NullLogger.Instance);
+      var buildArguments = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
+
+      var dockerfileArchive = new DockerfileArchive("Assets/", "Dockerfile", image, buildArguments, NullLogger.Instance);
 
       var dockerfileArchiveFilePath = await dockerfileArchive.Tar(TestContext.Current.CancellationToken)
         .ConfigureAwait(true);


### PR DESCRIPTION
## What does this PR do?

This PR extracts `ARG` statements from the Dockerfile and replaces variables in `FROM` statements with their values to identify all included base images.

## Why is it important?

When Testcontainers for .NET builds an image using `ImageFromDockerfileBuilder`, it needs to pre-pull the base images referenced in the Dockerfile. Previously, it didn't handle `FROM` statements with `ARG` variables, these were skipped. This PR fixes that by resolving `ARG` statements, using the Dockerfile's default values or any build arguments that override them.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #980

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
