### PR TITLE
fix(MongoDb): Use `db.runCommand({hello:1})` do detect readiness

### DIFF
--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -165,6 +165,10 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
             return;
         }
 
+        // This is a simple workaround to use the default options, which can be configured
+        // with custom configurations as needed.
+        var options = new WaitStrategy();
+
         var scriptContent = $"var r=rs.initiate({{_id:\"{configuration.ReplicaSetName}\",members:[{{_id:0,host:\"127.0.0.1:27017\"}}]}});quit(r.ok===1?0:1);";
 
         var initiate = async () =>
@@ -173,9 +177,9 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
                 .ConfigureAwait(false);
 
             return 0L.Equals(execResult.ExitCode);
-        }; 
+        };
 
-        await WaitStrategy.WaitUntilAsync(initiate, TimeSpan.FromSeconds(2), TimeSpan.FromMinutes(5), -1, ct)
+        await WaitStrategy.WaitUntilAsync(initiate, options.Interval, options.Timeout, options.Retries, ct)
             .ConfigureAwait(false);
     }
 


### PR DESCRIPTION
## What does this PR do?

The previous wait strategy indicated readiness too early when using a single-node replica set configuration.

This PR updates the wait strategy to match the approach used in other Testcontainers language implementations. Instead of relying on `db.runCommand({isMaster: 1}).ismaster`, it uses `db.runCommand({hello: 1}).isWritablePrimary` though. According to the docs, this is the recommended method, since `{isMaster: 1}` is deprecated and has been replaced by `{hello: 1}`.

@Yorie could you please test the changes in the PR? It would really help!

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1541

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
