### PR TITLE
fix(Milvus): Use healthcheck wait strategy

### DIFF
--- a/src/Testcontainers.Milvus/MilvusBuilder.cs
+++ b/src/Testcontainers.Milvus/MilvusBuilder.cs
@@ -71,8 +71,7 @@ public sealed class MilvusBuilder : ContainerBuilder<MilvusBuilder, MilvusContai
             .WithEnvironment("ETCD_CONFIG_PATH", MilvusEtcdConfigFilePath)
             .WithEnvironment("ETCD_DATA_DIR", "/var/lib/milvus/etcd")
             .WithResourceMapping(EtcdConfig, MilvusEtcdConfigFilePath)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
-                request.ForPort(MilvusManagementPort).ForPath("/healthz")))
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilContainerIsHealthy())
             .WithCreateParameterModifier(parameterModifier =>
                 parameterModifier.Healthcheck = Healthcheck.Instance);
     }

--- a/tests/Testcontainers.Milvus.Tests/MilvusContainerTest.cs
+++ b/tests/Testcontainers.Milvus.Tests/MilvusContainerTest.cs
@@ -2,8 +2,6 @@ namespace Testcontainers.Milvus;
 
 public abstract class MilvusContainerTest : IAsyncLifetime
 {
-    private const string MilvusVersion = "v2.3.10";
-
     private readonly MilvusContainer _milvusContainer;
 
     private MilvusContainerTest(MilvusContainer milvusContainer)
@@ -37,7 +35,7 @@ public abstract class MilvusContainerTest : IAsyncLifetime
             .ConfigureAwait(true);
 
         // Then
-        Assert.Equal(MilvusVersion, version);
+        Assert.EndsWith(version, MilvusBuilder.MilvusImage);
     }
 
     protected virtual ValueTask DisposeAsyncCore()
@@ -49,7 +47,7 @@ public abstract class MilvusContainerTest : IAsyncLifetime
     public sealed class MilvusDefaultConfiguration : MilvusContainerTest
     {
         public MilvusDefaultConfiguration()
-            : base(new MilvusBuilder().WithImage("milvusdb/milvus:" + MilvusVersion).Build())
+            : base(new MilvusBuilder().Build())
         {
         }
     }
@@ -64,7 +62,6 @@ public abstract class MilvusContainerTest : IAsyncLifetime
 
         private MilvusSidecarConfiguration(INetwork network)
             : base(new MilvusBuilder()
-                .WithImage("milvusdb/milvus:" + MilvusVersion)
                 .WithEtcdEndpoint("etcd:2379")
                 .DependsOn(new ContainerBuilder()
                     .WithImage("quay.io/coreos/etcd:v3.5.5")


### PR DESCRIPTION
Since we upgraded to Milvus 2.6, our tests started to randomly fail with `[service unavailable: internal: Milvus Proxy is not ready yet. please wait`. More info here https://github.com/milvus-io/milvus-sdk-csharp/pull/123.

My understanding is that even though the request to /healthz succeeds, Milvus might not be completely ready yet.

The fix is to imitate exactly what https://github.com/milvus-io/milvus/blob/master/scripts/standalone_embed.sh does.
