### PR TITLE
feat: Add startup callback overload with configuration type

### DIFF
--- a/src/Testcontainers.Weaviate/WeaviateContainer.cs
+++ b/src/Testcontainers.Weaviate/WeaviateContainer.cs
@@ -2,8 +2,17 @@ namespace Testcontainers.Weaviate;
 
 /// <inheritdoc cref="DockerContainer" />
 [PublicAPI]
-public sealed class WeaviateContainer(WeaviateConfiguration configuration) : DockerContainer(configuration)
+public sealed class WeaviateContainer : DockerContainer
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WeaviateContainer" /> class.
+    /// </summary>
+    /// <param name="configuration">The container configuration.</param>
+    public WeaviateContainer(WeaviateConfiguration configuration)
+        : base(configuration)
+    {
+    }
+
     /// <summary>
     /// Gets the Weaviate base address.
     /// </summary>

--- a/src/Testcontainers.Xunit/ContainerFixture.cs
+++ b/src/Testcontainers.Xunit/ContainerFixture.cs
@@ -11,5 +11,5 @@ namespace Testcontainers.Xunit;
 [PublicAPI]
 public class ContainerFixture<TBuilderEntity, TContainerEntity>(IMessageSink messageSink)
     : ContainerLifetime<TBuilderEntity, TContainerEntity>(new MessageSinkLogger(messageSink))
-    where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity>, new()
+    where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity, IContainerConfiguration>, new()
     where TContainerEntity : IContainer;

--- a/src/Testcontainers.Xunit/ContainerLifetime.cs
+++ b/src/Testcontainers.Xunit/ContainerLifetime.cs
@@ -6,7 +6,7 @@ namespace Testcontainers.Xunit;
 /// <typeparam name="TBuilderEntity">The builder entity.</typeparam>
 /// <typeparam name="TContainerEntity">The container entity.</typeparam>
 public abstract class ContainerLifetime<TBuilderEntity, TContainerEntity> : IAsyncLifetime
-    where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity>, new()
+    where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity, IContainerConfiguration>, new()
     where TContainerEntity : IContainer
 {
     private readonly Lazy<TContainerEntity> _container;
@@ -91,8 +91,8 @@ public abstract class ContainerLifetime<TBuilderEntity, TContainerEntity> : IAsy
 
 #if XUNIT_V3
     /// <inheritdoc cref="IAsyncDisposable.DisposeAsync" />
-#else 
-    /// <inheritdoc cref="IAsyncLifetime.DisposeAsync" /> 
+#else
+    /// <inheritdoc cref="IAsyncLifetime.DisposeAsync" />
 #endif
     protected virtual async LifetimeTask DisposeAsyncCore()
     {

--- a/src/Testcontainers.Xunit/ContainerTest.cs
+++ b/src/Testcontainers.Xunit/ContainerTest.cs
@@ -11,7 +11,7 @@ namespace Testcontainers.Xunit;
 [PublicAPI]
 public abstract class ContainerTest<TBuilderEntity, TContainerEntity>(ITestOutputHelper testOutputHelper, Func<TBuilderEntity, TBuilderEntity> configure = null)
     : ContainerLifetime<TBuilderEntity, TContainerEntity>(new TestOutputLogger(testOutputHelper))
-    where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity>, new()
+    where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity, IContainerConfiguration>, new()
     where TContainerEntity : IContainer
 {
     protected override TBuilderEntity Configure(TBuilderEntity builder) => configure != null ? configure(builder) : builder;

--- a/src/Testcontainers.Xunit/DbContainerFixture.cs
+++ b/src/Testcontainers.Xunit/DbContainerFixture.cs
@@ -10,7 +10,7 @@ namespace Testcontainers.Xunit;
 [PublicAPI]
 public abstract class DbContainerFixture<TBuilderEntity, TContainerEntity>(IMessageSink messageSink)
     : ContainerFixture<TBuilderEntity, TContainerEntity>(messageSink), IDbContainerTestMethods
-    where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity>, new()
+    where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity, IContainerConfiguration>, new()
     where TContainerEntity : IContainer, IDatabaseContainer
 {
     private DbContainerTestMethods _testMethods;

--- a/src/Testcontainers.Xunit/DbContainerTest.cs
+++ b/src/Testcontainers.Xunit/DbContainerTest.cs
@@ -9,7 +9,7 @@ namespace Testcontainers.Xunit;
 [PublicAPI]
 public abstract class DbContainerTest<TBuilderEntity, TContainerEntity>(ITestOutputHelper testOutputHelper, Func<TBuilderEntity, TBuilderEntity> configure = null)
     : ContainerTest<TBuilderEntity, TContainerEntity>(testOutputHelper, configure), IDbContainerTestMethods
-    where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity>, new()
+    where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity, IContainerConfiguration>, new()
     where TContainerEntity : IContainer, IDatabaseContainer
 {
     private DbContainerTestMethods _testMethods;

--- a/src/Testcontainers.Xunit/Usings.cs
+++ b/src/Testcontainers.Xunit/Usings.cs
@@ -5,6 +5,7 @@ global using System.Runtime.ExceptionServices;
 global using System.Threading;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Builders;
+global using DotNet.Testcontainers.Configurations;
 global using DotNet.Testcontainers.Containers;
 global using JetBrains.Annotations;
 global using Microsoft.Extensions.Logging;

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -22,7 +22,7 @@ namespace DotNet.Testcontainers.Builders
   /// <typeparam name="TContainerEntity">The resource entity.</typeparam>
   /// <typeparam name="TConfigurationEntity">The configuration entity.</typeparam>
   [PublicAPI]
-  public abstract class ContainerBuilder<TBuilderEntity, TContainerEntity, TConfigurationEntity> : AbstractBuilder<TBuilderEntity, TContainerEntity, CreateContainerParameters, TConfigurationEntity>, IContainerBuilder<TBuilderEntity, TContainerEntity>
+  public abstract class ContainerBuilder<TBuilderEntity, TContainerEntity, TConfigurationEntity> : AbstractBuilder<TBuilderEntity, TContainerEntity, CreateContainerParameters, TConfigurationEntity>, IContainerBuilder<TBuilderEntity, TContainerEntity, TConfigurationEntity>
     where TBuilderEntity : ContainerBuilder<TBuilderEntity, TContainerEntity, TConfigurationEntity>
     where TContainerEntity : IContainer
     where TConfigurationEntity : IContainerConfiguration
@@ -387,13 +387,19 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc />
     public TBuilderEntity WithStartupCallback(Func<TContainerEntity, CancellationToken, Task> startupCallback)
     {
-      return Clone(new ContainerConfiguration(startupCallback: (container, ct) => startupCallback((TContainerEntity)container, ct)));
+      return Clone(new ContainerConfiguration(startupCallback: (container, _, ct) => startupCallback((TContainerEntity)container, ct)));
+    }
+
+    /// <inheritdoc />
+    public TBuilderEntity WithStartupCallback(Func<TContainerEntity, TConfigurationEntity, CancellationToken, Task> startupCallback)
+    {
+      return Clone(new ContainerConfiguration(startupCallback: (container, configuration, ct) => startupCallback((TContainerEntity)container, (TConfigurationEntity)configuration, ct)));
     }
 
     /// <inheritdoc />
     protected override TBuilderEntity Init()
     {
-      return base.Init().WithImagePullPolicy(PullPolicy.Missing).WithPortForwarding().WithOutputConsumer(Consume.DoNotConsumeStdoutAndStderr()).WithWaitStrategy(Wait.ForUnixContainer()).WithStartupCallback((_, _) => Task.CompletedTask);
+      return base.Init().WithImagePullPolicy(PullPolicy.Missing).WithPortForwarding().WithOutputConsumer(Consume.DoNotConsumeStdoutAndStderr()).WithWaitStrategy(Wait.ForUnixContainer()).WithStartupCallback((_, _, _) => Task.CompletedTask);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -18,8 +18,9 @@ namespace DotNet.Testcontainers.Builders
   /// </summary>
   /// <typeparam name="TBuilderEntity">The builder entity.</typeparam>
   /// <typeparam name="TContainerEntity">The resource entity.</typeparam>
+  /// <typeparam name="TConfigurationEntity">The configuration entity.</typeparam>
   [PublicAPI]
-  public interface IContainerBuilder<out TBuilderEntity, out TContainerEntity> : IAbstractBuilder<TBuilderEntity, TContainerEntity, CreateContainerParameters>
+  public interface IContainerBuilder<out TBuilderEntity, out TContainerEntity, out TConfigurationEntity> : IAbstractBuilder<TBuilderEntity, TContainerEntity, CreateContainerParameters>
   {
     /// <summary>
     /// Accepts the license agreement.
@@ -488,5 +489,16 @@ namespace DotNet.Testcontainers.Builders
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithStartupCallback(Func<TContainerEntity, CancellationToken, Task> startupCallback);
+
+    /// <summary>
+    /// Sets a startup callback to invoke after the container start.
+    /// </summary>
+    /// <remarks>
+    /// The callback method is invoked after the container start, but before the wait strategies.
+    /// </remarks>
+    /// <param name="startupCallback">The callback method to invoke.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
+    TBuilderEntity WithStartupCallback(Func<TContainerEntity, TConfigurationEntity, CancellationToken, Task> startupCallback);
   }
 }

--- a/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
@@ -61,7 +61,7 @@ namespace DotNet.Testcontainers.Configurations
       IEnumerable<string> extraHosts = null,
       IOutputConsumer outputConsumer = null,
       IEnumerable<WaitStrategy> waitStrategies = null,
-      Func<IContainer, CancellationToken, Task> startupCallback = null,
+      Func<IContainer, IContainerConfiguration, CancellationToken, Task> startupCallback = null,
       bool? autoRemove = null,
       bool? privileged = null)
     {
@@ -216,6 +216,6 @@ namespace DotNet.Testcontainers.Configurations
 
     /// <inheritdoc />
     [JsonIgnore]
-    public Func<IContainer, CancellationToken, Task> StartupCallback { get; }
+    public Func<IContainer, IContainerConfiguration, CancellationToken, Task> StartupCallback { get; }
   }
 }

--- a/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
@@ -124,6 +124,6 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Gets the startup callback.
     /// </summary>
-    Func<IContainer, CancellationToken, Task> StartupCallback { get; }
+    Func<IContainer, IContainerConfiguration, CancellationToken, Task> StartupCallback { get; }
   }
 }

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -549,7 +549,7 @@ namespace DotNet.Testcontainers.Containers
 
       Starting?.Invoke(this, EventArgs.Empty);
 
-      await _configuration.StartupCallback(this, ct)
+      await _configuration.StartupCallback(this, _configuration, ct)
         .ConfigureAwait(false);
 
       Logger.StartReadinessCheck(_container.ID);


### PR DESCRIPTION
## What does this PR do?

This PR adds a new startup callback overload to the container builder that includes the container configuration (`TContainerEntity`, `TConfigurationEntity`, `CancellationToken`).

## Why is it important?

This lets developers access the configuration during startup, which wasn't possible before.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
