### PR TITLE
fix: Generate consistent reuse hashes by sorting dictionary keys

### DIFF
--- a/src/Testcontainers/Configurations/Commons/JsonIgnoreRuntimeResourceLabels.cs
+++ b/src/Testcontainers/Configurations/Commons/JsonIgnoreRuntimeResourceLabels.cs
@@ -1,39 +1,20 @@
 namespace DotNet.Testcontainers.Configurations
 {
-  using System;
   using System.Collections.Generic;
   using System.Linq;
   using System.Text.Json;
-  using System.Text.Json.Serialization;
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Containers;
 
-  internal sealed class JsonIgnoreRuntimeResourceLabels : JsonConverter<IReadOnlyDictionary<string, string>>
+  internal sealed class JsonIgnoreRuntimeResourceLabels : JsonOrderedKeysConverter
   {
     private static readonly ISet<string> IgnoreLabels = new HashSet<string> { ResourceReaper.ResourceReaperSessionLabel, TestcontainersClient.TestcontainersVersionLabel, TestcontainersClient.TestcontainersSessionIdLabel };
-
-    public override bool CanConvert(Type typeToConvert)
-    {
-      return typeof(IEnumerable<KeyValuePair<string, string>>).IsAssignableFrom(typeToConvert);
-    }
-
-    public override IReadOnlyDictionary<string, string> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-    {
-      return JsonSerializer.Deserialize<IReadOnlyDictionary<string, string>>(ref reader);
-    }
 
     public override void Write(Utf8JsonWriter writer, IReadOnlyDictionary<string, string> value, JsonSerializerOptions options)
     {
       var labels = value.Where(label => !IgnoreLabels.Contains(label.Key)).ToDictionary(label => label.Key, label => label.Value);
 
-      writer.WriteStartObject();
-
-      foreach (var label in labels)
-      {
-        writer.WriteString(label.Key, label.Value);
-      }
-
-      writer.WriteEndObject();
+      base.Write(writer, labels, options);
     }
   }
 }

--- a/src/Testcontainers/Configurations/Commons/JsonOrderedKeysConverter.cs
+++ b/src/Testcontainers/Configurations/Commons/JsonOrderedKeysConverter.cs
@@ -1,0 +1,33 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+  using System.Text.Json;
+  using System.Text.Json.Serialization;
+
+  internal class JsonOrderedKeysConverter : JsonConverter<IReadOnlyDictionary<string, string>>
+  {
+    public override bool CanConvert(Type typeToConvert)
+    {
+      return typeof(IEnumerable<KeyValuePair<string, string>>).IsAssignableFrom(typeToConvert);
+    }
+
+    public override IReadOnlyDictionary<string, string> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+      return JsonSerializer.Deserialize<IReadOnlyDictionary<string, string>>(ref reader);
+    }
+
+    public override void Write(Utf8JsonWriter writer, IReadOnlyDictionary<string, string> value, JsonSerializerOptions options)
+    {
+      writer.WriteStartObject();
+
+      foreach (var item in value.OrderBy(item => item.Key))
+      {
+        writer.WriteString(item.Key, item.Value);
+      }
+
+      writer.WriteEndObject();
+    }
+  }
+}

--- a/src/Testcontainers/Configurations/Commons/ResourceConfiguration.cs
+++ b/src/Testcontainers/Configurations/Commons/ResourceConfiguration.cs
@@ -14,6 +14,13 @@ namespace DotNet.Testcontainers.Configurations
   [PublicAPI]
   public class ResourceConfiguration<TCreateResourceEntity> : IResourceConfiguration<TCreateResourceEntity>
   {
+    private static readonly JsonSerializerOptions JsonSerializerOptions;
+
+    static ResourceConfiguration()
+    {
+      JsonSerializerOptions = new JsonSerializerOptions { Converters = { new JsonOrderedKeysConverter() } };
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ResourceConfiguration{TCreateResourceEntity}" /> class.
     /// </summary>
@@ -88,7 +95,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     public virtual string GetReuseHash()
     {
-      var jsonUtf8Bytes = JsonSerializer.SerializeToUtf8Bytes(this, GetType());
+      var jsonUtf8Bytes = JsonSerializer.SerializeToUtf8Bytes(this, GetType(), JsonSerializerOptions);
 
 #if NET6_0_OR_GREATER
       return Convert.ToBase64String(SHA1.HashData(jsonUtf8Bytes));

--- a/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
@@ -100,6 +100,44 @@ public sealed class ReusableResourceTest : IAsyncLifetime
 
     public static class ReuseHashTest
     {
+        public sealed class EqualTest
+        {
+            [Fact]
+            [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+            public void ForSameConfigurationCreatedInDifferentOrder()
+            {
+                var env1 = new Dictionary<string, string>
+                {
+                    ["keyA"] = "valueA",
+                    ["keyB"] = "valueB",
+                };
+                var env2 = new Dictionary<string, string>
+                {
+                    ["keyB"] = "valueB",
+                    ["keyA"] = "valueA",
+                };
+                var hash1 = new ReuseHashContainerBuilder().WithEnvironment(env1).WithLabel("labelA", "A").WithLabel("labelB", "B").GetReuseHash();
+                var hash2 = new ReuseHashContainerBuilder().WithEnvironment(env2).WithLabel("labelB", "B").WithLabel("labelA", "A").GetReuseHash();
+                Assert.Equal(hash1, hash2);
+            }
+
+            [Fact]
+            [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+            public void ForGivenConfiguration()
+            {
+                var env = new Dictionary<string, string>
+                {
+                    ["keyB"] = "valueB",
+                    ["keyA"] = "valueA",
+                };
+                var hash = new ReuseHashContainerBuilder().WithEnvironment(env).WithLabel("labelB", "B").WithLabel("labelA", "A").GetReuseHash();
+
+                // 50MEP+vnxEkQFo5PrndJ7oKOfh8= is the base64 encoded SHA1 of this JSON:
+                // {"Image":null,"Name":null,"Entrypoint":null,"Command":[],"Environments":{"keyA":"valueA","keyB":"valueB"},"ExposedPorts":{},"PortBindings":{},"NetworkAliases":[],"ExtraHosts":[],"Labels":{"labelA":"A","labelB":"B","org.testcontainers":"true","org.testcontainers.lang":"dotnet"}}
+                Assert.Equal("50MEP+vnxEkQFo5PrndJ7oKOfh8=", hash);
+            }
+        }
+
         public sealed class NotEqualTest
         {
             [Fact]


### PR DESCRIPTION
## What does this PR do?

This pull request ensures that the JSON used for hashing the configuration have object keys always in the same (alphabetical) order.

## Why is it important?

Hashing JSON data requires the order of the keys to be stable in order to compare equivalent JSON objects by their hashes (which is what is done to identify reused containers).

## Related issues

Closes #1553

## How to test this PR

New tests have been added to ensure that hashing is stable, see ReuseHashTest.EqualTest.

## Follow-ups

Note that this will break reused containers in the next Testcontainers version again, just like it broke between version 4.6.0 and 4.7.0. But reuse is still marked as experimental so we better fix this issue sooner than later.