### PR TITLE
chore: Skip unnecessary work for empty or null sequences

### DIFF
--- a/Testcontainers.slnx
+++ b/Testcontainers.slnx
@@ -26,7 +26,6 @@
         <Project Path="src/Testcontainers.DynamoDb/Testcontainers.DynamoDb.csproj"/>
         <Project Path="src/Testcontainers.Elasticsearch/Testcontainers.Elasticsearch.csproj"/>
         <Project Path="src/Testcontainers.EventHubs/Testcontainers.EventHubs.csproj"/>
-        <Project Path="src/Testcontainers.EventStoreDb/Testcontainers.EventStoreDb.csproj"/>
         <Project Path="src/Testcontainers.FakeGcsServer/Testcontainers.FakeGcsServer.csproj"/>
         <Project Path="src/Testcontainers.FirebirdSql/Testcontainers.FirebirdSql.csproj"/>
         <Project Path="src/Testcontainers.Firestore/Testcontainers.Firestore.csproj"/>

--- a/src/Testcontainers/Builders/BuildConfiguration.cs
+++ b/src/Testcontainers/Builders/BuildConfiguration.cs
@@ -42,9 +42,29 @@ namespace DotNet.Testcontainers.Builders
         return Array.Empty<T>();
       }
 
-      if (newValue == null || oldValue == null)
+      if (newValue == null)
       {
-        return newValue ?? oldValue;
+        return oldValue;
+      }
+
+      if (oldValue == null)
+      {
+        return newValue;
+      }
+
+      if (newValue is ICollection<T> collection && collection.Count == 0)
+      {
+        return oldValue;
+      }
+
+      if (oldValue is not ICollection<T>)
+      {
+        oldValue = oldValue.ToArray();
+      }
+
+      if (newValue is not ICollection<T>)
+      {
+        newValue = newValue.ToArray();
       }
 
       return oldValue.Concat(newValue).ToArray();
@@ -68,9 +88,19 @@ namespace DotNet.Testcontainers.Builders
         return Array.Empty<T>();
       }
 
-      if (newValue == null || oldValue == null)
+      if (newValue == null)
       {
-        return newValue ?? oldValue;
+        return oldValue;
+      }
+
+      if (oldValue == null)
+      {
+        return newValue;
+      }
+
+      if (newValue.Count == 0)
+      {
+        return oldValue;
       }
 
       return oldValue.Concat(newValue).ToArray();
@@ -128,9 +158,19 @@ namespace DotNet.Testcontainers.Builders
         return new ReadOnlyDictionary<TKey, TValue>(new Dictionary<TKey, TValue>());
       }
 
-      if (newValue == null || oldValue == null)
+      if (newValue == null)
       {
-        return newValue ?? oldValue;
+        return oldValue;
+      }
+
+      if (oldValue == null)
+      {
+        return newValue;
+      }
+
+      if (newValue.Count == 0)
+      {
+        return oldValue;
       }
 
       var result = new Dictionary<TKey, TValue>(oldValue.Count + newValue.Count);

--- a/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
@@ -39,6 +39,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="outputConsumer">The output consumer.</param>
     /// <param name="waitStrategies">The wait strategies.</param>
     /// <param name="startupCallback">The startup callback.</param>
+    /// <param name="connectionStringProvider">The connection string provider.</param>
     /// <param name="autoRemove">A value indicating whether Docker removes the container after it exits or not.</param>
     /// <param name="privileged">A value indicating whether the privileged flag is set or not.</param>
     public ContainerConfiguration(

--- a/tests/Testcontainers.Commons/DockerfileParser.cs
+++ b/tests/Testcontainers.Commons/DockerfileParser.cs
@@ -38,7 +38,7 @@ internal sealed class DockerfileParser
         var stages = fromMatches
             .Select(match => new
             {
-                Stage = match.Value.Split(separator, options).Skip(1).DefaultIfEmpty(string.Empty).First(),
+                Stage = match.Value.Split(separator, options).Skip(1).FirstOrDefault(string.Empty),
                 Image = match.Groups[imageGroup].Value,
             })
             .ToDictionary(

--- a/tests/Testcontainers.Commons/TestSession.cs
+++ b/tests/Testcontainers.Commons/TestSession.cs
@@ -3,7 +3,7 @@ namespace DotNet.Testcontainers.Commons;
 [PublicAPI]
 public static class TestSession
 {
-    private static readonly ConcurrentDictionary<string, Dictionary<string, string>> Cache = new ConcurrentDictionary<string, Dictionary<string, string>>();
+    private static readonly ConcurrentDictionary<string, Dictionary<string, string>> Stages = new ConcurrentDictionary<string, Dictionary<string, string>>();
 
     public static readonly string TempDirectoryPath = Path.Combine(Path.GetTempPath(), "testcontainers-tests", Guid.NewGuid().ToString("D"));
 
@@ -16,7 +16,7 @@ public static class TestSession
     {
         var absoluteFilePath = Path.GetFullPath(relativeFilePath);
 
-        var stages = Cache.GetOrAdd(absoluteFilePath, filePath => new DockerfileParser(filePath).Parse());
+        var stages = Stages.GetOrAdd(absoluteFilePath, filePath => new DockerfileParser(filePath).Parse());
 
         if (stages.TryGetValue(stage, out var image))
         {


### PR DESCRIPTION
## What does this PR do?

The PR slightly adjusts the build configuration (`Combine(...)` method) implementation and skips unnecessary work for empty or null sequences. These methods are called frequently, so this change slightly improves performance.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
