### PR TITLE
chore: Remove EventStoreDb test project from SLNX file

### DIFF
--- a/Testcontainers.slnx
+++ b/Testcontainers.slnx
@@ -91,7 +91,6 @@
         <Project Path="tests/Testcontainers.DynamoDb.Tests/Testcontainers.DynamoDb.Tests.csproj"/>
         <Project Path="tests/Testcontainers.Elasticsearch.Tests/Testcontainers.Elasticsearch.Tests.csproj"/>
         <Project Path="tests/Testcontainers.EventHubs.Tests/Testcontainers.EventHubs.Tests.csproj"/>
-        <Project Path="tests/Testcontainers.EventStoreDb.Tests/Testcontainers.EventStoreDb.Tests.csproj"/>
         <Project Path="tests/Testcontainers.FakeGcsServer.Tests/Testcontainers.FakeGcsServer.Tests.csproj"/>
         <Project Path="tests/Testcontainers.FirebirdSql.Tests/Testcontainers.FirebirdSql.Tests.csproj"/>
         <Project Path="tests/Testcontainers.Firestore.Tests/Testcontainers.Firestore.Tests.csproj"/>


### PR DESCRIPTION
## What does this PR do?

This pull request removes `Testcontainers.EventStoreDb.Tests.csproj` from the slnx file. The EventStoreDb module was removed in ed192fbc46127120f8170125feb56b3cd7c5a075 (sln) and 92af06f0b339e50dacb6bd240466c96e2d3ec158 (slnx) but the tests must also be removed from the slnx file.

## Why is it important?

It generates errors when using the slnx.

## Related issues

#1599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed EventStoreDb test project from the solution configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->