### PR TITLE
fix(Milvus): Set DEPLOY_MODE=STANDALONE (necessary for v2.6+)

### DIFF
--- a/src/Testcontainers.Milvus/MilvusBuilder.cs
+++ b/src/Testcontainers.Milvus/MilvusBuilder.cs
@@ -64,6 +64,7 @@ public sealed class MilvusBuilder : ContainerBuilder<MilvusBuilder, MilvusContai
             .WithPortBinding(MilvusManagementPort, true)
             .WithPortBinding(MilvusGrpcPort, true)
             .WithCommand("milvus", "run", "standalone")
+            .WithEnvironment("DEPLOY_MODE", "STANDALONE")
             .WithEnvironment("COMMON_STORAGETYPE", "local")
             // For embedded etcd only; see WithEtcdEndpoint(string) for using an external etcd.
             .WithEnvironment("ETCD_USE_EMBED", "true")


### PR DESCRIPTION
## What does this PR do?

Fix Milvus test container for v2.6+ following this script

https://github.com/milvus-io/milvus/blob/b1af0df9f34bb66ce414df7694cd082b96307596/scripts/standalone_embed.sh#L50

## Why is it important?

The container wouldn't start. See https://github.com/milvus-io/milvus/discussions/45420.
