### PR TITLE
chore: Don't create a static field in a generic class

### DIFF
--- a/src/Testcontainers/Configurations/Commons/DefaultJsonSerializerOptions.cs
+++ b/src/Testcontainers/Configurations/Commons/DefaultJsonSerializerOptions.cs
@@ -2,7 +2,7 @@ namespace DotNet.Testcontainers.Configurations
 {
   using System.Text.Json;
 
-  public static class DefaultJsonSerializerOptions
+  internal static class DefaultJsonSerializerOptions
   {
     static DefaultJsonSerializerOptions()
     {

--- a/src/Testcontainers/Configurations/Commons/DefaultJsonSerializerOptions.cs
+++ b/src/Testcontainers/Configurations/Commons/DefaultJsonSerializerOptions.cs
@@ -1,0 +1,14 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System.Text.Json;
+
+  public static class DefaultJsonSerializerOptions
+  {
+    static DefaultJsonSerializerOptions()
+    {
+      Instance.Converters.Add(new JsonOrderedKeysConverter());
+    }
+
+    public static JsonSerializerOptions Instance { get; } = new JsonSerializerOptions();
+  }
+}

--- a/src/Testcontainers/Configurations/Commons/DefaultJsonSerializerOptions.cs
+++ b/src/Testcontainers/Configurations/Commons/DefaultJsonSerializerOptions.cs
@@ -9,6 +9,7 @@ namespace DotNet.Testcontainers.Configurations
       Instance.Converters.Add(new JsonOrderedKeysConverter());
     }
 
-    public static JsonSerializerOptions Instance { get; } = new JsonSerializerOptions();
+    public static JsonSerializerOptions Instance { get; }
+      = new JsonSerializerOptions();
   }
 }

--- a/src/Testcontainers/Configurations/Commons/JsonIgnoreRuntimeResourceLabels.cs
+++ b/src/Testcontainers/Configurations/Commons/JsonIgnoreRuntimeResourceLabels.cs
@@ -8,12 +8,16 @@ namespace DotNet.Testcontainers.Configurations
 
   internal sealed class JsonIgnoreRuntimeResourceLabels : JsonOrderedKeysConverter
   {
-    private static readonly ISet<string> IgnoreLabels = new HashSet<string> { ResourceReaper.ResourceReaperSessionLabel, TestcontainersClient.TestcontainersVersionLabel, TestcontainersClient.TestcontainersSessionIdLabel };
+    private static readonly ISet<string> IgnoreLabels = new HashSet<string>
+    {
+      ResourceReaper.ResourceReaperSessionLabel,
+      TestcontainersClient.TestcontainersVersionLabel,
+      TestcontainersClient.TestcontainersSessionIdLabel,
+    };
 
     public override void Write(Utf8JsonWriter writer, IReadOnlyDictionary<string, string> value, JsonSerializerOptions options)
     {
       var labels = value.Where(label => !IgnoreLabels.Contains(label.Key)).ToDictionary(label => label.Key, label => label.Value);
-
       base.Write(writer, labels, options);
     }
   }

--- a/src/Testcontainers/Configurations/Commons/ResourceConfiguration.cs
+++ b/src/Testcontainers/Configurations/Commons/ResourceConfiguration.cs
@@ -14,13 +14,6 @@ namespace DotNet.Testcontainers.Configurations
   [PublicAPI]
   public class ResourceConfiguration<TCreateResourceEntity> : IResourceConfiguration<TCreateResourceEntity>
   {
-    private static readonly JsonSerializerOptions JsonSerializerOptions;
-
-    static ResourceConfiguration()
-    {
-      JsonSerializerOptions = new JsonSerializerOptions { Converters = { new JsonOrderedKeysConverter() } };
-    }
-
     /// <summary>
     /// Initializes a new instance of the <see cref="ResourceConfiguration{TCreateResourceEntity}" /> class.
     /// </summary>
@@ -95,7 +88,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     public virtual string GetReuseHash()
     {
-      var jsonUtf8Bytes = JsonSerializer.SerializeToUtf8Bytes(this, GetType(), JsonSerializerOptions);
+      var jsonUtf8Bytes = JsonSerializer.SerializeToUtf8Bytes(this, GetType(), DefaultJsonSerializerOptions.Instance);
 
 #if NET6_0_OR_GREATER
       return Convert.ToBase64String(SHA1.HashData(jsonUtf8Bytes));

--- a/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
@@ -104,37 +104,75 @@ public sealed class ReusableResourceTest : IAsyncLifetime
         {
             [Fact]
             [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
-            public void ForSameConfigurationCreatedInDifferentOrder()
+            public void ForKnownConfiguration()
             {
-                var env1 = new Dictionary<string, string>
-                {
-                    ["keyA"] = "valueA",
-                    ["keyB"] = "valueB",
-                };
-                var env2 = new Dictionary<string, string>
-                {
-                    ["keyB"] = "valueB",
-                    ["keyA"] = "valueA",
-                };
-                var hash1 = new ReuseHashContainerBuilder().WithEnvironment(env1).WithLabel("labelA", "A").WithLabel("labelB", "B").GetReuseHash();
-                var hash2 = new ReuseHashContainerBuilder().WithEnvironment(env2).WithLabel("labelB", "B").WithLabel("labelA", "A").GetReuseHash();
-                Assert.Equal(hash1, hash2);
+                // Given
+                var env = new Dictionary<string, string>();
+                env["keyA"] = "valueA";
+                env["keyB"] = "valueB";
+
+                // When
+                var hash = new ReuseHashContainerBuilder()
+                    .WithEnvironment(env)
+                    .WithLabel("labelA", "A")
+                    .WithLabel("labelB", "B")
+                    .GetReuseHash();
+
+                // Then
+
+                // `50MEP+vnxEkQFo5PrndJ7oKOfh8=` is the Base64-encoded SHA-1 hash of this JSON:
+                //
+                // {
+                //     "Image": null,
+                //     "Name": null,
+                //     "Entrypoint": null,
+                //     "Command": [],
+                //     "Environments": {
+                //         "keyA": "valueA",
+                //         "keyB": "valueB"
+                //     },
+                //     "ExposedPorts": {},
+                //     "PortBindings": {},
+                //     "NetworkAliases": [],
+                //     "ExtraHosts": [],
+                //     "Labels": {
+                //         "labelA": "A",
+                //         "labelB": "B",
+                //         "org.testcontainers": "true",
+                //         "org.testcontainers.lang": "dotnet"
+                //     }
+                // }
+                Assert.Equal("50MEP+vnxEkQFo5PrndJ7oKOfh8=", hash);
             }
 
             [Fact]
             [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
-            public void ForGivenConfiguration()
+            public void ForSameConfigurationInDifferentOrder()
             {
-                var env = new Dictionary<string, string>
-                {
-                    ["keyB"] = "valueB",
-                    ["keyA"] = "valueA",
-                };
-                var hash = new ReuseHashContainerBuilder().WithEnvironment(env).WithLabel("labelB", "B").WithLabel("labelA", "A").GetReuseHash();
+                // Given
+                var env1 = new Dictionary<string, string>();
+                env1["keyA"] = "valueA";
+                env1["keyB"] = "valueB";
 
-                // 50MEP+vnxEkQFo5PrndJ7oKOfh8= is the base64 encoded SHA1 of this JSON:
-                // {"Image":null,"Name":null,"Entrypoint":null,"Command":[],"Environments":{"keyA":"valueA","keyB":"valueB"},"ExposedPorts":{},"PortBindings":{},"NetworkAliases":[],"ExtraHosts":[],"Labels":{"labelA":"A","labelB":"B","org.testcontainers":"true","org.testcontainers.lang":"dotnet"}}
-                Assert.Equal("50MEP+vnxEkQFo5PrndJ7oKOfh8=", hash);
+                var env2 = new Dictionary<string, string>();
+                env2["keyB"] = "valueB";
+                env2["keyA"] = "valueA";
+
+                // When
+                var hash1 = new ReuseHashContainerBuilder()
+                    .WithEnvironment(env1)
+                    .WithLabel("labelA", "A")
+                    .WithLabel("labelB", "B")
+                    .GetReuseHash();
+
+                var hash2 = new ReuseHashContainerBuilder()
+                    .WithEnvironment(env2)
+                    .WithLabel("labelB", "B")
+                    .WithLabel("labelA", "A")
+                    .GetReuseHash();
+
+                // Then
+                Assert.Equal(hash1, hash2);
             }
         }
 

--- a/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
@@ -116,16 +116,12 @@ public sealed class ReusableResourceTest : IAsyncLifetime
                     .WithEnvironment(env)
                     .WithLabel("labelA", "A")
                     .WithLabel("labelB", "B")
-                    // When the port forwarding container runs, Testcontainers automatically adds an
-                    // extra host to the builder configuration. Since this extra host changes the
-                    // hash value, we pin it to keep the hash consistent for assertions.
-                    .WithExtraHost("host.testcontainers.internal", "127.0.0.1")
                     .GetReuseHash();
 
                 // Then
 
                 // The hash is calculated from the minified JSON. For readability, the JSON
-                // shown below is formatted. `d0r7YnGzcm1QQyS0KIVT9DvcayA=` is the
+                // shown below is formatted. `Dtj7Jx6NVlbDUnA3vmH1nNZw+o8=` is the
                 // Base64-encoded SHA-1 hash for this JSON (minified):
                 //
                 // {
@@ -140,9 +136,6 @@ public sealed class ReusableResourceTest : IAsyncLifetime
                 //     "ExposedPorts": {},
                 //     "PortBindings": {},
                 //     "NetworkAliases": [],
-                //     "ExtraHosts": [
-                //         "host.testcontainers.internal:127.0.0.1"
-                //     ],
                 //     "Labels": {
                 //         "labelA": "A",
                 //         "labelB": "B",
@@ -150,7 +143,7 @@ public sealed class ReusableResourceTest : IAsyncLifetime
                 //         "org.testcontainers.lang": "dotnet"
                 //     }
                 // }
-                Assert.Equal("d0r7YnGzcm1QQyS0KIVT9DvcayA=", hash);
+                Assert.Equal("Dtj7Jx6NVlbDUnA3vmH1nNZw+o8=", hash);
             }
 
             [Fact]
@@ -272,7 +265,12 @@ public sealed class ReusableResourceTest : IAsyncLifetime
     private sealed class ReuseHashContainerBuilder : ContainerBuilder<ReuseHashContainerBuilder, DockerContainer, ContainerConfiguration>
     {
         public ReuseHashContainerBuilder() : this(new ContainerConfiguration())
-            => DockerResourceConfiguration = Init().DockerResourceConfiguration;
+        {
+            // By default, the constructor calls `Init()`, which sets up the default builder
+            // configurations, including ones for the port forwarding container if it's running.
+            // To avoid applying those settings during tests, this class intentionally doesn't
+            // call `Init()`.
+        }
 
         private ReuseHashContainerBuilder(ContainerConfiguration configuration) : base(configuration)
             => DockerResourceConfiguration = configuration;

--- a/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
@@ -116,11 +116,17 @@ public sealed class ReusableResourceTest : IAsyncLifetime
                     .WithEnvironment(env)
                     .WithLabel("labelA", "A")
                     .WithLabel("labelB", "B")
+                    // When the port forwarding container runs, Testcontainers automatically adds an
+                    // extra host to the builder configuration. Since this extra host changes the
+                    // hash value, we pin it to keep the hash consistent for assertions.
+                    .WithExtraHost("host.testcontainers.internal", "127.0.0.1")
                     .GetReuseHash();
 
                 // Then
 
-                // `50MEP+vnxEkQFo5PrndJ7oKOfh8=` is the Base64-encoded SHA-1 hash of this JSON:
+                // The hash is calculated from the minified JSON. For readability, the JSON
+                // shown below is formatted. `d0r7YnGzcm1QQyS0KIVT9DvcayA=` is the
+                // Base64-encoded SHA-1 hash for this JSON (minified):
                 //
                 // {
                 //     "Image": null,
@@ -134,7 +140,9 @@ public sealed class ReusableResourceTest : IAsyncLifetime
                 //     "ExposedPorts": {},
                 //     "PortBindings": {},
                 //     "NetworkAliases": [],
-                //     "ExtraHosts": [],
+                //     "ExtraHosts": [
+                //         "host.testcontainers.internal:127.0.0.1"
+                //     ],
                 //     "Labels": {
                 //         "labelA": "A",
                 //         "labelB": "B",
@@ -142,7 +150,7 @@ public sealed class ReusableResourceTest : IAsyncLifetime
                 //         "org.testcontainers.lang": "dotnet"
                 //     }
                 // }
-                Assert.Equal("50MEP+vnxEkQFo5PrndJ7oKOfh8=", hash);
+                Assert.Equal("d0r7YnGzcm1QQyS0KIVT9DvcayA=", hash);
             }
 
             [Fact]


### PR DESCRIPTION
## What does this PR do?

This PR removes a minor code smell. It's generally not recommended to create static fields or properties in a generic class. Typically, a wrapper class is used instead to avoid creating multiple instances.

**Edit**: While looking into the flaky behavior, I noticed it's a known issue. When the port forwarding container starts, Testcontainers automatically adds the extra host to the builder configuration, which causes the hash to change. The PR pins the extra host to a fixed value. This seems to be a general limitation with reuse.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
