### PR TITLE
Update MsSql image to 2025-RTM-ubuntu-22.04

### DIFF
--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.MsSql;
 [PublicAPI]
 public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer, MsSqlConfiguration>
 {
-    public const string MsSqlImage = "mcr.microsoft.com/mssql/server:2025-latest";
+    public const string MsSqlImage = "mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04";
 
     public const ushort MsSqlPort = 1433;
 

--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -4,7 +4,7 @@ namespace Testcontainers.MsSql;
 [PublicAPI]
 public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer, MsSqlConfiguration>
 {
-    public const string MsSqlImage = "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04";
+    public const string MsSqlImage = "mcr.microsoft.com/mssql/server:2025-latest";
 
     public const ushort MsSqlPort = 1433;
 


### PR DESCRIPTION
## What does this PR do?

I changed the docker container version to `mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04`.

## Why is it important?

The current version `2022-CU14-ubuntu-22.04` does not support the latest features like json columns.

> Azure SQL Image 2022 does not support json column type

## Related issues

- #1596
- Related to foreign repo issue https://github.com/dotnet/aspire/issues/13084

## How to test this PR

Create a entity configration and use `.ToJson()` in `EntityTypeBuilder`.

---

# SQL Server 2025 Breaking Changes – Summary

> Use this change note when planning upgrades or reviewing PRs that involve SQL Server 2025 compatibility.  
> For details, see the official documentation and migration guides linked throughout.

## Major Breaking Changes

1. **Linked Server Connections**
   - The default is now to require encryption (`Encrypt` parameter) and valid TLS certificates; legacy/unsecured connections may break.
   - [Microsoft Docs: Breaking Changes](https://learn.microsoft.com/en-us/sql/database-engine/breaking-changes-to-database-engine-features-in-sql-server-2025?view=sql-server-ver17)

2. **Replication & Log Shipping**
   - Replication roles and log shipping monitoring may fail unless service accounts and encryption use modern standards; trusted certificates are now mandatory for remote distributors.
   - [Migration Risks Overview](https://www.sqlfingers.com/2025/10/breaking-changes-migration-risks-in-sql.html)

3. **Legacy Feature Removal**
   - *Master Data Services* (MDS) and *Data Quality Services* (DQS) are officially retired.
   - Features like Hot-Add CPU, Lightweight Pooling, and extended stored procedures are deprecated or fully unsupported.
   - [Migration Guide: Deprecated Features](https://gigxp.com/sql-server-2025-migration-guide/)

4. **Security Defaults**
   - "Encrypt by Default" enforced for all client connections; legacy drivers/apps may lose access unless updated for TLS 1.2+.
   - Hardened credential storage and authentication for replication/log shipping.
   - [Breaking Changes - Security](https://www.sqlfingers.com/2025/10/breaking-changes-migration-risks-in-sql.html)

5. **Database Engine & Query Processing**
   - Collation and Unicode normalization now matches UTF-8 standards, affecting string comparisons/sorting.
   - Query optimizer changes may break legacy workloads (join order, trace flag behavior, estimated row counts).
   - [What's New in SQL Server 2025](https://learn.microsoft.com/en-us/sql/sql-server/what-s-new-in-sql-server-2025?view=sql-server-ver17)

6. **Automation & .NET Providers**
   - Integration Services (SSIS) automation now requires `Microsoft.Data.SqlClient`—the old `System.Data.SqlClient` provider is unsupported and must be replaced.
   - [Critical Breaking Changes for DBAs](https://www.automatesql.com/blog/sql-server-2025-critical-breaking-changes-every-dba-must-know)

**Key Takeaway:**  
_SQL Server 2025 enforces stricter security defaults, retires multiple legacy features, and updates data provider compatibility. Review all code and deployment tools for compatibility before upgrading._

**Reference Links:**
- [All Breaking Changes (Official)](https://learn.microsoft.com/en-us/sql/database-engine/breaking-changes-to-database-engine-features-in-sql-server-2025?view=sql-server-ver17)
- [What’s New in SQL Server 2025 (Official)](https://learn.microsoft.com/en-us/sql/sql-server/what-s-new-in-sql-server-2025?view=sql-server-ver17)