### PR TITLE
feat: Add connection string provider

### DIFF
--- a/docs/api/connection_string_provider.md
+++ b/docs/api/connection_string_provider.md
@@ -29,7 +29,7 @@ var containerConnectionString = container.GetConnectionString(ConnectionMode.Con
 
 To create a custom provider, implement the generic interface: `IConnectionStringProvider<TContainer, TConfiguration>`. The `Configure(TContainer, TConfiguration)` method is invoked after the container has successfully started, ensuring that all runtime-assigned values are available.
 
-=== "Generic provider"
+=== "Generic builder"
     ```csharp
     public sealed class MyProvider1 : IConnectionStringProvider<IContainer, IContainerConfiguration>
     {
@@ -54,23 +54,29 @@ To create a custom provider, implement the generic interface: `IConnectionString
     }
     ```
 
-=== "Module provider"
+=== "Module builder"
     ```csharp
     public sealed class MyProvider2 : IConnectionStringProvider<PostgreSqlContainer, PostgreSqlConfiguration>
     {
+      private string _host;
+
+      private ushort _port;
+
       public void Configure(PostgreSqlContainer container, PostgreSqlConfiguration configuration)
       {
-        // Initialize provider with PostgreSQL-specific container information.
+        // Initialize provider with container information.
+        _host = container.Hostname;
+        _port = container.GetMappedPublicPort(PostgreSqlBuilder.PostgreSqlPort);
       }
 
       public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)
       {
-        return "Host=localhost;Port=5432;...";
+        return $"Host={_host};Port={_port};...";
       }
 
       public string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host)
       {
-        return "Host=localhost;Port=5432;...;SSL Mode=Require";
+        return $"Host={_host};Port={_port};...;SSL Mode=Require";
       }
     }
     ```

--- a/docs/api/connection_string_provider.md
+++ b/docs/api/connection_string_provider.md
@@ -1,0 +1,78 @@
+# Connection String Provider
+
+The Connection String Provider API provides a standardized way to access and manage connection information for Testcontainers modules. It allows developers to customize module-provided connection strings or add their own, and to access module-specific connection strings or endpoints (e.g., database connection strings, HTTP API base addresses) in a uniform way.
+
+!!!note
+
+    Testcontainers modules do not yet implement this feature. Developers can use the provider to define and manage their own connection strings or endpoints. Providers will be integrated by the modules in future releases.
+
+## Example
+
+Register a custom connection string provider via the container builder:
+
+```csharp
+IContainer container = new ContainerBuilder()
+  .WithConnectionStringProvider(new MyProvider1())
+  .Build();
+
+// Implicit host connection string (default)
+var hostConnectionStringImplicit = container.GetConnectionString();
+
+// Explicit host connection string
+var hostConnectionStringExplicit = container.GetConnectionString(ConnectionMode.Host);
+
+// Container-to-container connection string
+var containerConnectionString = container.GetConnectionString(ConnectionMode.Container);
+```
+
+## Implementing a custom provider
+
+To create a custom provider, implement the generic interface: `IConnectionStringProvider<TContainer, TConfiguration>`.
+
+### Example: Generic provider
+
+```csharp
+public sealed class MyProvider1 : IConnectionStringProvider<IContainer, IContainerConfiguration>
+{
+  public void Configure(IContainer container, IContainerConfiguration configuration)
+  {
+    // Initialize provider with container information.
+  }
+
+  public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)
+  {
+    // This method returns a default connection string. The connection mode argument
+    // lets you choose between a host connection or a container-to-container connection.
+    return "...";
+  }
+
+  public string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host)
+  {
+    // This method returns a connection string for the given name. Useful for modules
+    // with multiple endpoints (e.g., Azurite blob, queue, or table).
+    return "...";
+  }
+}
+```
+
+### Example: Module provider
+
+```csharp
+public sealed class MyProvider2 : IConnectionStringProvider<PostgreSqlContainer, PostgreSqlConfiguration>
+{
+  public void Configure(PostgreSqlContainer container, PostgreSqlConfiguration configuration)
+  {
+    // Initialize provider with PostgreSQL-specific container information.
+  }
+
+  public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)
+  {
+    return "Host=localhost;Port=5432;...";
+  }
+
+  public string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host)
+  {
+    return "Host=localhost;Port=5432;...;SSL Mode=Require";
+  }
+}
+```

--- a/docs/api/connection_string_provider.md
+++ b/docs/api/connection_string_provider.md
@@ -1,10 +1,10 @@
 # Connection String Provider
 
-The Connection String Provider API provides a standardized way to access and manage connection information for Testcontainers modules. It allows developers to customize module-provided connection strings or add their own, and to access module-specific connection strings or endpoints (e.g., database connection strings, HTTP API base addresses) in a uniform way.
+The Connection String Provider API provides a standardized way to access and manage connection information for Testcontainers (modules). It allows developers to customize module-provided connection strings or add their own, and to access module-specific connection strings or endpoints (e.g., database connection strings, HTTP API base addresses) in a uniform way.
 
 !!!note
 
-    Testcontainers modules do not yet implement this feature. Developers can use the provider to define and manage their own connection strings or endpoints. Providers will be integrated by the modules in future releases.
+    Testcontainers modules do not yet implement this feature. Developers can use the provider to define and manage their own connection strings or endpoints. Providers will be integrated by modules in future releases.
 
 ## Example
 
@@ -27,52 +27,50 @@ var containerConnectionString = container.GetConnectionString(ConnectionMode.Con
 
 ## Implementing a custom provider
 
-To create a custom provider, implement the generic interface: `IConnectionStringProvider<TContainer, TConfiguration>`.
+To create a custom provider, implement the generic interface: `IConnectionStringProvider<TContainer, TConfiguration>`. The `Configure(TContainer, TConfiguration)` method is invoked after the container has successfully started, ensuring that all runtime-assigned values are available.
 
-### Example: Generic provider
+=== "Generic provider"
+    ```csharp
+    public sealed class MyProvider1 : IConnectionStringProvider<IContainer, IContainerConfiguration>
+    {
+      public void Configure(IContainer container, IContainerConfiguration configuration)
+      {
+        // Initialize provider with container information.
+      }
 
-```csharp
-public sealed class MyProvider1 : IConnectionStringProvider<IContainer, IContainerConfiguration>
-{
-  public void Configure(IContainer container, IContainerConfiguration configuration)
-  {
-    // Initialize provider with container information.
-  }
+      public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)
+      {
+        // This method returns a default connection string. The connection mode argument
+        // lets you choose between a host connection or a container-to-container connection.
+        return "...";
+      }
 
-  public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)
-  {
-    // This method returns a default connection string. The connection mode argument
-    // lets you choose between a host connection or a container-to-container connection.
-    return "...";
-  }
+      public string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host)
+      {
+        // This method returns a connection string for the given name. Useful for modules
+        // with multiple endpoints (e.g., Azurite blob, queue, or table).
+        return "...";
+      }
+    }
+    ```
 
-  public string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host)
-  {
-    // This method returns a connection string for the given name. Useful for modules
-    // with multiple endpoints (e.g., Azurite blob, queue, or table).
-    return "...";
-  }
-}
-```
+=== "Module provider"
+    ```csharp
+    public sealed class MyProvider2 : IConnectionStringProvider<PostgreSqlContainer, PostgreSqlConfiguration>
+    {
+      public void Configure(PostgreSqlContainer container, PostgreSqlConfiguration configuration)
+      {
+        // Initialize provider with PostgreSQL-specific container information.
+      }
 
-### Example: Module provider
+      public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)
+      {
+        return "Host=localhost;Port=5432;...";
+      }
 
-```csharp
-public sealed class MyProvider2 : IConnectionStringProvider<PostgreSqlContainer, PostgreSqlConfiguration>
-{
-  public void Configure(PostgreSqlContainer container, PostgreSqlConfiguration configuration)
-  {
-    // Initialize provider with PostgreSQL-specific container information.
-  }
-
-  public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)
-  {
-    return "Host=localhost;Port=5432;...";
-  }
-
-  public string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host)
-  {
-    return "Host=localhost;Port=5432;...;SSL Mode=Require";
-  }
-}
-```
+      public string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host)
+      {
+        return "Host=localhost;Port=5432;...;SSL Mode=Require";
+      }
+    }
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - api/resource_reaper.md
   - api/resource_reuse.md
   - api/wait_strategies.md
+  - api/connection_string_provider.md
   - api/best_practices.md
   - dind/index.md
   - full_framework/index.md

--- a/src/Testcontainers.Couchbase/CouchbaseBuilder.cs
+++ b/src/Testcontainers.Couchbase/CouchbaseBuilder.cs
@@ -179,7 +179,7 @@ public sealed class CouchbaseBuilder : ContainerBuilder<CouchbaseBuilder, Couchb
     /// <summary>
     /// Configures the Couchbase node.
     /// </summary>
-    /// <param name="container">The container.</param>
+    /// <param name="container">The Couchbase container.</param>
     /// <param name="ct">Cancellation token.</param>
     private async Task ConfigureCouchbaseAsync(IContainer container, CancellationToken ct = default)
     {

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -397,6 +397,12 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <inheritdoc />
+    public TBuilderEntity WithConnectionStringProvider(IConnectionStringProvider<TContainerEntity, TConfigurationEntity> connectionStringProvider)
+    {
+      return Clone(new ContainerConfiguration(connectionStringProvider: new ConnectionStringProvider<TContainerEntity, TConfigurationEntity>(connectionStringProvider)));
+    }
+
+    /// <inheritdoc />
     protected override TBuilderEntity Init()
     {
       return base.Init().WithImagePullPolicy(PullPolicy.Missing).WithPortForwarding().WithOutputConsumer(Consume.DoNotConsumeStdoutAndStderr()).WithWaitStrategy(Wait.ForUnixContainer()).WithStartupCallback((_, _, _) => Task.CompletedTask);

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -21,6 +21,8 @@ namespace DotNet.Testcontainers.Builders
   /// <typeparam name="TConfigurationEntity">The configuration entity.</typeparam>
   [PublicAPI]
   public interface IContainerBuilder<out TBuilderEntity, out TContainerEntity, out TConfigurationEntity> : IAbstractBuilder<TBuilderEntity, TContainerEntity, CreateContainerParameters>
+    where TContainerEntity : IContainer
+    where TConfigurationEntity : IContainerConfiguration
   {
     /// <summary>
     /// Accepts the license agreement.
@@ -500,5 +502,13 @@ namespace DotNet.Testcontainers.Builders
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithStartupCallback(Func<TContainerEntity, TConfigurationEntity, CancellationToken, Task> startupCallback);
+
+    /// <summary>
+    /// Sets the connection string provider.
+    /// </summary>
+    /// <param name="connectionStringProvider">The connection string provider.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
+    TBuilderEntity WithConnectionStringProvider(IConnectionStringProvider<TContainerEntity, TConfigurationEntity> connectionStringProvider);
   }
 }

--- a/src/Testcontainers/Configurations/Containers/ConnectionMode.cs
+++ b/src/Testcontainers/Configurations/Containers/ConnectionMode.cs
@@ -1,0 +1,21 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Represents the connection mode.
+  /// </summary>
+  [PublicAPI]
+  public enum ConnectionMode
+  {
+    /// <summary>
+    /// The connection string for the container.
+    /// </summary>
+    Container,
+
+    /// <summary>
+    /// The connection string for the host.
+    /// </summary>
+    Host,
+  }
+}

--- a/src/Testcontainers/Configurations/Containers/ConnectionStringProvider.cs
+++ b/src/Testcontainers/Configurations/Containers/ConnectionStringProvider.cs
@@ -10,7 +10,7 @@ namespace DotNet.Testcontainers.Configurations
     private readonly IConnectionStringProvider<TContainerEntity, TConfigurationEntity> _connectionStringProvider;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ContainerConfiguration" /> class.
+    /// Initializes a new instance of the <see cref="ConnectionStringProvider{TContainerEntity, TConfigurationEntity}" /> class.
     /// </summary>
     /// <param name="connectionStringProvider">The connection string provider.</param>
     public ConnectionStringProvider(IConnectionStringProvider<TContainerEntity, TConfigurationEntity> connectionStringProvider)

--- a/src/Testcontainers/Configurations/Containers/ConnectionStringProvider.cs
+++ b/src/Testcontainers/Configurations/Containers/ConnectionStringProvider.cs
@@ -1,0 +1,39 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using DotNet.Testcontainers.Containers;
+
+  /// <inheritdoc cref="IConnectionStringProvider{TContainerEntity, TConfigurationEntity}" />
+  internal sealed class ConnectionStringProvider<TContainerEntity, TConfigurationEntity> : IConnectionStringProvider<IContainer, IContainerConfiguration>
+    where TContainerEntity : IContainer
+    where TConfigurationEntity : IContainerConfiguration
+  {
+    private readonly IConnectionStringProvider<TContainerEntity, TConfigurationEntity> _connectionStringProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ContainerConfiguration" /> class.
+    /// </summary>
+    /// <param name="connectionStringProvider">The connection string provider.</param>
+    public ConnectionStringProvider(IConnectionStringProvider<TContainerEntity, TConfigurationEntity> connectionStringProvider)
+    {
+      _connectionStringProvider = connectionStringProvider;
+    }
+
+    /// <inheritdoc />
+    public void Configure(IContainer container, IContainerConfiguration configuration)
+    {
+      _connectionStringProvider.Configure((TContainerEntity)container, (TConfigurationEntity)configuration);
+    }
+
+    /// <inheritdoc />
+    public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)
+    {
+      return _connectionStringProvider.GetConnectionString(connectionMode);
+    }
+
+    /// <inheritdoc />
+    public string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host)
+    {
+      return _connectionStringProvider.GetConnectionString(name, connectionMode);
+    }
+  }
+}

--- a/src/Testcontainers/Configurations/Containers/ConnectionStringProvider.cs
+++ b/src/Testcontainers/Configurations/Containers/ConnectionStringProvider.cs
@@ -1,5 +1,6 @@
 namespace DotNet.Testcontainers.Configurations
 {
+  using System;
   using DotNet.Testcontainers.Containers;
 
   /// <inheritdoc cref="IConnectionStringProvider{TContainerEntity, TConfigurationEntity}" />
@@ -21,7 +22,17 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     public void Configure(IContainer container, IContainerConfiguration configuration)
     {
-      _connectionStringProvider.Configure((TContainerEntity)container, (TConfigurationEntity)configuration);
+      if (container is not TContainerEntity typedContainer)
+      {
+        throw new InvalidCastException($"Expected container type '{typeof(TContainerEntity).FullName}', but received '{container.GetType().FullName}'.");
+      }
+
+      if (configuration is not TConfigurationEntity typedConfiguration)
+      {
+        throw new InvalidCastException($"Expected configuration type '{typeof(TConfigurationEntity).FullName}', but received '{configuration.GetType().FullName}'.");
+      }
+
+      _connectionStringProvider.Configure(typedContainer, typedConfiguration);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Configurations/Containers/ConnectionStringProvider.cs
+++ b/src/Testcontainers/Configurations/Containers/ConnectionStringProvider.cs
@@ -1,6 +1,5 @@
 namespace DotNet.Testcontainers.Configurations
 {
-  using System;
   using DotNet.Testcontainers.Containers;
 
   /// <inheritdoc cref="IConnectionStringProvider{TContainerEntity, TConfigurationEntity}" />
@@ -22,17 +21,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     public void Configure(IContainer container, IContainerConfiguration configuration)
     {
-      if (container is not TContainerEntity typedContainer)
-      {
-        throw new InvalidCastException($"Expected container type '{typeof(TContainerEntity).FullName}', but received '{container.GetType().FullName}'.");
-      }
-
-      if (configuration is not TConfigurationEntity typedConfiguration)
-      {
-        throw new InvalidCastException($"Expected configuration type '{typeof(TConfigurationEntity).FullName}', but received '{configuration.GetType().FullName}'.");
-      }
-
-      _connectionStringProvider.Configure(typedContainer, typedConfiguration);
+      _connectionStringProvider.Configure((TContainerEntity)container, (TConfigurationEntity)configuration);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
@@ -62,6 +62,7 @@ namespace DotNet.Testcontainers.Configurations
       IOutputConsumer outputConsumer = null,
       IEnumerable<WaitStrategy> waitStrategies = null,
       Func<IContainer, IContainerConfiguration, CancellationToken, Task> startupCallback = null,
+      IConnectionStringProvider<IContainer, IContainerConfiguration> connectionStringProvider = null,
       bool? autoRemove = null,
       bool? privileged = null)
     {
@@ -87,6 +88,7 @@ namespace DotNet.Testcontainers.Configurations
       OutputConsumer = outputConsumer;
       WaitStrategies = waitStrategies;
       StartupCallback = startupCallback;
+      ConnectionStringProvider = connectionStringProvider;
     }
 
     /// <summary>
@@ -135,6 +137,7 @@ namespace DotNet.Testcontainers.Configurations
       OutputConsumer = BuildConfiguration.Combine(oldValue.OutputConsumer, newValue.OutputConsumer);
       WaitStrategies = BuildConfiguration.Combine<IEnumerable<WaitStrategy>>(oldValue.WaitStrategies, newValue.WaitStrategies);
       StartupCallback = BuildConfiguration.Combine(oldValue.StartupCallback, newValue.StartupCallback);
+      ConnectionStringProvider = BuildConfiguration.Combine(oldValue.ConnectionStringProvider, newValue.ConnectionStringProvider);
       AutoRemove = (oldValue.AutoRemove.HasValue && oldValue.AutoRemove.Value) || (newValue.AutoRemove.HasValue && newValue.AutoRemove.Value);
       Privileged = (oldValue.Privileged.HasValue && oldValue.Privileged.Value) || (newValue.Privileged.HasValue && newValue.Privileged.Value);
     }
@@ -217,5 +220,9 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     [JsonIgnore]
     public Func<IContainer, IContainerConfiguration, CancellationToken, Task> StartupCallback { get; }
+
+    /// <inheritdoc />
+    [JsonIgnore]
+    public IConnectionStringProvider<IContainer, IContainerConfiguration> ConnectionStringProvider { get; }
   }
 }

--- a/src/Testcontainers/Configurations/Containers/IConnectionStringProvider.cs
+++ b/src/Testcontainers/Configurations/Containers/IConnectionStringProvider.cs
@@ -1,5 +1,6 @@
 namespace DotNet.Testcontainers.Configurations
 {
+  using DotNet.Testcontainers.Containers;
   using JetBrains.Annotations;
 
   /// <summary>
@@ -13,6 +14,7 @@ namespace DotNet.Testcontainers.Configurations
     /// </summary>
     /// <param name="connectionMode">The connection mode.</param>
     /// <returns>The connection string.</returns>
+    /// <exception cref="ConnectionStringProviderNotConfiguredException">Thrown when the connection string provider is not configured.</exception>
     [NotNull]
     string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host);
 
@@ -22,6 +24,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="name">The connection string name.</param>
     /// <param name="connectionMode">The connection mode.</param>
     /// <returns>The connection string.</returns>
+    /// <exception cref="ConnectionStringProviderNotConfiguredException">Thrown when the connection string provider is not configured.</exception>
     [NotNull]
     string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host);
   }

--- a/src/Testcontainers/Configurations/Containers/IConnectionStringProvider.cs
+++ b/src/Testcontainers/Configurations/Containers/IConnectionStringProvider.cs
@@ -1,0 +1,28 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// A connection string provider.
+  /// </summary>
+  [PublicAPI]
+  public interface IConnectionStringProvider
+  {
+    /// <summary>
+    /// Gets the connection string.
+    /// </summary>
+    /// <param name="connectionMode">The connection mode.</param>
+    /// <returns>The connection string.</returns>
+    [NotNull]
+    string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host);
+
+    /// <summary>
+    /// Gets the connection string.
+    /// </summary>
+    /// <param name="name">The connection string name.</param>
+    /// <param name="connectionMode">The connection mode.</param>
+    /// <returns>The connection string.</returns>
+    [NotNull]
+    string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host);
+  }
+}

--- a/src/Testcontainers/Configurations/Containers/IConnectionStringProvider`2.cs
+++ b/src/Testcontainers/Configurations/Containers/IConnectionStringProvider`2.cs
@@ -1,0 +1,19 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using DotNet.Testcontainers.Containers;
+  using JetBrains.Annotations;
+
+  /// <inheritdoc cref="IConnectionStringProvider" />
+  [PublicAPI]
+  public interface IConnectionStringProvider<in TContainerEntity, in TConfigurationEntity> : IConnectionStringProvider
+    where TContainerEntity : IContainer
+    where TConfigurationEntity : IContainerConfiguration
+  {
+    /// <summary>
+    /// Configures the connection string provider.
+    /// </summary>
+    /// <param name="container">The container instance.</param>
+    /// <param name="configuration">The container configuration.</param>
+    void Configure(TContainerEntity container, TConfigurationEntity configuration);
+  }
+}

--- a/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
@@ -125,5 +125,10 @@ namespace DotNet.Testcontainers.Configurations
     /// Gets the startup callback.
     /// </summary>
     Func<IContainer, IContainerConfiguration, CancellationToken, Task> StartupCallback { get; }
+
+    /// <summary>
+    /// Gets the connection string provider.
+    /// </summary>
+    IConnectionStringProvider<IContainer, IContainerConfiguration> ConnectionStringProvider { get; }
   }
 }

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitUntil.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitUntil.cs
@@ -13,7 +13,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Evaluates the condition asynchronously against the specified container.
     /// </summary>
-    /// <param name="container">The container instance to check readiness against.</param>
+    /// <param name="container">The container to check the condition for.</param>
     /// <returns>A task that returns <c>true</c> when the condition is satisfied; otherwise, <c>false</c>.</returns>
     Task<bool> UntilAsync(IContainer container);
   }

--- a/src/Testcontainers/Configurations/WaitStrategies/IWaitWhile.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/IWaitWhile.cs
@@ -13,7 +13,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <summary>
     /// Evaluates the condition asynchronously against the specified container.
     /// </summary>
-    /// <param name="container">The container instance to check readiness against.</param>
+    /// <param name="container">The container to check the condition for.</param>
     /// <returns>A task that returns <c>true</c> while the condition holds; otherwise, <c>false</c>.</returns>
     Task<bool> WhileAsync(IContainer container);
   }

--- a/src/Testcontainers/Containers/ConnectionStringProviderNotConfiguredException.cs
+++ b/src/Testcontainers/Containers/ConnectionStringProviderNotConfiguredException.cs
@@ -1,0 +1,20 @@
+namespace DotNet.Testcontainers.Containers
+{
+  using System;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Represents an exception that is thrown when the connection string provider is not configured.
+  /// </summary>
+  [PublicAPI]
+  public sealed class ConnectionStringProviderNotConfiguredException : Exception
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConnectionStringProviderNotConfiguredException" /> class.
+    /// </summary>
+    public ConnectionStringProviderNotConfiguredException()
+      : base("No connection string provider is configured for this container.")
+    {
+    }
+  }
+}

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -423,7 +423,7 @@ namespace DotNet.Testcontainers.Containers
     {
       if (_connectionStringProvider == null)
       {
-        throw new InvalidOperationException("No connection string provider is configured for this container.");
+        throw new ConnectionStringProviderNotConfiguredException();
       }
 
       return _connectionStringProvider.GetConnectionString(connectionMode);
@@ -434,7 +434,7 @@ namespace DotNet.Testcontainers.Containers
     {
       if (_connectionStringProvider == null)
       {
-        throw new InvalidOperationException("No connection string provider is configured for this container.");
+        throw new ConnectionStringProviderNotConfiguredException();
       }
 
       return _connectionStringProvider.GetConnectionString(name, connectionMode);

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -29,6 +29,8 @@ namespace DotNet.Testcontainers.Containers
 
     private ContainerInspectResponse _container = new ContainerInspectResponse();
 
+    private IConnectionStringProvider<IContainer, IContainerConfiguration> _connectionStringProvider;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerContainer" /> class.
     /// </summary>
@@ -416,6 +418,28 @@ namespace DotNet.Testcontainers.Containers
       return _client.ExecAsync(Id, command, ct);
     }
 
+    /// <inheritdoc />
+    public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)
+    {
+      if (_connectionStringProvider == null)
+      {
+        throw new InvalidOperationException("No connection string provider is configured for this container.");
+      }
+
+      return _connectionStringProvider.GetConnectionString(connectionMode);
+    }
+
+    /// <inheritdoc />
+    public string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host)
+    {
+      if (_connectionStringProvider == null)
+      {
+        throw new InvalidOperationException("No connection string provider is configured for this container.");
+      }
+
+      return _connectionStringProvider.GetConnectionString(name, connectionMode);
+    }
+
     /// <inheritdoc cref="IAsyncDisposable.DisposeAsync" />
     protected override async ValueTask DisposeAsyncCore()
     {
@@ -560,6 +584,13 @@ namespace DotNet.Testcontainers.Containers
       Logger.CompleteReadinessCheck(_container.ID);
 
       StartedTime = DateTime.TryParse(_container.State!.StartedAt, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal, out var startedTime) ? startedTime : DateTime.UtcNow;
+
+      if (_configuration.ConnectionStringProvider != null)
+      {
+        _connectionStringProvider = _configuration.ConnectionStringProvider;
+        _connectionStringProvider.Configure(this, _configuration);
+      }
+
       Started?.Invoke(this, EventArgs.Empty);
     }
 

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -14,7 +14,7 @@ namespace DotNet.Testcontainers.Containers
   /// A container instance.
   /// </summary>
   [PublicAPI]
-  public interface IContainer : IAsyncDisposable
+  public interface IContainer : IConnectionStringProvider, IAsyncDisposable
   {
     /// <summary>
     /// Subscribes to the creating event.

--- a/tests/Testcontainers.Platform.Linux.Tests/ConnectionStringProviderTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ConnectionStringProviderTest.cs
@@ -4,11 +4,18 @@ public sealed class ConnectionStringProviderTests : IAsyncLifetime
 {
     private const string ExpectedConnectionString = "connection string";
 
-    private readonly IContainer _container = new ContainerBuilder()
-        .WithImage(CommonImages.Alpine)
-        .WithCommand(CommonCommands.SleepInfinity)
-        .WithConnectionStringProvider(new ConnectionStringProvider())
-        .Build();
+    private readonly ConnectionStringProvider _connectionStringProvider = new ConnectionStringProvider();
+
+    private readonly IContainer _container;
+
+    public ConnectionStringProviderTests()
+    {
+        _container = new ContainerBuilder()
+            .WithImage(CommonImages.Alpine)
+            .WithCommand(CommonCommands.SleepInfinity)
+            .WithConnectionStringProvider(_connectionStringProvider)
+            .Build();
+    }
 
     public async ValueTask InitializeAsync()
     {
@@ -25,16 +32,20 @@ public sealed class ConnectionStringProviderTests : IAsyncLifetime
     [Fact]
     public void GetConnectionStringReturnsExpectedValue()
     {
+        Assert.True(_connectionStringProvider.IsConfigured, "Configure should have been called during container startup.");
         Assert.Equal(ExpectedConnectionString, _container.GetConnectionString());
         Assert.Equal(ExpectedConnectionString, _container.GetConnectionString("name"));
     }
 
     private sealed class ConnectionStringProvider : IConnectionStringProvider<IContainer, IContainerConfiguration>
     {
+        public bool IsConfigured { get; private set; }
+
         public void Configure(IContainer container, IContainerConfiguration configuration)
         {
             Assert.NotNull(container);
             Assert.NotNull(configuration);
+            IsConfigured = true;
         }
 
         public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)

--- a/tests/Testcontainers.Platform.Linux.Tests/ConnectionStringProviderTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ConnectionStringProviderTest.cs
@@ -1,0 +1,50 @@
+namespace Testcontainers.Tests;
+
+public sealed class ConnectionStringProviderTests : IAsyncLifetime
+{
+    private const string ExpectedConnectionString = "connection string";
+
+    private readonly IContainer _container = new ContainerBuilder()
+        .WithImage(CommonImages.Alpine)
+        .WithCommand(CommonCommands.SleepInfinity)
+        .WithConnectionStringProvider(new ConnectionStringProvider())
+        .Build();
+
+    public async ValueTask InitializeAsync()
+    {
+        await _container.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _container.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public void GetConnectionStringReturnsExpectedValue()
+    {
+        Assert.Equal(ExpectedConnectionString, _container.GetConnectionString());
+        Assert.Equal(ExpectedConnectionString, _container.GetConnectionString("name"));
+    }
+
+    private sealed class ConnectionStringProvider : IConnectionStringProvider<IContainer, IContainerConfiguration>
+    {
+        public void Configure(IContainer container, IContainerConfiguration configuration)
+        {
+            Assert.NotNull(container);
+            Assert.NotNull(configuration);
+        }
+
+        public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)
+        {
+            return ExpectedConnectionString;
+        }
+
+        public string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host)
+        {
+            return ExpectedConnectionString;
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR adds a connection string provider, which provides a standardized way to access and manage connection information for Testcontainers. Configuring connection strings for modules can sometimes be tricky or tedious, and this API aims to simplify that process.

This PR does not implement the connection string provider in modules yet. That will be done in the future. Modules would offer a default implementation that users can override or replace with their own. For now, I want to test whether the proposed solution effectively addresses the issue.

### Usage

```csharp
var container = new ContainerBuilder()
    .WithImage(CommonImages.Alpine)
    .WithCommand(CommonCommands.SleepInfinity)
    .WithConnectionStringProvider(new ConnectionStringProvider())
    .Build();

// Host connection string
_ = _container.GetConnectionString();

// Container connection string
_ = _container.GetConnectionString(ConnectionMode.Container);

// Custom connection string
_ = _container.GetConnectionString("HTTPS");


private sealed class ConnectionStringProvider : IConnectionStringProvider<IContainer, IContainerConfiguration>
{
    public void Configure(IContainer container, IContainerConfiguration configuration)
    {
        // Use the arguments to set up the connection strings.
    }

    public string GetConnectionString(ConnectionMode connectionMode = ConnectionMode.Host)
    {
        return "...";
    }

    public string GetConnectionString(string name, ConnectionMode connectionMode = ConnectionMode.Host)
    {
        return "...";
    }
}
```

**I'd appreciate feedback from the community**.

## Why is it important?

The connection string provider API lets developers configure a provider that resolves connection strings based on the container and its configuration.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #1074
- Relates #1436

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
