### PR TITLE
fix(Keycloak): Wait until user created

### DIFF
--- a/src/Testcontainers.Keycloak/KeycloakBuilder.cs
+++ b/src/Testcontainers.Keycloak/KeycloakBuilder.cs
@@ -89,6 +89,7 @@ public sealed class KeycloakBuilder : ContainerBuilder<KeycloakBuilder, Keycloak
         var isMajorVersionGreaterOrEqual25 = image.MatchLatestOrNightly() || image.MatchVersion(predicate);
 
         var waitStrategy = Wait.ForUnixContainer()
+            .UntilMessageIsLogged("Added user '[^']+' to realm '[^']+'|Created temporary admin user with username \\S+")
             .UntilHttpRequestIsSucceeded(request =>
                 request.ForPath("/health/ready").ForPort(isMajorVersionGreaterOrEqual25 ? KeycloakHealthPort : KeycloakPort));
 


### PR DESCRIPTION
## What does this PR do?

This PR adds another wait strategy to the Keycloak module. In addition to waiting for the health API, the module now also waits until one of these log messages appears:

`Added user '[^']+' to realm '[^']+'|Created temporary admin user with username \S+`.

I ran the tests for a while in a GH Codespaces environment (which behaves more like our CI) and didn't run into any issues.

## Why is it important?

Our CI occasionally fails with stack traces that indicates Keycloak isn't fully ready to handle requests. It seems that the user setup wasn't complete, causing authentication against the instance to fail.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1533

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
