### PR TITLE
fix: Split ALL_CHANGED_FILES on any whitespace

### DIFF
--- a/.github/scripts/Filter-TestProjects.ps1
+++ b/.github/scripts/Filter-TestProjects.ps1
@@ -117,7 +117,7 @@ function Filter-TestProjects {
 
     Begin {
         $script:branch = $env:GITHUB_REF_NAME
-        $script:allChangedFiles = $env:ALL_CHANGED_FILES -Split "`n"
+        $script:allChangedFiles = $env:ALL_CHANGED_FILES -Split "[\s\t\n]"
         $script:filteredModules = @()
 
         Write-Host "Filtering test projects for branch '$script:branch'."

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,10 +3,8 @@ name: Continuous Integration & Delivery
 on:
   push:
     branches: [ develop, main, bugfix/*, feature/* ]
-    paths-ignore: [ 'docs/**', 'examples/**' ]
   pull_request:
     branches: [ develop, main ]
-    paths-ignore: [ 'docs/**', 'examples/**' ]
   workflow_dispatch:
     inputs:
       publish_nuget_package:


### PR DESCRIPTION
## What does this PR do?

This PR fixes an issue in the incremental build and test setup. The GH Action step that collects all changed files doesn't use `\n` as a separator. It uses spaces. I updated the split implementation to split on any whitespace.

Previously, the `allChangedFiles` variable only contained a single string with all changed files, which caused the wrong test configurations to run. @digital88, we should double-check whether filenames with spaces might break this. According to the docs, the [GH Action](https://github.com/tj-actions/changed-files) step lets you configure the separator, and the default is supposed to be `\n`, but that doesn't seem to be the case (probably I misunderstood the docs).

## Why is it important?

To select and run the appropriate test projects.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
