### PR TITLE
docs: Remove obsolete UntilOperationIsSucceeded wait strategy example

### DIFF
--- a/docs/api/wait_strategies.md
+++ b/docs/api/wait_strategies.md
@@ -7,7 +7,6 @@ _ = Wait.ForUnixContainer()
   .UntilInternalTcpPortIsAvailable(80)
   .UntilFileExists("/tmp/foo")
   .UntilFileExists("/tmp/bar")
-  .UntilOperationIsSucceeded(() => true, 1)
   .AddCustomWaitStrategy(new MyCustomWaitStrategy());
 ```
 


### PR DESCRIPTION
## What does this PR do?

Remove non-existent method from docs

## Why is it important?

Docs were confusing

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #1202

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
