### PR TITLE
chore: Update CI workflow to ubuntu-24.04

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,14 +28,14 @@ env:
 
 jobs:
   collect-test-projects:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     outputs:
       test-projects: ${{ steps.set-test-projects.outputs.test-projects }}
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - id: set-test-projects
         name: Collect Test Projects
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
 
@@ -65,7 +65,7 @@ jobs:
           path: ~/.nuget/packages
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
 
       - name: Restore NuGet Packages
         run: ./build.sh --target=Restore-NuGet-Packages
@@ -97,7 +97,7 @@ jobs:
       contents: write
       pull-requests: read
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     env:
       CODE_SIGNING_CERTIFICATE_BASE64: ${{ secrets.CODE_SIGNING_CERTIFICATE_BASE64 }}
@@ -112,13 +112,13 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
           fetch-depth: 0
 
       - name: Download Test And Coverage Results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: Testcontainers*
           path: test-results
@@ -130,17 +130,17 @@ jobs:
       - name: Cache NuGet Packages
         uses: actions/cache@v4
         with:
-          key: ubuntu-22.04-nuget-${{ hashFiles('Directory.Packages.props') }}
+          key: ubuntu-24.04-nuget-${{ hashFiles('Directory.Packages.props') }}
           path: ~/.nuget/packages
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
 
       - name: Restore NuGet Packages
         run: ./build.sh --target=Restore-NuGet-Packages

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,11 +22,11 @@ jobs:
     permissions:
       security-events: write
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           lfs: true
 

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -13,12 +13,12 @@ jobs:
       checks: write
       contents: read
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       # https://github.com/dorny/test-reporter/issues/363#issuecomment-2381625959.
       - name: Publish Test Report
-        uses: dorny/test-reporter@v1.9.1
+        uses: dorny/test-reporter@v2.1.1
         with:
           artifact: '/Testcontainers.*/'
           name: Test Report

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           pattern: Testcontainers*
 
-      - name: List Artifacts
-        run: ls -R ${{ github.workspace }}
-
       - name: Publish Test Report
         uses: dorny/test-reporter@v2.1.1
         with:

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Publish Test Report
         uses: dorny/test-reporter@v2.1.1
         with:
-          artifact: '/Testcontainers.*/'
+          artifact: /Testcontainers.*/
           name: Test Report
           path: '*.trx'
           reporter: dotnet-trx

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -16,11 +16,17 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      # https://github.com/dorny/test-reporter/issues/363#issuecomment-2381625959.
+      - name: Download Test And Coverage Results
+        uses: actions/download-artifact@v5
+        with:
+          pattern: Testcontainers*
+
+      - name: List Artifacts
+        run: ls -R ${{ github.workspace }}
+
       - name: Publish Test Report
         uses: dorny/test-reporter@v2.1.1
         with:
-          artifact: /Testcontainers.*/
-          name: Test Report
+          name: test-report
           path: '*.trx'
           reporter: dotnet-trx

--- a/tests/Testcontainers.ActiveMq.Tests/.runs-on
+++ b/tests/Testcontainers.ActiveMq.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.ArangoDb.Tests/.runs-on
+++ b/tests/Testcontainers.ArangoDb.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Azurite.Tests/.runs-on
+++ b/tests/Testcontainers.Azurite.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.BigQuery.Tests/.runs-on
+++ b/tests/Testcontainers.BigQuery.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Bigtable.Tests/.runs-on
+++ b/tests/Testcontainers.Bigtable.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Cassandra.Tests/.runs-on
+++ b/tests/Testcontainers.Cassandra.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.ClickHouse.Tests/.runs-on
+++ b/tests/Testcontainers.ClickHouse.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.CockroachDb.Tests/.runs-on
+++ b/tests/Testcontainers.CockroachDb.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -15,5 +15,5 @@ public static class CommonImages
 
     public static readonly IImage Nginx = new DockerImage("nginx:1.22");
 
-    public static readonly IImage ServerCore = new DockerImage("mcr.microsoft.com/windows/servercore:ltsc2022");
+    public static readonly IImage ServerCore = new DockerImage("mcr.microsoft.com/windows/servercore:ltsc2025");
 }

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -15,5 +15,5 @@ public static class CommonImages
 
     public static readonly IImage Nginx = new DockerImage("nginx:1.22");
 
-    public static readonly IImage ServerCore = new DockerImage("mcr.microsoft.com/windows/servercore:ltsc2025");
+    public static readonly IImage ServerCore = new DockerImage("mcr.microsoft.com/windows/servercore:ltsc2022");
 }

--- a/tests/Testcontainers.Consul.Tests/.runs-on
+++ b/tests/Testcontainers.Consul.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.CosmosDb.Tests/.runs-on
+++ b/tests/Testcontainers.CosmosDb.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.CouchDb.Tests/.runs-on
+++ b/tests/Testcontainers.CouchDb.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Couchbase.Tests/.runs-on
+++ b/tests/Testcontainers.Couchbase.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Databases.Tests/.runs-on
+++ b/tests/Testcontainers.Databases.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Db2.Tests/.runs-on
+++ b/tests/Testcontainers.Db2.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.DynamoDb.Tests/.runs-on
+++ b/tests/Testcontainers.DynamoDb.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Elasticsearch.Tests/.runs-on
+++ b/tests/Testcontainers.Elasticsearch.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.EventHubs.Tests/.runs-on
+++ b/tests/Testcontainers.EventHubs.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.EventStoreDb.Tests/.runs-on
+++ b/tests/Testcontainers.EventStoreDb.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.FakeGcsServer.Tests/.runs-on
+++ b/tests/Testcontainers.FakeGcsServer.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.FirebirdSql.Tests/.runs-on
+++ b/tests/Testcontainers.FirebirdSql.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Firestore.Tests/.runs-on
+++ b/tests/Testcontainers.Firestore.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.InfluxDb.Tests/.runs-on
+++ b/tests/Testcontainers.InfluxDb.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.JanusGraph.Tests/.runs-on
+++ b/tests/Testcontainers.JanusGraph.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.K3s.Tests/.runs-on
+++ b/tests/Testcontainers.K3s.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Kafka.Tests/.runs-on
+++ b/tests/Testcontainers.Kafka.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Keycloak.Tests/.runs-on
+++ b/tests/Testcontainers.Keycloak.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Kusto.Tests/.runs-on
+++ b/tests/Testcontainers.Kusto.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.LocalStack.Tests/.runs-on
+++ b/tests/Testcontainers.LocalStack.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.LowkeyVault.Tests/.runs-on
+++ b/tests/Testcontainers.LowkeyVault.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.MariaDb.Tests/.runs-on
+++ b/tests/Testcontainers.MariaDb.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Milvus.Tests/.runs-on
+++ b/tests/Testcontainers.Milvus.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Minio.Tests/.runs-on
+++ b/tests/Testcontainers.Minio.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.MongoDb.Tests/.runs-on
+++ b/tests/Testcontainers.MongoDb.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.MsSql.Tests/.runs-on
+++ b/tests/Testcontainers.MsSql.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.MySql.Tests/.runs-on
+++ b/tests/Testcontainers.MySql.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Nats.Tests/.runs-on
+++ b/tests/Testcontainers.Nats.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Neo4j.Tests/.runs-on
+++ b/tests/Testcontainers.Neo4j.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Ollama.Tests/.runs-on
+++ b/tests/Testcontainers.Ollama.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.OpenSearch.Tests/.runs-on
+++ b/tests/Testcontainers.OpenSearch.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Oracle.Tests/.runs-on
+++ b/tests/Testcontainers.Oracle.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Oracle11.Tests/.runs-on
+++ b/tests/Testcontainers.Oracle11.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Oracle18.Tests/.runs-on
+++ b/tests/Testcontainers.Oracle18.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Oracle21.Tests/.runs-on
+++ b/tests/Testcontainers.Oracle21.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Oracle23.Tests/.runs-on
+++ b/tests/Testcontainers.Oracle23.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Papercut.Tests/.runs-on
+++ b/tests/Testcontainers.Papercut.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Platform.Linux.Tests/.runs-on
+++ b/tests/Testcontainers.Platform.Linux.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Platform.Windows.Tests/.runs-on
+++ b/tests/Testcontainers.Platform.Windows.Tests/.runs-on
@@ -1,1 +1,1 @@
-windows-2022
+windows-2025

--- a/tests/Testcontainers.Platform.Windows.Tests/.runs-on
+++ b/tests/Testcontainers.Platform.Windows.Tests/.runs-on
@@ -1,1 +1,1 @@
-windows-2025
+windows-2022

--- a/tests/Testcontainers.PostgreSql.Tests/.runs-on
+++ b/tests/Testcontainers.PostgreSql.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.PubSub.Tests/.runs-on
+++ b/tests/Testcontainers.PubSub.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Pulsar.Tests/.runs-on
+++ b/tests/Testcontainers.Pulsar.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Qdrant.Tests/.runs-on
+++ b/tests/Testcontainers.Qdrant.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.RabbitMq.Tests/.runs-on
+++ b/tests/Testcontainers.RabbitMq.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.RavenDb.Tests/.runs-on
+++ b/tests/Testcontainers.RavenDb.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Redis.Tests/.runs-on
+++ b/tests/Testcontainers.Redis.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Redpanda.Tests/.runs-on
+++ b/tests/Testcontainers.Redpanda.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.ResourceReaper.Tests/.runs-on
+++ b/tests/Testcontainers.ResourceReaper.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.ServiceBus.Tests/.runs-on
+++ b/tests/Testcontainers.ServiceBus.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Sftp.Tests/.runs-on
+++ b/tests/Testcontainers.Sftp.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Tests/.runs-on
+++ b/tests/Testcontainers.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Typesense.Tests/.runs-on
+++ b/tests/Testcontainers.Typesense.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Weaviate.Tests/.runs-on
+++ b/tests/Testcontainers.Weaviate.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.WebDriver.Tests/.runs-on
+++ b/tests/Testcontainers.WebDriver.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.Xunit.Tests/.runs-on
+++ b/tests/Testcontainers.Xunit.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04

--- a/tests/Testcontainers.XunitV3.Tests/.runs-on
+++ b/tests/Testcontainers.XunitV3.Tests/.runs-on
@@ -1,1 +1,1 @@
-ubuntu-22.04
+ubuntu-24.04


### PR DESCRIPTION
## What does this PR do?

This PR updates the GitHub-hosted runners (CI workflow) to Ubuntu 24.04.

I noticed an issue with [test-reporter](https://github.com/dorny/test-reporter). For some reason, some tests (projects) no longer appear in the Test Reporter results.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
