### PR TITLE
feat: Throw if container not running

### DIFF
--- a/docs/api/wait_strategies.md
+++ b/docs/api/wait_strategies.md
@@ -20,6 +20,17 @@ _ = Wait.ForUnixContainer()
 
 Besides configuring the wait strategy, cancelling a container start can always be done utilizing a [CancellationToken](create_docker_container.md#canceling-a-container-start).
 
+## Wait strategy modes
+
+Wait strategy modes define how Testcontainers for .NET handles container readiness checks. By default, wait strategies assume the container remains running throughout the startup. If a container exits unexpectedly during startup, Testcontainers for .NET will throw a `ContainerNotRunningException` containing the exit code and logs.
+
+Some containers are intended to stop after completing short-lived tasks like migrations or setup scripts. In these cases, the container exit is expected, not a failure. Use `WaitStrategyMode.OneShot` to treat a normal exit as successful rather than throwing an exception.
+
+```csharp
+_ = Wait.ForUnixContainer()
+  .UntilMessageIsLogged("Migration completed", o => o.WithMode(WaitStrategyMode.OneShot));
+```
+
 ## Wait until an HTTP(S) endpoint is available
 
 You can choose to wait for an HTTP(S) endpoint to return a particular HTTP response status code or to match a predicate. The default configuration tries to access the HTTP endpoint running inside the container. Chose `ForPort(ushort)` or `ForPath(string)` to adjust the endpoint or `UsingTls()` to switch to HTTPS. When using `UsingTls()` port 443 is used as a default. If your container exposes a different HTTPS port, make sure that the correct waiting port is configured accordingly.

--- a/docs/custom_configuration/index.md
+++ b/docs/custom_configuration/index.md
@@ -81,13 +81,13 @@ Once configured, Testcontainers will rewrite Docker Hub image names by adding th
 For example, the image:
 
 ```
-testcontainers/helloworld:1.2.0
+testcontainers/helloworld:1.3.0
 ```
 
 will automatically become:
 
 ```
-registry.mycompany.com/mirror/testcontainers/helloworld:1.2.0
+registry.mycompany.com/mirror/testcontainers/helloworld:1.3.0
 ```
 
 ## Enable logging

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@ dotnet add package Testcontainers
 ```csharp title="Run the Hello World container"
 // Create a new instance of a container.
 var container = new ContainerBuilder()
-  // Set the image for the container to "testcontainers/helloworld:1.2.0".
-  .WithImage("testcontainers/helloworld:1.2.0")
+  // Set the image for the container to "testcontainers/helloworld:1.3.0".
+  .WithImage("testcontainers/helloworld:1.3.0")
   // Bind port 8080 of the container to a random port on the host.
   .WithPortBinding(8080, true)
   // Wait until the HTTP endpoint of the container is available.

--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -158,7 +158,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
     /// <param name="configuration">The container configuration.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that completes when the replica set initiation has been executed.</returns>
-    private async Task InitiateReplicaSetAsync(MongoDbContainer container, MongoDbConfiguration configuration, CancellationToken ct)
+    private static async Task InitiateReplicaSetAsync(MongoDbContainer container, MongoDbConfiguration configuration, CancellationToken ct)
     {
         if (string.IsNullOrEmpty(configuration.ReplicaSetName))
         {
@@ -224,7 +224,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
         }
 
         /// <inheritdoc cref="IWaitUntil.UntilAsync" />
-        private async Task<bool> UntilAsync(MongoDbContainer container)
+        private static async Task<bool> UntilAsync(MongoDbContainer container)
         {
             var execResult = await container.ExecScriptAsync(ScriptContent)
                 .ConfigureAwait(false);

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitStrategy.cs
@@ -10,6 +10,13 @@ namespace DotNet.Testcontainers.Configurations
   public interface IWaitStrategy
   {
     /// <summary>
+    /// Sets the wait strategy mode.
+    /// </summary>
+    /// <param name="mode">The wait strategy mode.</param>
+    /// <returns>The updated instance of the wait strategy.</returns>
+    IWaitStrategy WithMode(WaitStrategyMode mode);
+
+    /// <summary>
     /// Sets the number of retries for the wait strategy.
     /// </summary>
     /// <param name="retries">The number of retries.</param>

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitForContainerOS.cs
@@ -15,7 +15,10 @@ namespace DotNet.Testcontainers.Configurations
     /// </summary>
     protected WaitForContainerOS()
     {
-      _waitStrategies.Add(new WaitStrategy(new UntilContainerIsRunning()));
+      var waitStrategy = new WaitStrategy(new UntilContainerIsRunning());
+      _ = waitStrategy.WithMode(WaitStrategyMode.OneShot);
+
+      _waitStrategies.Add(waitStrategy);
     }
 
     /// <inheritdoc />
@@ -31,7 +34,7 @@ namespace DotNet.Testcontainers.Configurations
     public abstract IWaitForContainerOS UntilInternalTcpPortIsAvailable(int containerPort, Action<IWaitStrategy> waitStrategyModifier = null);
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS AddCustomWaitStrategy(IWaitUntil waitUntil, Action<IWaitStrategy> waitStrategyModifier = null)
+    public IWaitForContainerOS AddCustomWaitStrategy(IWaitUntil waitUntil, Action<IWaitStrategy> waitStrategyModifier = null)
     {
       var waitStrategy = new WaitStrategy(waitUntil);
 
@@ -51,7 +54,7 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS UntilFileExists(string filePath, FileSystem fileSystem = FileSystem.Host, Action<IWaitStrategy> waitStrategyModifier = null)
+    public IWaitForContainerOS UntilFileExists(string filePath, FileSystem fileSystem = FileSystem.Host, Action<IWaitStrategy> waitStrategyModifier = null)
     {
       switch (fileSystem)
       {
@@ -76,19 +79,19 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS UntilHttpRequestIsSucceeded(Func<HttpWaitStrategy, HttpWaitStrategy> request, Action<IWaitStrategy> waitStrategyModifier = null)
+    public IWaitForContainerOS UntilHttpRequestIsSucceeded(Func<HttpWaitStrategy, HttpWaitStrategy> request, Action<IWaitStrategy> waitStrategyModifier = null)
     {
       return AddCustomWaitStrategy(request.Invoke(new HttpWaitStrategy()), waitStrategyModifier);
     }
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS UntilContainerIsHealthy(long failingStreak = 3, Action<IWaitStrategy> waitStrategyModifier = null)
+    public IWaitForContainerOS UntilContainerIsHealthy(long failingStreak = 3, Action<IWaitStrategy> waitStrategyModifier = null)
     {
       return AddCustomWaitStrategy(new UntilContainerIsHealthy(failingStreak), waitStrategyModifier);
     }
 
     /// <inheritdoc />
-    public virtual IWaitForContainerOS UntilDatabaseIsAvailable(DbProviderFactory dbProviderFactory, Action<IWaitStrategy> waitStrategyModifier = null)
+    public IWaitForContainerOS UntilDatabaseIsAvailable(DbProviderFactory dbProviderFactory, Action<IWaitStrategy> waitStrategyModifier = null)
     {
       return AddCustomWaitStrategy(new UntilDatabaseIsAvailable(dbProviderFactory), waitStrategyModifier);
     }

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitStrategy.cs
@@ -42,6 +42,12 @@ namespace DotNet.Testcontainers.Configurations
     }
 
     /// <summary>
+    /// Gets the wait strategy mode.
+    /// </summary>
+    public WaitStrategyMode Mode { get; private set; }
+      =  WaitStrategyMode.Running;
+
+    /// <summary>
     /// Gets the number of retries.
     /// </summary>
     public ushort Retries { get; private set; }
@@ -58,6 +64,13 @@ namespace DotNet.Testcontainers.Configurations
     /// </summary>
     public TimeSpan Timeout { get; private set; }
       = TestcontainersSettings.WaitStrategyTimeout ?? TimeSpan.FromHours(1);
+
+    /// <inheritdoc />
+    public IWaitStrategy WithMode(WaitStrategyMode mode)
+    {
+      Mode = mode;
+      return this;
+    }
 
     /// <inheritdoc />
     public IWaitStrategy WithRetries(ushort retries)

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitStrategyMode.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitStrategyMode.cs
@@ -1,0 +1,30 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using DotNet.Testcontainers.Containers;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Defines the execution mode for wait strategies.
+  /// </summary>
+  [PublicAPI]
+  public enum WaitStrategyMode
+  {
+    /// <summary>
+    /// Indicates that the container is expected to be in the <c>Running</c> state.
+    /// </summary>
+    /// <remarks>
+    /// When this mode is used, the library verifies that the container is running. If
+    /// the container is not running, it collects the container's <c>stdout</c> and
+    /// <c>stderr</c> logs and throws a <see cref="ContainerNotRunningException"/> exception.
+    /// </remarks>
+    Running,
+
+    /// <summary>
+    /// Executes the wait strategy a single time without requiring the container to be running.
+    /// </summary>
+    /// <remarks>
+    /// This mode does not check the container's running state and does not retry.
+    /// </remarks>
+    OneShot,
+  }
+}

--- a/src/Testcontainers/Configurations/WaitStrategies/WaitStrategyMode.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/WaitStrategyMode.cs
@@ -4,7 +4,7 @@ namespace DotNet.Testcontainers.Configurations
   using JetBrains.Annotations;
 
   /// <summary>
-  /// Defines the execution mode for wait strategies.
+  /// Represents the execution mode for a wait strategy.
   /// </summary>
   [PublicAPI]
   public enum WaitStrategyMode
@@ -15,15 +15,15 @@ namespace DotNet.Testcontainers.Configurations
     /// <remarks>
     /// When this mode is used, the library verifies that the container is running. If
     /// the container is not running, it collects the container's <c>stdout</c> and
-    /// <c>stderr</c> logs and throws a <see cref="ContainerNotRunningException"/> exception.
+    /// <c>stderr</c> logs and throws a <see cref="ContainerNotRunningException" /> exception.
     /// </remarks>
     Running,
 
     /// <summary>
-    /// Executes the wait strategy a single time without requiring the container to be running.
+    /// Executes the wait strategy without requiring the container to be running.
     /// </summary>
     /// <remarks>
-    /// This mode does not check the container's running state and does not retry.
+    /// This mode does not check the container's running state.
     /// </remarks>
     OneShot,
   }

--- a/src/Testcontainers/Containers/ContainerNotRunningException.cs
+++ b/src/Testcontainers/Containers/ContainerNotRunningException.cs
@@ -1,0 +1,60 @@
+namespace DotNet.Testcontainers.Containers
+{
+  using System;
+  using System.Linq;
+  using System.Text;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Represents an exception that is thrown when a container is not running anymore,
+  /// and exited unexpectedly.
+  /// </summary>
+  [PublicAPI]
+  public sealed class ContainerNotRunningException : Exception
+  {
+    private static readonly string[] LineEndings = new[] { "\r\n", "\n" };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContainerNotRunningException" /> class.
+    /// </summary>
+    /// <param name="id">The container id.</param>
+    /// <param name="stdout">The stdout.</param>
+    /// <param name="stderr">The stderr.</param>
+    /// <param name="exitCode">The exit code.</param>
+    /// <param name="exception">The inner exception.</param>
+    public ContainerNotRunningException(string id, string stdout, string stderr, long exitCode, [CanBeNull] Exception exception)
+      : base(CreateMessage(id, stdout, stderr, exitCode), exception)
+    {
+    }
+
+    private static string CreateMessage(string id, string stdout, string stderr, long exitCode)
+    {
+      var exceptionInfo = new StringBuilder(256);
+      exceptionInfo.Append($"Container {id} exited with code {exitCode}.");
+
+      if (!string.IsNullOrEmpty(stdout))
+      {
+        var stdoutLines = stdout
+          .Split(LineEndings, StringSplitOptions.RemoveEmptyEntries)
+          .Select(line => "    " + line);
+
+        exceptionInfo.AppendLine();
+        exceptionInfo.AppendLine("  Stdout: ");
+        exceptionInfo.Append(string.Join(Environment.NewLine, stdoutLines));
+      }
+
+      if (!string.IsNullOrEmpty(stderr))
+      {
+        var stderrLines = stderr
+          .Split(LineEndings, StringSplitOptions.RemoveEmptyEntries)
+          .Select(line => "    " + line);
+
+        exceptionInfo.AppendLine();
+        exceptionInfo.AppendLine("  Stderr: ");
+        exceptionInfo.Append(string.Join(Environment.NewLine, stderrLines));
+      }
+
+      return exceptionInfo.ToString();
+    }
+  }
+}

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -716,7 +716,7 @@ namespace DotNet.Testcontainers.Containers
     }
 
     /// <summary>
-    /// Throws an <see cref="ContainerNotRunningException" /> when the container exited unexpectedly.
+    /// Throws <see cref="ContainerNotRunningException" /> when the container exited unexpectedly.
     /// </summary>
     /// <param name="waitStrategyMode">The wait strategy mode.</param>
     /// <param name="innerException">The inner exception.</param>

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -671,11 +671,27 @@ namespace DotNet.Testcontainers.Containers
     /// <returns>A task representing the asynchronous operation, returning true if the wait strategy indicates readiness; otherwise, false.</returns>
     private async Task<bool> CheckReadinessAsync(WaitStrategy waitStrategy, CancellationToken ct = default)
     {
+      Exception exception = null;
+
       _container = await _client.Container.ByIdAsync(_container.ID, ct)
         .ConfigureAwait(false);
 
-      return await waitStrategy.UntilAsync(this, ct)
-        .ConfigureAwait(false);
+      try
+      {
+        return await waitStrategy.UntilAsync(this, ct)
+          .ConfigureAwait(false);
+      }
+      catch (DockerApiException e)
+      {
+        exception = e;
+      }
+      finally
+      {
+        await ThrowIfContainerNotRunningAsync(waitStrategy.Mode, exception)
+          .ConfigureAwait(false);
+      }
+
+      return false;
     }
 
     /// <summary>
@@ -699,6 +715,28 @@ namespace DotNet.Testcontainers.Containers
       return true;
     }
 
+    /// <summary>
+    /// Throws an <see cref="ContainerNotRunningException" /> when the container exited unexpectedly.
+    /// </summary>
+    /// <param name="waitStrategyMode">The wait strategy mode.</param>
+    /// <param name="innerException">The inner exception.</param>
+    /// <exception cref="ContainerNotRunningException">The container exited unexpectedly.</exception>
+    private async Task ThrowIfContainerNotRunningAsync(WaitStrategyMode waitStrategyMode, [CanBeNull] Exception innerException = null)
+    {
+      if (innerException == null && (TestcontainersStates.Exited != State || WaitStrategyMode.Running != waitStrategyMode))
+      {
+        return;
+      }
+
+      var (stdout, stderr) = await GetLogsAsync()
+        .ConfigureAwait(false);
+
+      var exitCode = await GetExitCodeAsync()
+        .ConfigureAwait(false);
+
+      throw new ContainerNotRunningException(Id, stdout, stderr, exitCode, innerException);
+    }
+
     private sealed class WaitUntilPortBindingsMapped : WaitStrategy
     {
       private readonly DockerContainer _parent;
@@ -706,6 +744,7 @@ namespace DotNet.Testcontainers.Containers
       public WaitUntilPortBindingsMapped(DockerContainer parent)
       {
         _parent = parent;
+        _ = WithMode(WaitStrategyMode.OneShot);
         _ = WithInterval(TimeSpan.FromSeconds(1));
         _ = WithTimeout(TimeSpan.FromSeconds(15));
       }

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -5,7 +5,7 @@ public static class CommonImages
 {
     public static readonly IImage Ryuk = new DockerImage("testcontainers/ryuk:0.14.0");
 
-    public static readonly IImage HelloWorld = new DockerImage("testcontainers/helloworld:1.2.0");
+    public static readonly IImage HelloWorld = new DockerImage("testcontainers/helloworld:1.3.0");
 
     public static readonly IImage Alpine = new DockerImage("alpine:3.17");
 

--- a/tests/Testcontainers.Platform.Linux.Tests/ContainerNotRunningExceptionTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ContainerNotRunningExceptionTest.cs
@@ -1,0 +1,96 @@
+namespace Testcontainers.Tests;
+
+public sealed class ContainerNotRunningExceptionTest
+{
+    public static TheoryData<ContainerInfoSerializable, string> ContainerTestData { get; }
+        = new TheoryData<ContainerInfoSerializable, string>
+        {
+            {
+                new ContainerInfoSerializable("container-id", "Stdout\nStdout", "Stderr\nStderr", 1),
+                "Container container-id exited with code 1." + Environment.NewLine +
+                "  Stdout: " + Environment.NewLine +
+                "    Stdout" + Environment.NewLine +
+                "    Stdout" + Environment.NewLine +
+                "  Stderr: " + Environment.NewLine +
+                "    Stderr" + Environment.NewLine +
+                "    Stderr"
+            },
+            {
+                new ContainerInfoSerializable("container-id", "Stdout\nStdout", string.Empty, 1),
+                "Container container-id exited with code 1." + Environment.NewLine +
+                "  Stdout: " + Environment.NewLine +
+                "    Stdout" + Environment.NewLine +
+                "    Stdout"
+            },
+            {
+                new ContainerInfoSerializable("container-id", string.Empty, "Stderr\nStderr", 1),
+                "Container container-id exited with code 1." + Environment.NewLine +
+                "  Stderr: " + Environment.NewLine +
+                "    Stderr" + Environment.NewLine +
+                "    Stderr"
+            },
+            {
+                new ContainerInfoSerializable("container-id", string.Empty, string.Empty, 1),
+                "Container container-id exited with code 1."
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(ContainerTestData))]
+    public void ContainerNotRunningExceptionCreatesExpectedMessage(ContainerInfoSerializable serializable, string message)
+    {
+        // Given
+        var (id, stdout, stderr, exitCode) = serializable.ToTuple();
+
+        // When
+        var exception = new ContainerNotRunningException(id, stdout, stderr, exitCode, null);
+
+        // Then
+        Assert.Equal(message, exception.Message);
+    }
+
+    [PublicAPI]
+    public sealed class ContainerInfoSerializable : IXunitSerializable
+    {
+        private string _id;
+
+        private string _stdout;
+
+        private string _stderr;
+
+        private long _exitCode;
+
+        public ContainerInfoSerializable()
+        {
+        }
+
+        public ContainerInfoSerializable(string id, string stdout, string stderr, long exitCode)
+        {
+            _id = id;
+            _stdout = stdout;
+            _stderr = stderr;
+            _exitCode = exitCode;
+        }
+
+        public (string Id, string Stdout, string Stderr, long ExitCode) ToTuple()
+        {
+            return (_id, _stdout, _stderr, _exitCode);
+        }
+
+        public void Deserialize(IXunitSerializationInfo info)
+        {
+            _id = info.GetValue<string>(nameof(_id));
+            _stdout = info.GetValue<string>(nameof(_stdout));
+            _stderr = info.GetValue<string>(nameof(_stderr));
+            _exitCode = info.GetValue<long>(nameof(_exitCode));
+        }
+
+        public void Serialize(IXunitSerializationInfo info)
+        {
+            info.AddValue(nameof(_id), _id);
+            info.AddValue(nameof(_stdout), _stdout);
+            info.AddValue(nameof(_stderr), _stderr);
+            info.AddValue(nameof(_exitCode), _exitCode);
+        }
+    }
+}

--- a/tests/Testcontainers.Platform.Linux.Tests/PortForwardingTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/PortForwardingTest.cs
@@ -51,7 +51,8 @@ public abstract class PortForwardingTest : IAsyncLifetime
                 .WithAutoRemove(false)
                 .WithEntrypoint("nc")
                 .WithCommand(HostedService.Host, fixture.Port.ToString(CultureInfo.InvariantCulture))
-                .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil()))
+                .WithWaitStrategy(Wait.ForUnixContainer()
+                    .AddCustomWaitStrategy(new WaitUntil(), o => o.WithMode(WaitStrategyMode.OneShot)))
                 .Build())
         {
         }
@@ -67,7 +68,8 @@ public abstract class PortForwardingTest : IAsyncLifetime
                 .WithEntrypoint("nc")
                 .WithCommand(HostedService.Host, fixture.Port.ToString(CultureInfo.InvariantCulture))
                 .WithNetwork(new NetworkBuilder().Build())
-                .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil()))
+                .WithWaitStrategy(Wait.ForUnixContainer()
+                    .AddCustomWaitStrategy(new WaitUntil(), o => o.WithMode(WaitStrategyMode.OneShot)))
                 .Build())
         {
         }

--- a/tests/Testcontainers.Platform.Linux.Tests/WaitStrategyModeTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/WaitStrategyModeTest.cs
@@ -1,0 +1,71 @@
+namespace Testcontainers.Tests;
+
+public abstract class WaitStrategyModeTest : IAsyncLifetime
+{
+    private const string Message = "Hello, World!";
+
+    private readonly IContainer _container;
+
+    private WaitStrategyModeTest(WaitStrategyMode waitStrategyMode)
+    {
+        _container = new ContainerBuilder()
+            .WithImage(CommonImages.Alpine)
+            .WithEntrypoint("/bin/sh", "-c")
+            .WithCommand("echo " + Message)
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(Message, o => o.WithMode(waitStrategyMode)))
+            .Build();
+    }
+
+    public ValueTask InitializeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _container.DisposeAsync()
+            .ConfigureAwait(false);
+
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual ValueTask DisposeAsyncCore()
+    {
+        return _container.DisposeAsync();
+    }
+
+    public sealed class WaitStrategyModeRunningTest : WaitStrategyModeTest
+    {
+        public WaitStrategyModeRunningTest()
+            : base(WaitStrategyMode.Running)
+        {
+        }
+
+        [Fact]
+        public async Task StartAsyncShouldNotSucceedWhenContainerIsNotRunning()
+        {
+            var exception = await Record.ExceptionAsync(() => _container.StartAsync(TestContext.Current.CancellationToken))
+                .ConfigureAwait(true);
+
+            Assert.NotNull(exception);
+            Assert.IsType<ContainerNotRunningException>(exception);
+        }
+    }
+
+    public sealed class WaitStrategyModeOneShotTest : WaitStrategyModeTest
+    {
+        public WaitStrategyModeOneShotTest()
+            : base(WaitStrategyMode.OneShot)
+        {
+        }
+
+        [Fact]
+        public async Task StartAsyncShouldSucceedWhenContainerIsNotRunning()
+        {
+            var exception = await Record.ExceptionAsync(() => _container.StartAsync(TestContext.Current.CancellationToken))
+                .ConfigureAwait(true);
+
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -244,7 +244,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .WithEntrypoint("/bin/sh", "-c")
           .WithCommand($"hostname > /{target}/{file}")
           .WithBindMount(TestSession.TempDirectoryPath, $"/{target}")
-          .WithWaitStrategy(Wait.ForUnixContainer().UntilFileExists(Path.Combine(TestSession.TempDirectoryPath, file)))
+          .WithWaitStrategy(Wait.ForUnixContainer().UntilFileExists(Path.Combine(TestSession.TempDirectoryPath, file), waitStrategyModifier: o => o.WithMode(WaitStrategyMode.OneShot)))
           .Build();
 
         // When
@@ -273,7 +273,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .WithEntrypoint("/bin/sh", "-c")
           .WithCommand($"printf $DAY_OF_WEEK > /{target}/{file}")
           .WithBindMount(TestSession.TempDirectoryPath, $"/{target}")
-          .WithWaitStrategy(Wait.ForUnixContainer().UntilFileExists(Path.Combine(TestSession.TempDirectoryPath, file)))
+          .WithWaitStrategy(Wait.ForUnixContainer().UntilFileExists(Path.Combine(TestSession.TempDirectoryPath, file), waitStrategyModifier: o => o.WithMode(WaitStrategyMode.OneShot)))
           .Build();
 
         // When
@@ -336,7 +336,7 @@ namespace DotNet.Testcontainers.Tests.Unit
           .WithEntrypoint("/bin/sh", "-c")
           .WithCommand($"printf \"%s\" \"{unixTimeInMilliseconds}\" | tee /dev/stderr")
           .WithOutputConsumer(consumer)
-          .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(unixTimeInMilliseconds))
+          .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged(unixTimeInMilliseconds, o => o.WithMode(WaitStrategyMode.OneShot)))
           .Build();
 
         await container.StartAsync(TestContext.Current.CancellationToken)


### PR DESCRIPTION
## What does this PR do?

This PR introduces wait strategy modes. Wait strategy modes define how Testcontainers for .NET handles wait strategies. Normally, a wait strategy indicates when a container (and the service inside it) is ready to use. These strategies assume the container stays running.

However, sometimes a container fails to start and exits during startup. In those cases, Testcontainers kept retrying the wait strategy indefinitely, never indicating readiness. From a developer's point of view, it looks like the container startup is just hanging.

This PR updates the internal behavior of wait strategies. They now expect the container to be running. If the container exits unexpectedly, Testcontainers for .NET will collect the exit code and logs, then throw a meaningful exception: `ContainerNotRunningException`, which includes that information.

Some scenarios do not require the container to stay running. For example, running database migrations in a sidecar container during startup. In those cases, it is fine if the container exits after finishing its work. To support this, Testcontainers for .NET now provides wait strategy modes.

If you do not want an exception when a container exits unexpectedly, set the wait strategy mode to `OneShot`.

**TODOs**

- [x] Add integration tests.
- [x] Add docs.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1445
- Closes #1451

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
