### PR TITLE
feat: Add Docker build context

### DIFF
--- a/docs/api/create_docker_image.md
+++ b/docs/api/create_docker_image.md
@@ -16,11 +16,19 @@ await futureImage.CreateAsync()
   .ConfigureAwait(false);
 ```
 
+To build a Docker image with Testcontainers, it's important to understand the build context. Testcontainers needs three things:
+
+1. **Docker build context**: The directory containing files Docker can use during the build
+2. **Dockerfile name**: The name of the Dockerfile to use
+3. **Dockerfile directory**: Where the Dockerfile is located
+
 !!!tip
 
-    The Dockerfile must be part of the build context, otherwise the build fails.
+    The build context is optional. If you don't specify one, it defaults to the Dockerfile directory.
 
-It is essential to take into account and comprehend the build context to enable Testcontainers to build the Docker image. Testcontainers generates a tarball that contains all the files and subdirectories within the build context. The tarball is passed to the Docker daemon to build the image. The tarball serves as the new root of the Dockerfile's content. Therefore, all paths must be relative to the new root. If your app or service follows to the following project structure, the build context is `/Users/testcontainers/WeatherForecast/`.
+Testcontainers creates a tarball with all files and subdirectorys in the build context, incl. the Dockerfile. This tarball is sent to the Docker daemon to build the image. The build context acts as the root for all file operations in the Dockerfile, so all paths (like `COPY` commands) must be relative to it.
+
+For example, if your project looks like this, the build context would be: `/Users/testcontainers/WeatherForecast/`.
 
     /
     └── Users/
@@ -61,6 +69,17 @@ RUN dotnet publish $SLN_FILE_PATH --configuration Release --framework net6.0 --o
 ENTRYPOINT ["dotnet", "/app/WeatherForecast.dll"]
 ```
 
+### Choosing the build context
+
+You can use `WithContextDirectory(string)` to set a build context separate from your Dockerfile. This is useful when the Dockerfile is in one directory but the files you want to include are in another.
+
+```csharp
+_ = new ImageFromDockerfileBuilder()
+  .WithContextDirectory("/path/to/build/context")
+  .WithDockerfile("Dockerfile")
+  .WithDockerfileDirectory("/path/to/dockerfile/directory");
+```
+
 ## Delete multi-stage intermediate layers
 
 A multi-stage Docker image build generates intermediate layers that serve as caches. Testcontainers' Resource Reaper is unable to automatically delete these layers after the test execution. The necessary label is not forwarded by the Docker image build. Testcontainers is unable to track the intermediate layers during the test. To delete the intermediate layers after the test execution, pass the Resource Reaper session to each stage.
@@ -92,8 +111,9 @@ _ = new ImageFromDockerfileBuilder()
 | `WithCleanUp`                 | Will remove the image automatically after all tests have been run.           |
 | `WithLabel`                   | Applies metadata to the image e.g. `-l`, `--label "testcontainers=awesome"`. |
 | `WithName`                    | Sets the image name e.g. `-t`, `--tag "testcontainers:0.1.0"`.               |
+| `WithContextDirectory`        | Sets the Docker build context directory.                                     |
 | `WithDockerfile`              | Sets the name of the `Dockerfile`.                                           |
-| `WithDockerfileDirectory`     | Sets the build context (directory path that contains the `Dockerfile`).      |
+| `WithDockerfileDirectory`     | Sets the directory path that contains the `Dockerfile`.                      |
 | `WithImageBuildPolicy`        | Specifies an image build policy to determine when an image is built.         |
 | `WithDeleteIfExists`          | Will remove the image if it already exists.                                  |
 | `WithBuildArgument`           | Sets build-time variables e.g `--build-arg "MAGIC_NUMBER=42"`.               |

--- a/docs/api/create_docker_image.md
+++ b/docs/api/create_docker_image.md
@@ -69,7 +69,7 @@ RUN dotnet publish $SLN_FILE_PATH --configuration Release --framework net6.0 --o
 ENTRYPOINT ["dotnet", "/app/WeatherForecast.dll"]
 ```
 
-### Choosing the build context
+### Choosing a build context
 
 You can use `WithContextDirectory(string)` to set a build context separate from your Dockerfile. This is useful when the Dockerfile is in one directory but the files you want to include are in another.
 

--- a/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
+++ b/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
@@ -29,26 +29,38 @@ namespace DotNet.Testcontainers.Builders
     TBuilderEntity WithName(IImage image);
 
     /// <summary>
-    /// Sets the Dockerfile.
+    /// Sets the directory to use as the Docker build context.
+    /// This is the folder that Docker will use to resolve files referenced in the Dockerfile.
     /// </summary>
-    /// <param name="dockerfile">An absolute path or a name value within the Docker build context.</param>
+    /// <param name="contextDirectory">An absolute path or relative name of the directory to use as the Docker build context.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
+    TBuilderEntity WithContextDirectory(string contextDirectory);
+
+    /// <summary>
+    /// Sets the path to the Dockerfile to use for the build.
+    /// This can be an absolute path or a path relative to the Docker build context.
+    /// </summary>
+    /// <param name="dockerfile">The filename or path of the Dockerfile.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithDockerfile(string dockerfile);
 
     /// <summary>
-    /// Sets the Dockerfile directory.
+    /// Sets the directory containing the Dockerfile.
+    /// This is useful if the Dockerfile is not located in the build context root.
     /// </summary>
-    /// <param name="dockerfileDirectory">An absolute path or a name value to the Docker build context.</param>
+    /// <param name="dockerfileDirectory">An absolute path or relative path to the directory containing the Dockerfile.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithDockerfileDirectory(string dockerfileDirectory);
 
     /// <summary>
-    /// Sets the Dockerfile directory.
+    /// Sets the directory containing the Dockerfile.
+    /// This is useful if the Dockerfile is not located in the build context root.
     /// </summary>
     /// <param name="commonDirectoryPath">A common directory path that contains the Dockerfile directory.</param>
-    /// <param name="dockerfileDirectory">A relative path or a name value to the Docker build context.</param>
+    /// <param name="dockerfileDirectory">An absolute path or relative path to the directory containing the Dockerfile.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithDockerfileDirectory(CommonDirectoryPath commonDirectoryPath, string dockerfileDirectory);

--- a/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
+++ b/src/Testcontainers/Builders/IImageFromDockerfileBuilder`1.cs
@@ -30,7 +30,7 @@ namespace DotNet.Testcontainers.Builders
 
     /// <summary>
     /// Sets the directory to use as the Docker build context.
-    /// This is the folder that Docker will use to resolve files referenced in the Dockerfile.
+    /// This is the directory that Docker will use to resolve files referenced in the Dockerfile.
     /// </summary>
     /// <param name="contextDirectory">An absolute path or relative name of the directory to use as the Docker build context.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
@@ -39,7 +39,6 @@ namespace DotNet.Testcontainers.Builders
 
     /// <summary>
     /// Sets the path to the Dockerfile to use for the build.
-    /// This can be an absolute path or a path relative to the Docker build context.
     /// </summary>
     /// <param name="dockerfile">The filename or path of the Dockerfile.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
@@ -48,7 +47,6 @@ namespace DotNet.Testcontainers.Builders
 
     /// <summary>
     /// Sets the directory containing the Dockerfile.
-    /// This is useful if the Dockerfile is not located in the build context root.
     /// </summary>
     /// <param name="dockerfileDirectory">An absolute path or relative path to the directory containing the Dockerfile.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
@@ -57,7 +55,6 @@ namespace DotNet.Testcontainers.Builders
 
     /// <summary>
     /// Sets the directory containing the Dockerfile.
-    /// This is useful if the Dockerfile is not located in the build context root.
     /// </summary>
     /// <param name="commonDirectoryPath">A common directory path that contains the Dockerfile directory.</param>
     /// <param name="dockerfileDirectory">An absolute path or relative path to the directory containing the Dockerfile.</param>

--- a/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
@@ -64,6 +64,12 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
+    public ImageFromDockerfileBuilder WithContextDirectory(string contextDirectory)
+    {
+      return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(contextDirectory: contextDirectory));
+    }
+
+    /// <inheritdoc />
     public ImageFromDockerfileBuilder WithDockerfile(string dockerfile)
     {
       var dockerfileFilePath = Regex.Replace(dockerfile, "^\\.(\\/|\\\\)", string.Empty, RegexOptions.None, TimeSpan.FromSeconds(1));

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -372,6 +372,7 @@ namespace DotNet.Testcontainers.Clients
       if (configuration.ImageBuildPolicy(cachedImage))
       {
         var dockerfileArchive = new DockerfileArchive(
+          configuration.ContextDirectory,
           configuration.DockerfileDirectory,
           configuration.Dockerfile,
           configuration.Image,

--- a/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/IImageFromDockerfileConfiguration.cs
@@ -18,6 +18,11 @@ namespace DotNet.Testcontainers.Configurations
     bool? DeleteIfExists { get; }
 
     /// <summary>
+    /// Gets the context directory.
+    /// </summary>
+    string ContextDirectory { get; }
+
+    /// <summary>
     /// Gets the Dockerfile.
     /// </summary>
     string Dockerfile { get; }

--- a/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
+++ b/src/Testcontainers/Configurations/Images/ImageFromDockerfileConfiguration.cs
@@ -15,6 +15,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Initializes a new instance of the <see cref="ImageFromDockerfileConfiguration" /> class.
     /// </summary>
+    /// <param name="contextDirectory">The context directory.</param>
     /// <param name="dockerfile">The Dockerfile.</param>
     /// <param name="dockerfileDirectory">The Dockerfile directory.</param>
     /// <param name="target">The target.</param>
@@ -23,6 +24,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="buildArguments">A list of build arguments.</param>
     /// <param name="deleteIfExists">A value indicating whether Testcontainers removes an existing image or not.</param>
     public ImageFromDockerfileConfiguration(
+      string contextDirectory = null,
       string dockerfile = null,
       string dockerfileDirectory = null,
       string target = null,
@@ -31,6 +33,7 @@ namespace DotNet.Testcontainers.Configurations
       IReadOnlyDictionary<string, string> buildArguments = null,
       bool? deleteIfExists = null)
     {
+      ContextDirectory = contextDirectory;
       Dockerfile = dockerfile;
       DockerfileDirectory = dockerfileDirectory;
       Target = target;
@@ -66,6 +69,7 @@ namespace DotNet.Testcontainers.Configurations
     public ImageFromDockerfileConfiguration(IImageFromDockerfileConfiguration oldValue, IImageFromDockerfileConfiguration newValue)
       : base(oldValue, newValue)
     {
+      ContextDirectory = BuildConfiguration.Combine(oldValue.ContextDirectory, newValue.ContextDirectory);
       Dockerfile = BuildConfiguration.Combine(oldValue.Dockerfile, newValue.Dockerfile);
       DockerfileDirectory = BuildConfiguration.Combine(oldValue.DockerfileDirectory, newValue.DockerfileDirectory);
       Target = BuildConfiguration.Combine(oldValue.Target, newValue.Target);
@@ -78,6 +82,10 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     [JsonIgnore]
     public bool? DeleteIfExists { get; }
+
+    /// <inheritdoc />
+    [JsonIgnore]
+    public string ContextDirectory { get; }
 
     /// <inheritdoc />
     [JsonIgnore]

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -23,9 +23,13 @@ namespace DotNet.Testcontainers.Images
 
     private static readonly Regex VariablePattern = new Regex("\\$(\\{(?<name>[A-Za-z_][A-Za-z0-9_]*)\\}|(?<name>[A-Za-z_][A-Za-z0-9_]*))", RegexOptions.None, TimeSpan.FromSeconds(1));
 
+    private readonly DirectoryInfo _contextDirectory;
+
     private readonly DirectoryInfo _dockerfileDirectory;
 
     private readonly FileInfo _dockerfile;
+
+    private readonly FileInfo _dockerignore;
 
     private readonly IImage _image;
 
@@ -36,6 +40,7 @@ namespace DotNet.Testcontainers.Images
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerfileArchive" /> class.
     /// </summary>
+    /// <param name="contextDirectory"></param>
     /// <param name="dockerfileDirectory">Directory to Docker configuration files.</param>
     /// <param name="dockerfile">Name of the Dockerfile, which is necessary to start the Docker build.</param>
     /// <param name="image">Docker image information to create the tar archive for.</param>
@@ -43,14 +48,20 @@ namespace DotNet.Testcontainers.Images
     /// <param name="logger">The logger.</param>
     /// <exception cref="ArgumentException">Thrown when the Dockerfile directory does not exist or the directory does not contain a Dockerfile.</exception>
     public DockerfileArchive(
+      string contextDirectory,
       string dockerfileDirectory,
       string dockerfile,
       IImage image,
       IReadOnlyDictionary<string, string> buildArguments,
       ILogger logger)
       : this(
+        // The Docker build context wasn't originally supported. To stay backwards
+        // compatible, the argument is optional and can be null. If it isn't set,
+        // fall back to the Dockerfile directory.
+        new DirectoryInfo(contextDirectory),
         new DirectoryInfo(dockerfileDirectory),
-        new FileInfo(dockerfile),
+        new FileInfo(Path.Combine(dockerfileDirectory, dockerfile)),
+        new FileInfo(Path.Combine(dockerfileDirectory, dockerfile + ".dockerignore")),
         image,
         buildArguments,
         logger)
@@ -60,15 +71,19 @@ namespace DotNet.Testcontainers.Images
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerfileArchive" /> class.
     /// </summary>
+    /// <param name="contextDirectory"></param>
     /// <param name="dockerfileDirectory">Directory to Docker configuration files.</param>
     /// <param name="dockerfile">Name of the Dockerfile, which is necessary to start the Docker build.</param>
+    /// <param name="dockerignore"></param>
     /// <param name="image">Docker image information to create the tar archive for.</param>
     /// <param name="buildArguments">Docker build arguments.</param>
     /// <param name="logger">The logger.</param>
     /// <exception cref="ArgumentException">Thrown when the Dockerfile directory does not exist or the directory does not contain a Dockerfile.</exception>
-    public DockerfileArchive(
+    private DockerfileArchive(
+      DirectoryInfo contextDirectory,
       DirectoryInfo dockerfileDirectory,
       FileInfo dockerfile,
+      FileInfo dockerignore,
       IImage image,
       IReadOnlyDictionary<string, string> buildArguments,
       ILogger logger)
@@ -78,13 +93,15 @@ namespace DotNet.Testcontainers.Images
         throw new ArgumentException($"Directory '{dockerfileDirectory.FullName}' does not exist.");
       }
 
-      if (dockerfileDirectory.GetFiles(dockerfile.ToString(), SearchOption.TopDirectoryOnly).Length == 0)
+      if (!dockerfile.Exists)
       {
-        throw new ArgumentException($"{dockerfile} does not exist in '{dockerfileDirectory.FullName}'.");
+        throw new ArgumentException($"{dockerfile.Name} does not exist in '{dockerfileDirectory.FullName}'.");
       }
 
+      _contextDirectory = contextDirectory;
       _dockerfileDirectory = dockerfileDirectory;
       _dockerfile = dockerfile;
+      _dockerignore = dockerignore;
       _image = image;
       _buildArguments = buildArguments;
       _logger = logger;
@@ -111,7 +128,7 @@ namespace DotNet.Testcontainers.Images
 
       const string valueGroup = "value";
 
-      var lines = File.ReadAllLines(Path.Combine(_dockerfileDirectory.FullName, _dockerfile.ToString()))
+      var lines = File.ReadAllLines(_dockerfile.FullName)
         .Select(line => line.Trim())
         .Where(line => !string.IsNullOrEmpty(line))
         .Where(line => !line.StartsWith("#", StringComparison.Ordinal))
@@ -157,15 +174,15 @@ namespace DotNet.Testcontainers.Images
     /// <inheritdoc />
     public async Task<string> Tar(CancellationToken ct = default)
     {
-      var dockerfileDirectoryPath = Unix.Instance.NormalizePath(_dockerfileDirectory.FullName);
+      var dockerIgnoreFileName = _dockerignore.Exists ? _dockerignore.Name : ".dockerignore";
 
-      var dockerfileFilePath = Unix.Instance.NormalizePath(_dockerfile.ToString());
+      var dockerIgnoreFile = new DockerIgnoreFile(_dockerfileDirectory, dockerIgnoreFileName, _dockerfile.Name, _logger);
 
       var dockerfileArchiveFileName = Regex.Replace(_image.FullName, "[^a-zA-Z0-9]", "-", RegexOptions.None, TimeSpan.FromSeconds(1)).ToLowerInvariant();
 
       var dockerfileArchiveFilePath = Path.Combine(Path.GetTempPath(), $"{dockerfileArchiveFileName}.tar");
 
-      var dockerIgnoreFile = new DockerIgnoreFile(dockerfileDirectoryPath, ".dockerignore", dockerfileFilePath, _logger);
+      var baseDirectoryLength = _contextDirectory.FullName.TrimEnd(Path.DirectorySeparatorChar).Length + 1;
 
       using (var tarOutputFileStream = new FileStream(dockerfileArchiveFilePath, FileMode.Create, FileAccess.Write))
       {
@@ -173,43 +190,79 @@ namespace DotNet.Testcontainers.Images
         {
           tarOutputStream.IsStreamOwner = false;
 
-          foreach (var absoluteFilePath in GetFiles(dockerfileDirectoryPath))
+          foreach (var absoluteFilePath in GetFiles(_contextDirectory.FullName))
           {
             // SharpZipLib drops the root path: https://github.com/icsharpcode/SharpZipLib/pull/582.
-            var relativeFilePath = absoluteFilePath.Substring(dockerfileDirectoryPath.TrimEnd(Path.AltDirectorySeparatorChar).Length + 1);
+            var relativeFilePath = absoluteFilePath.Substring(baseDirectoryLength);
 
             if (dockerIgnoreFile.Denies(relativeFilePath))
             {
               continue;
             }
 
-            try
+            // If the build context already has a `Dockerfile` or `.dockerignore`, we
+            // need ignore them and instead use the ones from the specified Dockerfile
+            // directory, which might be different.
+            if (_dockerfile.Name.Equals(relativeFilePath, StringComparison.Ordinal))
             {
-              using (var inputStream = new FileStream(absoluteFilePath, FileMode.Open, FileAccess.Read))
-              {
-                var entry = TarEntry.CreateTarEntry(relativeFilePath);
-                entry.TarHeader.Size = inputStream.Length;
-                entry.TarHeader.Mode = GetUnixFileMode(absoluteFilePath);
-
-                await tarOutputStream.PutNextEntryAsync(entry, ct)
-                  .ConfigureAwait(false);
-
-                await inputStream.CopyToAsync(tarOutputStream, 81920, ct)
-                  .ConfigureAwait(false);
-
-                await tarOutputStream.CloseEntryAsync(ct)
-                  .ConfigureAwait(false);
-              }
+              continue;
             }
-            catch (IOException e)
+
+            if (_dockerignore.Name.Equals(relativeFilePath, StringComparison.Ordinal))
             {
-              throw new IOException("Cannot create Docker image tar archive.", e);
+              continue;
             }
+
+            await AddAsync(absoluteFilePath, relativeFilePath, tarOutputStream)
+              .ConfigureAwait(false);
           }
+
+          await AddAsync(_dockerfile.FullName, _dockerfile.Name, tarOutputStream)
+            .ConfigureAwait(false);
+
+          await AddAsync(_dockerignore.FullName, _dockerignore.Name, tarOutputStream)
+            .ConfigureAwait(false);
         }
       }
 
       return dockerfileArchiveFilePath;
+
+      async Task AddAsync(string absoluteFilePath, string relativeFilePath, TarOutputStream tarOutputStream)
+      {
+        const int bufferSize = 4096;
+
+        try
+        {
+          using (var stream = new FileStream(
+            absoluteFilePath,
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.Read,
+            bufferSize,
+            FileOptions.Asynchronous | FileOptions.SequentialScan))
+          {
+            var fileMode = GetUnixFileMode(absoluteFilePath);
+
+            var tarEntry = new TarEntry(new TarHeader());
+            tarEntry.TarHeader.Name = relativeFilePath;
+            tarEntry.TarHeader.Mode = fileMode;
+            tarEntry.Size = stream.Length;
+
+            await tarOutputStream.PutNextEntryAsync(tarEntry, ct)
+              .ConfigureAwait(false);
+
+            await stream.CopyToAsync(tarOutputStream, bufferSize, ct)
+              .ConfigureAwait(false);
+
+            await tarOutputStream.CloseEntryAsync(ct)
+              .ConfigureAwait(false);
+          }
+        }
+        catch (IOException e)
+        {
+          throw new IOException("Cannot create Docker image tar archive.", e);
+        }
+      }
     }
 
     /// <summary>

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -11,6 +11,7 @@ namespace DotNet.Testcontainers.Images
   using DotNet.Testcontainers.Configurations;
   using ICSharpCode.SharpZipLib.Tar;
   using Microsoft.Extensions.Logging;
+  using JetBrains.Annotations;
 
   /// <summary>
   /// Generates a tar archive with Docker configuration files. The tar archive can be used to build a Docker image.
@@ -48,17 +49,17 @@ namespace DotNet.Testcontainers.Images
     /// <param name="logger">The logger.</param>
     /// <exception cref="ArgumentException">Thrown when the Dockerfile directory does not exist or the directory does not contain a Dockerfile.</exception>
     public DockerfileArchive(
-      string contextDirectory,
-      string dockerfileDirectory,
-      string dockerfile,
-      IImage image,
-      IReadOnlyDictionary<string, string> buildArguments,
-      ILogger logger)
+      [CanBeNull] string contextDirectory,
+      [NotNull] string dockerfileDirectory,
+      [NotNull] string dockerfile,
+      [NotNull] IImage image,
+      [NotNull] IReadOnlyDictionary<string, string> buildArguments,
+      [NotNull] ILogger logger)
       : this(
         // The Docker build context wasn't originally supported. To stay backwards
         // compatible, the argument is optional and can be null. If it isn't set,
         // fall back to the Dockerfile directory.
-        new DirectoryInfo(contextDirectory),
+        new DirectoryInfo(contextDirectory ?? dockerfileDirectory),
         new DirectoryInfo(dockerfileDirectory),
         new FileInfo(Path.Combine(dockerfileDirectory, dockerfile)),
         new FileInfo(Path.Combine(dockerfileDirectory, dockerfile + ".dockerignore")),
@@ -80,13 +81,13 @@ namespace DotNet.Testcontainers.Images
     /// <param name="logger">The logger.</param>
     /// <exception cref="ArgumentException">Thrown when the Dockerfile directory does not exist or the directory does not contain a Dockerfile.</exception>
     private DockerfileArchive(
-      DirectoryInfo contextDirectory,
-      DirectoryInfo dockerfileDirectory,
-      FileInfo dockerfile,
-      FileInfo dockerignore,
-      IImage image,
-      IReadOnlyDictionary<string, string> buildArguments,
-      ILogger logger)
+      [NotNull] DirectoryInfo contextDirectory,
+      [NotNull] DirectoryInfo dockerfileDirectory,
+      [NotNull] FileInfo dockerfile,
+      [NotNull] FileInfo dockerignore,
+      [NotNull] IImage image,
+      [NotNull] IReadOnlyDictionary<string, string> buildArguments,
+      [NotNull] ILogger logger)
     {
       if (!dockerfileDirectory.Exists)
       {
@@ -260,11 +261,11 @@ namespace DotNet.Testcontainers.Images
     /// <summary>
     /// Gets all accepted Docker archive files.
     /// </summary>
-    /// <param name="directory">Directory to Docker configuration files.</param>
+    /// <param name="path">Directory to Docker configuration files.</param>
     /// <returns>Returns a list with all accepted Docker archive files.</returns>
-    private static IEnumerable<string> GetFiles(string directory)
+    private static IEnumerable<string> GetFiles(string path)
     {
-      return Directory.EnumerateFiles(directory, "*", SearchOption.AllDirectories)
+      return Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories)
         .AsParallel()
         .Select(Path.GetFullPath)
         .Select(Unix.Instance.NormalizePath)

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -40,7 +40,7 @@ namespace DotNet.Testcontainers.Images
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerfileArchive" /> class.
     /// </summary>
-    /// <param name="contextDirectory"></param>
+    /// <param name="contextDirectory">Directory to Docker build context.</param>
     /// <param name="dockerfileDirectory">Directory to Docker configuration files.</param>
     /// <param name="dockerfile">Name of the Dockerfile, which is necessary to start the Docker build.</param>
     /// <param name="image">Docker image information to create the tar archive for.</param>
@@ -71,10 +71,10 @@ namespace DotNet.Testcontainers.Images
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerfileArchive" /> class.
     /// </summary>
-    /// <param name="contextDirectory"></param>
+    /// <param name="contextDirectory">Directory to Docker build context.</param>
     /// <param name="dockerfileDirectory">Directory to Docker configuration files.</param>
     /// <param name="dockerfile">Name of the Dockerfile, which is necessary to start the Docker build.</param>
-    /// <param name="dockerignore"></param>
+    /// <param name="dockerignore">Name of the .dockerignore file.</param>
     /// <param name="image">Docker image information to create the tar archive for.</param>
     /// <param name="buildArguments">Docker build arguments.</param>
     /// <param name="logger">The logger.</param>
@@ -200,15 +200,10 @@ namespace DotNet.Testcontainers.Images
               continue;
             }
 
-            // If the build context already has a `Dockerfile` or `.dockerignore`, we
-            // need ignore them and instead use the ones from the specified Dockerfile
-            // directory, which might be different.
+            // If the build context already has a `Dockerfile`, we need to ignore it and
+            // instead use the one from the specified Dockerfile directory, which might be
+            // different.
             if (_dockerfile.Name.Equals(relativeFilePath, StringComparison.Ordinal))
-            {
-              continue;
-            }
-
-            if (_dockerignore.Name.Equals(relativeFilePath, StringComparison.Ordinal))
             {
               continue;
             }
@@ -218,9 +213,6 @@ namespace DotNet.Testcontainers.Images
           }
 
           await AddAsync(_dockerfile.FullName, _dockerfile.Name, tarOutputStream)
-            .ConfigureAwait(false);
-
-          await AddAsync(_dockerignore.FullName, _dockerignore.Name, tarOutputStream)
             .ConfigureAwait(false);
         }
       }

--- a/tests/Testcontainers.Tests/Assets/.dockerignore
+++ b/tests/Testcontainers.Tests/Assets/.dockerignore
@@ -1,6 +1,7 @@
 Dockerfile
 credHelpers
 credsStore
+context
 healthWaitStrategy
 pullBaseImages
 scratch

--- a/tests/Testcontainers.Tests/Assets/context/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/context/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY docker-entrypoint.sh docker-entrypoint.sh

--- a/tests/Testcontainers.Tests/Unit/Images/BuildContextTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/BuildContextTest.cs
@@ -26,9 +26,9 @@ namespace DotNet.Testcontainers.Tests.Unit
     {
       // Given
       var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
+        .WithContextDirectory(_contextDirectory)
         .WithDockerfile("Dockerfile")
         .WithDockerfileDirectory("Assets/context/")
-        .WithContextDirectory(_contextDirectory)
         .Build();
 
       // When
@@ -47,9 +47,9 @@ namespace DotNet.Testcontainers.Tests.Unit
     {
       // Given
       var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
+        .WithContextDirectory(_contextDirectory)
         .WithDockerfile("Dockerfile")
         .WithDockerfileDirectory("Assets/context/")
-        .WithContextDirectory(_contextDirectory)
         .Build();
 
       // When

--- a/tests/Testcontainers.Tests/Unit/Images/BuildContextTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/BuildContextTest.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Tests.Unit
+namespace DotNet.Testcontainers.Tests.Unit
 {
   using System;
   using System.IO;

--- a/tests/Testcontainers.Tests/Unit/Images/BuildContextTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/BuildContextTest.cs
@@ -1,0 +1,63 @@
+﻿namespace DotNet.Testcontainers.Tests.Unit
+{
+  using System;
+  using System.IO;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Commons;
+  using Xunit;
+
+  public sealed class BuildContextTest : IDisposable
+  {
+    private readonly string _contextDirectory = Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"));
+
+    public BuildContextTest()
+    {
+      Directory.CreateDirectory(_contextDirectory);
+    }
+
+    public void Dispose()
+    {
+      Directory.Delete(_contextDirectory, true);
+    }
+
+    [Fact]
+    public async Task CreateImageShouldSucceedWhenContextContainsRequiredFiles()
+    {
+      // Given
+      var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
+        .WithDockerfile("Dockerfile")
+        .WithDockerfileDirectory("Assets/context/")
+        .WithContextDirectory(_contextDirectory)
+        .Build();
+
+      // When
+      await File.WriteAllBytesAsync(Path.Combine(_contextDirectory, "docker-entrypoint.sh"), Array.Empty<byte>(), TestContext.Current.CancellationToken)
+        .ConfigureAwait(true);
+
+      var exception = await Record.ExceptionAsync(() => imageFromDockerfileBuilder.CreateAsync(TestContext.Current.CancellationToken))
+        .ConfigureAwait(true);
+
+      // Then
+      Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task CreateImageShouldFailWhenContextDoesNotContainRequiredFiles()
+    {
+      // Given
+      var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
+        .WithDockerfile("Dockerfile")
+        .WithDockerfileDirectory("Assets/context/")
+        .WithContextDirectory(_contextDirectory)
+        .Build();
+
+      // When
+      var exception = await Record.ExceptionAsync(() => imageFromDockerfileBuilder.CreateAsync(TestContext.Current.CancellationToken))
+        .ConfigureAwait(true);
+
+      // Then
+      Assert.NotNull(exception);
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -38,7 +38,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var buildArguments = new Dictionary<string, string>();
       buildArguments.Add("SDK_VERSION_8_0", "8.0.414");
 
-      var dockerfileArchive = new DockerfileArchive("Assets/pullBaseImages/", "Dockerfile", image, buildArguments, NullLogger.Instance);
+      var dockerfileArchive = new DockerfileArchive(null, "Assets/pullBaseImages/", "Dockerfile", image, buildArguments, NullLogger.Instance);
 
       // When
       var actual = dockerfileArchive.GetBaseImages();
@@ -59,7 +59,7 @@ namespace DotNet.Testcontainers.Tests.Unit
 
       var buildArguments = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>());
 
-      var dockerfileArchive = new DockerfileArchive("Assets/", "Dockerfile", image, buildArguments, NullLogger.Instance);
+      var dockerfileArchive = new DockerfileArchive(null, "Assets/", "Dockerfile", image, buildArguments, NullLogger.Instance);
 
       var dockerfileArchiveFilePath = await dockerfileArchive.Tar(TestContext.Current.CancellationToken)
         .ConfigureAwait(true);
@@ -120,7 +120,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     {
       // Given
       var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
-        .WithDockerfileDirectory("Assets/scratch")
+        .WithDockerfileDirectory("Assets/scratch/")
         .Build();
 
       // When
@@ -177,7 +177,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var logger = new TestLogger();
 
       var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
-        .WithDockerfileDirectory("Assets/target")
+        .WithDockerfileDirectory("Assets/target/")
         .WithTarget("build")
         .WithLogger(logger)
         .Build();


### PR DESCRIPTION
## What does this PR do?

This PR adds `WithContextDirectory(string)` to `ImageFromDockerfileBuilder`, letting developers specify the Docker build context directory. Previously, Testcontainers for .NET required the `Dockerfile` and `.dockerignore` to be **inside** the build context, which isn't always necessary/practical. The Docker CLI allows specifying a separate build context for a `Dockerfile`.

For backward compatibility, developers still need to specify the Dockerfile directory and name. We may refactor this in a follow-up PR. If no build context is specified, Testcontainers for .NET defaults to using the Dockerfile directory as the build context.

Additionally, this PR adds support for [Dockerfile-specific ignore files](https://docs.docker.com/build/concepts/context/#filename-and-location). If such a file exists in the Dockerfile directory, it will be used instead of `.dockerignore`.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1514
- Closes #1182

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
