### PR TITLE
chore: Add script to detect which tests to run in CI

### DIFF
--- a/.github/scripts/Collect-TestProjects.ps1
+++ b/.github/scripts/Collect-TestProjects.ps1
@@ -26,4 +26,5 @@ If ($runsOnNotFound) {
 }
 
 # Filter projects and output as compressed JSON.
-$testProjects | & (Join-Path $PSScriptRoot 'Filter-TestProjects.ps1') | ConvertTo-Json -Compress
+$filteredTestProjects = $testProjects | & (Join-Path $PSScriptRoot 'Filter-TestProjects.ps1') | ConvertTo-Json -AsArray -Compress
+$filteredTestProjects ?? "[]"

--- a/.github/scripts/Filter-TestProjects.ps1
+++ b/.github/scripts/Filter-TestProjects.ps1
@@ -52,6 +52,8 @@ $XUNIT_MODULES = @(
 function Should-RunTests {
     param ([string]$ModuleName)
 
+    return $false
+
     If ($script:branch -In $PROTECTED_BRANCHES) {
         Write-Host "Running '$ModuleName': protected branch '$script:branch'."
         return $true

--- a/.github/scripts/Filter-TestProjects.ps1
+++ b/.github/scripts/Filter-TestProjects.ps1
@@ -7,12 +7,113 @@
     Currently, all projects are passed through unchanged.
 #>
 
-Param (
-    [Parameter(ValueFromPipeline)]
-    $InputObject
+$PROTECTED_BRANCHES = @(
+    'main',
+    'develop'
 )
 
-Process {
-    # Return test projects unchanged.
-    $InputObject
+$GLOBAL_PATTERNS = @(
+    '^\.github/scripts/',
+    '^\.github/workflows/',
+    '^build/',
+    '^Directory\.Build\.props$',
+    '^Directory\.Packages\.props$',
+    '^src/Testcontainers/'
+)
+
+$DATABASE_MODULES = @(
+    'Testcontainers.Cassandra',
+    'Testcontainers.ClickHouse',
+    'Testcontainers.CockroachDb',
+    'Testcontainers.Db2',
+    'Testcontainers.FirebirdSql',
+    'Testcontainers.MariaDb',
+    'Testcontainers.MsSql',
+    'Testcontainers.MySql',
+    'Testcontainers.Oracle',
+    'Testcontainers.PostgreSql',
+    'Testcontainers.Xunit',
+    'Testcontainers.XunitV3'
+)
+
+$ORACLE_MODULES = @(
+    'Testcontainers.Oracle',
+    'Testcontainers.Oracle11',
+    'Testcontainers.Oracle18',
+    'Testcontainers.Oracle21',
+    'Testcontainers.Oracle23'
+)
+
+$XUNIT_MODULES = @(
+    'Testcontainers.Xunit',
+    'Testcontainers.XunitV3'
+)
+
+function Should-RunTests {
+    param ([string]$ModuleName)
+
+    If ($script:branch -In $PROTECTED_BRANCHES) {
+        Write-Host "Running '$ModuleName': protected branch '$script:branch'."
+        return $true
+    }
+
+    ForEach ($pattern In $GLOBAL_PATTERNS) {
+        If ($script:allChangedFiles | Where-Object { $_ -Match $pattern }) {
+            Write-Host "Running '$ModuleName': global changes detected ($pattern)."
+            return $true
+        }
+    }
+
+    If ($script:allChangedFiles | Where-Object { $_ -Match "^(src|tests)/$ModuleName" }) {
+        Write-Host "Running '$ModuleName': module-specific changes detected."
+        return $true
+    }
+
+    If ($ModuleName -In $DATABASE_MODULES -And ($script:allChangedFiles | Where-Object { $_ -Match '^tests/Testcontainers\.Databases\.Tests' })) {
+        Write-Host "Running '$ModuleName': database test changes detected."
+        return $true
+    }
+
+    If ($ModuleName -In $ORACLE_MODULES -And ($script:allChangedFiles | Where-Object { $_ -Match '^(src|tests)/Testcontainers\.Oracle' })) {
+        Write-Host "Running '$ModuleName': Oracle module changes detected."
+        return $true
+    }
+
+    If ($ModuleName -In $XUNIT_MODULES -And ($script:allChangedFiles | Where-Object { $_ -Match '^(src|tests)/Testcontainers\.Xunit(V3)?' })) {
+        Write-Host "Running '$ModuleName': xUnit module changes detected."
+        return $true
+    }
+
+    Write-Host "Skipping '$ModuleName': no relevant changes detected."
+    return $false
 }
+
+function Filter-TestProjects {
+    [CmdletBinding()]
+    Param (
+        [Parameter(ValueFromPipeline = $true)]
+        $TestProject
+    )
+
+    Begin {
+        $script:branch = $env:GITHUB_REF_NAME
+        $script:allChangedFiles = $env:ALL_CHANGED_FILES -Split "`n"
+        $script:filteredModules = @()
+
+        Write-Host "Filtering test projects for branch '$script:branch'."
+        Write-Host "Analyzing $($script:allChangedFiles.Count) changed file(s)."
+    }
+
+    Process {
+        If (Should-RunTests $TestProject.name) {
+            $script:filteredModules += $TestProject
+        }
+    }
+
+    End {
+        Write-Host "Filtered $($script:filteredModules.Count) module(s) will run."
+        $script:filteredModules
+    }
+}
+
+$input | Filter-TestProjects

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,6 +51,8 @@ jobs:
           ALL_CHANGED_FILES: ${{ steps.get-all-changed-files.outputs.all_changed_files }}
 
   ci:
+    if: ${{ needs.collect-test-projects.outputs.test-projects != '[]' }}
+
     needs: collect-test-projects
 
     strategy:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,10 +39,16 @@ jobs:
         with:
           lfs: true
 
+      - id: get-all-changed-files
+        name: Collect Changed Files
+        uses: tj-actions/changed-files@v47
+
       - id: set-test-projects
         name: Collect Test Projects
         shell: pwsh
         run: echo "test-projects=$(.github/scripts/Collect-TestProjects.ps1)" >> $env:GITHUB_OUTPUT
+        env:
+          ALL_CHANGED_FILES: ${{ steps.get-all-changed-files.outputs.all_changed_files }}
 
   ci:
     needs: collect-test-projects

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -35,8 +35,8 @@ jobs:
           name: test-report
           path: '**/*.trx'
           reporter: dotnet-trx
-          fail-on-empty: false
           only-summary: true
           use-actions-summary: false
           list-suites: failed
           list-tests: failed
+          fail-on-empty: false

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -35,6 +35,7 @@ jobs:
           name: test-report
           path: '**/*.trx'
           reporter: dotnet-trx
+          fail-on-empty: false
           only-summary: true
           use-actions-summary: false
           list-suites: failed


### PR DESCRIPTION
## What does this PR do?

This PR adds a script that filters which test projects need to run based on the list of changed files.
The CI workflow gathers all available test projects and passes them to the script for filtering.

For the `main` and `develop` branches, all tests still run as usual.

@digital88 WDYT? It's quite aligned with your version. This version doesn't yet make use of file extensions, which we should probably include. I also like the comments and explanations in your version, which we should add as well.

## Why is it important?

This should help reduce CI usage and overall build time, especially for pull requests.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1136
- Closes #1417

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
