### PR TITLE
fix: Compute correct relative Dockerfile file path

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <PackageId>$(AssemblyName)</PackageId>
-    <Version>4.8.0</Version>
+    <Version>4.8.1</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Product>Testcontainers</Product>

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -213,11 +213,11 @@ namespace DotNet.Testcontainers.Images
               .ConfigureAwait(false);
           }
 
-          var dockerfileDirectoryPath = _dockerfileDirectory.FullName
+          var dockerfileDirectoryLength  = _dockerfileDirectory.FullName
             .TrimEnd(Path.DirectorySeparatorChar).Length + 1;
 
           var dockerfileRelativeFilePath = _dockerfile.FullName
-            .Substring(dockerfileDirectoryPath);
+            .Substring(dockerfileDirectoryLength );
 
           var dockerfileNormalizedRelativeFilePath = Unix.Instance.NormalizePath(dockerfileRelativeFilePath);
 

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -213,7 +213,15 @@ namespace DotNet.Testcontainers.Images
               .ConfigureAwait(false);
           }
 
-          await AddAsync(_dockerfile.FullName, _dockerfile.Name, tarOutputStream)
+          var dockerfileDirectoryPath = _dockerfileDirectory.FullName
+            .TrimEnd(Path.DirectorySeparatorChar).Length + 1;
+
+          var dockerfileRelativeFilePath = _dockerfile.FullName
+            .Substring(dockerfileDirectoryPath);
+
+          var dockerfileNormalizedRelativeFilePath = Unix.Instance.NormalizePath(dockerfileRelativeFilePath);
+
+          await AddAsync(_dockerfile.FullName, dockerfileNormalizedRelativeFilePath, tarOutputStream)
             .ConfigureAwait(false);
         }
       }


### PR DESCRIPTION
## What does this PR do?

This PR fixes a regression. The Docker image build may fail on some builder configurations. The `DockerfileArchive` implementation fails to copy the Dockerfile to the correct path in the tarball, which results in a failed image build. Developers might see something like:

> Cannot locate specified Dockerfile: \<path-to-dockerfile\>

Instead of copying the Dockerfile to the correct subdirectory, the `DockerfileArchive` implementation mistakenly copied it to the root of the tarball. This happened because the relative path for the Dockerfile inside the tarball was computed incorrectly.

## Why is it important?

This change is necessary to fix the Docker image build.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1557

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
