### PR TITLE
chore: Make the continuous delivery job fork-friendly

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -89,7 +89,7 @@ jobs:
           path: test-results
 
   cd:
-    if: ${{ contains(fromJson('["develop", "main"]'), github.ref_name) }}
+    if: ${{ github.repository == 'testcontainers/testcontainers-dotnet' && contains(fromJson('["develop", "main"]'), github.ref_name) }}
 
     needs: ci
 

--- a/Testcontainers.sln
+++ b/Testcontainers.sln
@@ -13,6 +13,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{673F23AE-769
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{78E879DE-E97B-4E19-B71B-628ED9FA7F7C}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\cicd.yml = .github\workflows\cicd.yml
+		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
+		.github\workflows\test-report.yml = .github\workflows\test-report.yml
+	EndProjectSection
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testcontainers.ActiveMq", "src\Testcontainers.ActiveMq\Testcontainers.ActiveMq.csproj", "{5365F780-0E6C-41F0-B1B9-7DC34368F80C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testcontainers.ArangoDb", "src\Testcontainers.ArangoDb\Testcontainers.ArangoDb.csproj", "{AB9C1563-07C7-4685-BACD-BB1FF64B3611}"
@@ -878,5 +885,6 @@ Global
 		{EBA72C3B-57D5-43FF-A5B4-3D55B3B6D4C2} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
 		{E901DF14-6F05-4FC2-825A-3055FAD33561} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
 		{B2E8B7FB-7D1E-4DD3-A25E-34DE4386B1EB} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
+		{78E879DE-E97B-4E19-B71B-628ED9FA7F7C} = {AF017206-CE20-4DDF-8301-CAC68CED1BE6}
 	EndGlobalSection
 EndGlobal

--- a/Testcontainers.sln
+++ b/Testcontainers.sln
@@ -9,16 +9,16 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{673F23AE-7694-4BB9-ABD4-136D6C13634E}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{78E879DE-E97B-4E19-B71B-628ED9FA7F7C}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Workflows", "Workflows", "{78E879DE-E97B-4E19-B71B-628ED9FA7F7C}"
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\cicd.yml = .github\workflows\cicd.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 		.github\workflows\test-report.yml = .github\workflows\test-report.yml
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{673F23AE-7694-4BB9-ABD4-136D6C13634E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Testcontainers.ActiveMq", "src\Testcontainers.ActiveMq\Testcontainers.ActiveMq.csproj", "{5365F780-0E6C-41F0-B1B9-7DC34368F80C}"
 EndProject
@@ -763,6 +763,7 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{78E879DE-E97B-4E19-B71B-628ED9FA7F7C} = {AF017206-CE20-4DDF-8301-CAC68CED1BE6}
 		{5365F780-0E6C-41F0-B1B9-7DC34368F80C} = {673F23AE-7694-4BB9-ABD4-136D6C13634E}
 		{AB9C1563-07C7-4685-BACD-BB1FF64B3611} = {673F23AE-7694-4BB9-ABD4-136D6C13634E}
 		{3F2E254F-C203-43FD-A078-DC3E2CBC0F9F} = {673F23AE-7694-4BB9-ABD4-136D6C13634E}
@@ -885,6 +886,5 @@ Global
 		{EBA72C3B-57D5-43FF-A5B4-3D55B3B6D4C2} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
 		{E901DF14-6F05-4FC2-825A-3055FAD33561} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
 		{B2E8B7FB-7D1E-4DD3-A25E-34DE4386B1EB} = {7164F1FB-7F24-444A-ACD2-2C329C2B3CCF}
-		{78E879DE-E97B-4E19-B71B-628ED9FA7F7C} = {AF017206-CE20-4DDF-8301-CAC68CED1BE6}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## What does this PR do?

Run the continuous delivery job only from the testcontainers/testcontainers-dotnet repository.

The secrets required for the `cd` job to run successfully won't be configured in the forks anyway.

## Why is it important?

The continuous delivery job has no reason to be run from forks. It will just end up with errors.

## Related issues

N/A