### PR TITLE
fix(Papercut): Pin version 7.0 and set new HTTP and SMTP ports

### DIFF
--- a/src/Testcontainers.Papercut/PapercutBuilder.cs
+++ b/src/Testcontainers.Papercut/PapercutBuilder.cs
@@ -4,11 +4,11 @@ namespace Testcontainers.Papercut;
 [PublicAPI]
 public sealed class PapercutBuilder : ContainerBuilder<PapercutBuilder, PapercutContainer, PapercutConfiguration>
 {
-    public const string PapercutImage = "changemakerstudiosus/papercut-smtp:latest";
+    public const string PapercutImage = "changemakerstudiosus/papercut-smtp:7.0";
 
-    public const ushort SmtpPort = 25;
+    public const ushort SmtpPort = 2525;
 
-    public const ushort HttpPort = 80;
+    public const ushort HttpPort = 8080;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PapercutBuilder" /> class.


### PR DESCRIPTION
## What does this PR do?

Earlier versions of Papercut didn't use tags, so we had to rely on the `latest` tag. With version 7, Papercut introduced a breaking change and updated the ports for the HTTP and SMTP services. This PR pins Papercut to version 7 and updates the ports accordingly.

## Why is it important?

The module needs this change to start properly. Without it, the wait strategy never finishes because it cannot connect to the services.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
