### PR TITLE
feat: Add `WithTarget(string)` to image builder

### DIFF
--- a/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
+++ b/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
@@ -54,6 +54,15 @@ namespace DotNet.Testcontainers.Builders
     TBuilderEntity WithDockerfileDirectory(CommonDirectoryPath commonDirectoryPath, string dockerfileDirectory);
 
     /// <summary>
+    /// Sets the target build stage for the Docker image, allowing partial builds for
+    /// multi-stage Dockerfiles.
+    /// </summary>
+    /// <param name="target">The target build stage to use for the image build.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
+    TBuilderEntity WithTarget(string target);
+
+    /// <summary>
     /// Sets the image build policy.
     /// </summary>
     /// <param name="imageBuildPolicy">The image build policy.</param>

--- a/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
@@ -84,6 +84,12 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
+    public ImageFromDockerfileBuilder WithTarget(string target)
+    {
+      return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(target: target));
+    }
+
+    /// <inheritdoc />
     public ImageFromDockerfileBuilder WithImageBuildPolicy(Func<ImageInspectResponse, bool> imageBuildPolicy)
     {
       return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(imageBuildPolicy: imageBuildPolicy));

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -98,6 +98,7 @@ namespace DotNet.Testcontainers.Clients
       var buildParameters = new ImageBuildParameters
       {
         Dockerfile = configuration.Dockerfile,
+        Target = configuration.Target,
         Tags = new List<string> { image.FullName },
         BuildArgs = configuration.BuildArguments.ToDictionary(item => item.Key, item => item.Value),
         Labels = configuration.Labels.ToDictionary(item => item.Key, item => item.Value),

--- a/src/Testcontainers/Clients/TraceProgress.cs
+++ b/src/Testcontainers/Clients/TraceProgress.cs
@@ -19,22 +19,22 @@ namespace DotNet.Testcontainers.Clients
 
       if (!string.IsNullOrWhiteSpace(value.Status))
       {
-        _logger.LogDebug(value.Status);
+        _logger.LogDebug(value.Status.TrimEnd());
       }
 
       if (!string.IsNullOrWhiteSpace(value.Stream))
       {
-        _logger.LogDebug(value.Stream);
+        _logger.LogDebug(value.Stream.TrimEnd());
       }
 
       if (!string.IsNullOrWhiteSpace(value.ProgressMessage))
       {
-        _logger.LogDebug(value.ProgressMessage);
+        _logger.LogDebug(value.ProgressMessage.TrimEnd());
       }
 
       if (!string.IsNullOrWhiteSpace(value.ErrorMessage))
       {
-        _logger.LogError(value.ErrorMessage);
+        _logger.LogError(value.ErrorMessage.TrimEnd());
       }
 
 #pragma warning restore CA1848, CA2254

--- a/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
@@ -28,6 +28,11 @@ namespace DotNet.Testcontainers.Configurations
     string DockerfileDirectory { get; }
 
     /// <summary>
+    /// Gets the target.
+    /// </summary>
+    string Target { get; }
+
+    /// <summary>
     /// Gets the image.
     /// </summary>
     IImage Image { get; }

--- a/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
@@ -17,6 +17,7 @@ namespace DotNet.Testcontainers.Configurations
     /// </summary>
     /// <param name="dockerfile">The Dockerfile.</param>
     /// <param name="dockerfileDirectory">The Dockerfile directory.</param>
+    /// <param name="target">The target.</param>
     /// <param name="image">The image.</param>
     /// <param name="imageBuildPolicy">The image build policy.</param>
     /// <param name="buildArguments">A list of build arguments.</param>
@@ -24,6 +25,7 @@ namespace DotNet.Testcontainers.Configurations
     public ImageFromDockerfileConfiguration(
       string dockerfile = null,
       string dockerfileDirectory = null,
+      string target = null,
       IImage image = null,
       Func<ImageInspectResponse, bool> imageBuildPolicy = null,
       IReadOnlyDictionary<string, string> buildArguments = null,
@@ -31,6 +33,7 @@ namespace DotNet.Testcontainers.Configurations
     {
       Dockerfile = dockerfile;
       DockerfileDirectory = dockerfileDirectory;
+      Target = target;
       Image = image;
       ImageBuildPolicy = imageBuildPolicy;
       BuildArguments = buildArguments;
@@ -65,6 +68,7 @@ namespace DotNet.Testcontainers.Configurations
     {
       Dockerfile = BuildConfiguration.Combine(oldValue.Dockerfile, newValue.Dockerfile);
       DockerfileDirectory = BuildConfiguration.Combine(oldValue.DockerfileDirectory, newValue.DockerfileDirectory);
+      Target = BuildConfiguration.Combine(oldValue.Target, newValue.Target);
       Image = BuildConfiguration.Combine(oldValue.Image, newValue.Image);
       ImageBuildPolicy = BuildConfiguration.Combine(oldValue.ImageBuildPolicy, newValue.ImageBuildPolicy);
       BuildArguments = BuildConfiguration.Combine(oldValue.BuildArguments, newValue.BuildArguments);
@@ -82,6 +86,10 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     [JsonIgnore]
     public string DockerfileDirectory { get; }
+
+    /// <inheritdoc />
+    [JsonIgnore]
+    public string Target { get; }
 
     /// <inheritdoc />
     [JsonIgnore]

--- a/tests/Testcontainers.Tests/Assets/.dockerignore
+++ b/tests/Testcontainers.Tests/Assets/.dockerignore
@@ -4,4 +4,5 @@ credsStore
 healthWaitStrategy
 pullBaseImages
 scratch
+target
 **/*.md

--- a/tests/Testcontainers.Tests/Assets/target/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/target/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch AS base
+FROM base AS build
+FROM build AS final


### PR DESCRIPTION
## What does this PR do?

The PR extends the `IImageFromDockerfileBuilder` interface with a new `WithTarget(string)` method, allowing developers to specify the stage up to which the image is built.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1475

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
