### PR TITLE
chore: Update Toxiproxy NuGet dependency to a .NET compatible version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": true
     },
-    "ghcr.io/devcontainers/features/dotnet:2.2.2": {
+    "ghcr.io/devcontainers/features/dotnet:2.4.0": {
       "version": "9.0",
       "installUsingApt": false
     }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -88,6 +88,6 @@
         <PackageVersion Include="RavenDB.Client" Version="5.4.100"/>
         <PackageVersion Include="Selenium.WebDriver" Version="4.8.1"/>
         <PackageVersion Include="StackExchange.Redis" Version="2.6.90"/>
-        <PackageVersion Include="Toxiproxy.Net" Version="2.0.1"/>
+        <PackageVersion Include="ToxiproxyNetCore" Version="1.0.40"/>
     </ItemGroup>
 </Project>

--- a/Testcontainers.dic
+++ b/Testcontainers.dic
@@ -35,5 +35,6 @@ testcontainer
 testcontainers
 tlsverify
 toml
+toxiproxy
 vstest
 weaviate

--- a/Testcontainers.sln.DotSettings
+++ b/Testcontainers.sln.DotSettings
@@ -44,6 +44,7 @@
   <s:Boolean x:Key="/Default/UserDictionary/Words/=testcontainers/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=tlsverify/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=toml/@EntryIndexedValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/UserDictionary/Words/=toxiproxy/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=vstest/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/UserDictionary/Words/=weaviate/@EntryIndexedValue">True</s:Boolean>
   <s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">DO_NOT_SHOW</s:String>

--- a/docs/modules/playwright.md
+++ b/docs/modules/playwright.md
@@ -41,7 +41,7 @@ To execute the tests, use the command `dotnet test` from a terminal.
 The Playwright container is configured with a network that can be shared with other containers. This is useful when testing applications that need to communicate with other services. Use the `GetNetwork()` method to access the container's network:
 
 ```csharp
-var helloWorldContainer = new ContainerBuilder()
-    .WithNetwork(playwrightContainer.GetNetwork())
+IContainer _helloWorldContainer = new ContainerBuilder()
+    .WithNetwork(_playwrightContainer.GetNetwork())
     .Build();
 ```

--- a/docs/modules/playwright.md
+++ b/docs/modules/playwright.md
@@ -41,7 +41,7 @@ To execute the tests, use the command `dotnet test` from a terminal.
 The Playwright container is configured with a network that can be shared with other containers. This is useful when testing applications that need to communicate with other services. Use the `GetNetwork()` method to access the container's network:
 
 ```csharp
-IContainer _helloWorldContainer = new ContainerBuilder()
+IContainer helloWorldContainer = new ContainerBuilder()
     .WithNetwork(_playwrightContainer.GetNetwork())
     .Build();
 ```

--- a/src/Testcontainers.Mosquitto/MosquittoBuilder.cs
+++ b/src/Testcontainers.Mosquitto/MosquittoBuilder.cs
@@ -1,4 +1,4 @@
-﻿namespace Testcontainers.Mosquitto;
+namespace Testcontainers.Mosquitto;
 
 /// <inheritdoc cref="ContainerBuilder{TBuilderEntity, TContainerEntity, TConfigurationEntity}" />
 [PublicAPI]

--- a/src/Testcontainers.Mosquitto/MosquittoConfiguration.cs
+++ b/src/Testcontainers.Mosquitto/MosquittoConfiguration.cs
@@ -1,4 +1,4 @@
-﻿namespace Testcontainers.Mosquitto;
+namespace Testcontainers.Mosquitto;
 
 /// <inheritdoc cref="ContainerConfiguration" />
 [PublicAPI]

--- a/src/Testcontainers.Mosquitto/MosquittoContainer.cs
+++ b/src/Testcontainers.Mosquitto/MosquittoContainer.cs
@@ -1,4 +1,4 @@
-﻿namespace Testcontainers.Mosquitto;
+namespace Testcontainers.Mosquitto;
 
 /// <inheritdoc cref="DockerContainer" />
 [PublicAPI]

--- a/src/Testcontainers.Mosquitto/Testcontainers.Mosquitto.csproj
+++ b/src/Testcontainers.Mosquitto/Testcontainers.Mosquitto.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net8.0;net9.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>latest</LangVersion>

--- a/tests/Testcontainers.Mosquitto.Tests/Testcontainers.Mosquitto.Tests.csproj
+++ b/tests/Testcontainers.Mosquitto.Tests/Testcontainers.Mosquitto.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net9.0</TargetFrameworks>
         <IsPackable>false</IsPackable>

--- a/tests/Testcontainers.Toxiproxy.Tests/Testcontainers.Toxiproxy.Tests.csproj
+++ b/tests/Testcontainers.Toxiproxy.Tests/Testcontainers.Toxiproxy.Tests.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="coverlet.collector"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
         <PackageReference Include="xunit.v3"/>
-        <PackageReference Include="Toxiproxy.Net"/>
+        <PackageReference Include="ToxiproxyNetCore"/>
         <PackageReference Include="StackExchange.Redis"/>
         <!-- -8<- [end:PackageReferences] -->
     </ItemGroup>

--- a/tests/Testcontainers.Toxiproxy.Tests/ToxiproxyContainerTest.cs
+++ b/tests/Testcontainers.Toxiproxy.Tests/ToxiproxyContainerTest.cs
@@ -73,7 +73,9 @@ public sealed class ToxiproxyContainerTest : IAsyncLifetime
         proxy.Enabled = true;
         proxy.Listen = "0.0.0.0:" + redisProxyPort;
         proxy.Upstream = RedisNetworkAlias + ":6379";
-        var redisProxy = client.Add(proxy);
+
+        var redisProxy = await client.AddAsync(proxy)
+            .ConfigureAwait(true);
         // # --8<-- [end:ProxyConfiguration]
 
         // Don't establish a connection directly to the Redis container.
@@ -104,7 +106,9 @@ public sealed class ToxiproxyContainerTest : IAsyncLifetime
         latencyToxic.Toxicity = 1;
         latencyToxic.Attributes.Latency = 1100;
         latencyToxic.Attributes.Jitter = 100;
-        redisProxy.Add(latencyToxic);
+
+        await redisProxy.AddAsync(latencyToxic)
+            .ConfigureAwait(true);
         // # --8<-- [end:ToxicConfiguration]
 
         var latencyWithToxic = await MeasureLatencyAsync(db, key, value)


### PR DESCRIPTION
## What does this PR do?

This PR fixes a few minor issues that came up after merging other PRs and tidies up some small inconsistencies that slipped through.

- Updates the Toxiproxy NuGet dependency to a version compatible with .NET (not just the legacy framework). Unfortunately, both available implementations seem a bit outdated and inactive.
- Removes unnecessary BOMs and converts files to UTF-8 encoding.
- Updates the .NET feature in the Dev Containers configuration.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
