### PR TITLE
fix(Kafka): Bump image version to prevent container crash on startup

### DIFF
--- a/src/Testcontainers.Kafka/KafkaBuilder.cs
+++ b/src/Testcontainers.Kafka/KafkaBuilder.cs
@@ -5,7 +5,7 @@ namespace Testcontainers.Kafka;
 public sealed class KafkaBuilder : ContainerBuilder<KafkaBuilder, KafkaContainer, KafkaConfiguration>
 {
     [Obsolete("This constant is obsolete and will be removed in the future. Use the constructor with the image parameter instead: https://github.com/testcontainers/testcontainers-dotnet/discussions/1470#discussioncomment-15185721.")]
-    public const string KafkaImage = "confluentinc/cp-kafka:7.5.9";
+    public const string KafkaImage = "confluentinc/cp-kafka:7.5.12";
 
     public const ushort KafkaPort = 9092;
 
@@ -39,7 +39,7 @@ public sealed class KafkaBuilder : ContainerBuilder<KafkaBuilder, KafkaContainer
     /// </summary>
     /// <param name="image">
     /// The full Docker image name, including the image repository and tag
-    /// (e.g., <c>confluentinc/cp-kafka:7.5.9</c>).
+    /// (e.g., <c>confluentinc/cp-kafka:7.5.12</c>).
     /// </param>
     /// <remarks>
     /// Docker image tags available at <see href="https://hub.docker.com/r/confluentinc/cp-kafka/tags" />.

--- a/tests/Testcontainers.Kafka.Tests/Dockerfile
+++ b/tests/Testcontainers.Kafka.Tests/Dockerfile
@@ -1,3 +1,3 @@
-FROM confluentinc/cp-kafka:7.5.9
-FROM apache/kafka:3.9.1 AS kafka3.9.1
-FROM apache/kafka-native:3.9.1 AS kafka-native3.9.1
+FROM confluentinc/cp-kafka:7.5.12
+FROM apache/kafka:4.1.1 AS kafka4.1.1
+FROM apache/kafka-native:4.1.1 AS kafka-native4.1.1

--- a/tests/Testcontainers.Kafka.Tests/KafkaContainerTest.cs
+++ b/tests/Testcontainers.Kafka.Tests/KafkaContainerTest.cs
@@ -99,7 +99,7 @@ public abstract class KafkaContainerTest : IAsyncLifetime
     public sealed class ApacheKafkaConfiguration : KafkaContainerTest
     {
         public ApacheKafkaConfiguration()
-            : base(new KafkaBuilder(TestSession.GetImageFromDockerfile(stage: "kafka3.9.1"))
+            : base(new KafkaBuilder(TestSession.GetImageFromDockerfile(stage: "kafka4.1.1"))
                 .Build())
         {
         }
@@ -109,7 +109,7 @@ public abstract class KafkaContainerTest : IAsyncLifetime
     public sealed class ApacheKafkaNativeConfiguration : KafkaContainerTest
     {
         public ApacheKafkaNativeConfiguration()
-            : base(new KafkaBuilder(TestSession.GetImageFromDockerfile(stage: "kafka-native3.9.1"))
+            : base(new KafkaBuilder(TestSession.GetImageFromDockerfile(stage: "kafka-native4.1.1"))
                 .Build())
         {
         }


### PR DESCRIPTION
## What does this PR do?

This PR updates the Kafka versions. The Kafka module is now using the latest patch of the default image.

I'm not entirely sure what caused it, but the previous versions sometimes crashed on container startup. While testing in GH Codespaces, the old versions would fail after a few runs with various errors, usually pointing to a container crash at startup.

With the updated versions, I haven't seen any issues. I ran Codespaces for several hours without failures, whereas the old versions would fail quickly.

## Why is it important?

Remove flakiness.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1597

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Default Kafka container image updated from version 7.5.9 to 7.5.12 in the builder
  * Test container images upgraded: Kafka updated from version 3.9.1 to 4.1.1, Kafka-native upgraded from 3.9.1 to 4.1.1
  * Test configurations updated accordingly to work with the new container image versions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->