### PR TITLE
chore: Set remaining container image explicit

### DIFF
--- a/src/Testcontainers.EventHubs/EventHubsBuilder.cs
+++ b/src/Testcontainers.EventHubs/EventHubsBuilder.cs
@@ -142,7 +142,7 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
         var network = new NetworkBuilder()
             .Build();
 
-        var container = new AzuriteBuilder()
+        var container = new AzuriteBuilder("mcr.microsoft.com/azure-storage/azurite:3.28.0")
             .WithNetwork(network)
             .WithNetworkAliases(AzuriteNetworkAlias)
             .Build();

--- a/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
@@ -147,7 +147,7 @@ public sealed class ServiceBusBuilder : ContainerBuilder<ServiceBusBuilder, Serv
         var network = new NetworkBuilder()
             .Build();
 
-        var container = new MsSqlBuilder()
+        var container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04")
             .WithNetwork(network)
             .WithNetworkAliases(DatabaseNetworkAlias)
             .Build();

--- a/src/Testcontainers/Containers/SocatBuilder.cs
+++ b/src/Testcontainers/Containers/SocatBuilder.cs
@@ -6,21 +6,55 @@ namespace DotNet.Testcontainers.Containers
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Builders;
   using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Images;
   using JetBrains.Annotations;
 
   /// <inheritdoc cref="ContainerBuilder{TBuilderEntity, TContainerEntity, TConfigurationEntity}" />
   [PublicAPI]
   public sealed class SocatBuilder : ContainerBuilder<SocatBuilder, SocatContainer, SocatConfiguration>
   {
+    [Obsolete("This constant is obsolete and will be removed in the future. Use the constructor with the image parameter instead: https://github.com/testcontainers/testcontainers-dotnet/discussions/1470#discussioncomment-15185721.")]
     public const string SocatImage = "alpine/socat:1.7.4.3-r0";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SocatBuilder" /> class.
     /// </summary>
+    [Obsolete("This parameterless constructor is obsolete and will be removed. Use the constructor with the image parameter instead: https://github.com/testcontainers/testcontainers-dotnet/discussions/1470#discussioncomment-15185721.")]
     public SocatBuilder()
       : this(new SocatConfiguration())
     {
       DockerResourceConfiguration = Init().DockerResourceConfiguration;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SocatBuilder" /> class.
+    /// </summary>
+    /// <param name="image">
+    /// The full Docker image name, including the image repository and tag
+    /// (e.g., <c>alpine/socat:1.7.4.3-r0</c>).
+    /// </param>
+    /// <remarks>
+    /// Docker image tags available at <see href="https://hub.docker.com/r/alpine/socat/tags" />.
+    /// </remarks>
+    public SocatBuilder(string image)
+        : this(new DockerImage(image))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SocatBuilder" /> class.
+    /// </summary>
+    /// <param name="image">
+    /// An <see cref="IImage" /> instance that specifies the Docker image to be used
+    /// for the container builder configuration.
+    /// </param>
+    /// <remarks>
+    /// Docker image tags available at <see href="https://hub.docker.com/r/alpine/socat/tags" />.
+    /// </remarks>
+    public SocatBuilder(IImage image)
+        : this(new SocatConfiguration())
+    {
+        DockerResourceConfiguration = Init().WithImage(image).DockerResourceConfiguration;
     }
 
     /// <summary>

--- a/src/Testcontainers/Containers/SocatBuilder.cs
+++ b/src/Testcontainers/Containers/SocatBuilder.cs
@@ -14,16 +14,15 @@ namespace DotNet.Testcontainers.Containers
   public sealed class SocatBuilder : ContainerBuilder<SocatBuilder, SocatContainer, SocatConfiguration>
   {
     [Obsolete("This constant is obsolete and will be removed in the future. Use the constructor with the image parameter instead: https://github.com/testcontainers/testcontainers-dotnet/discussions/1470#discussioncomment-15185721.")]
-    public const string SocatImage = "alpine/socat:1.7.4.3-r0";
+    public const string SocatImage = "alpine/socat:1.7.4.4";
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SocatBuilder" /> class.
     /// </summary>
     [Obsolete("This parameterless constructor is obsolete and will be removed. Use the constructor with the image parameter instead: https://github.com/testcontainers/testcontainers-dotnet/discussions/1470#discussioncomment-15185721.")]
     public SocatBuilder()
-      : this(new SocatConfiguration())
+      : this(SocatImage)
     {
-      DockerResourceConfiguration = Init().DockerResourceConfiguration;
     }
 
     /// <summary>
@@ -31,7 +30,7 @@ namespace DotNet.Testcontainers.Containers
     /// </summary>
     /// <param name="image">
     /// The full Docker image name, including the image repository and tag
-    /// (e.g., <c>alpine/socat:1.7.4.3-r0</c>).
+    /// (e.g., <c>alpine/socat:1.7.4.4</c>).
     /// </param>
     /// <remarks>
     /// Docker image tags available at <see href="https://hub.docker.com/r/alpine/socat/tags" />.

--- a/tests/Testcontainers.EventHubs.Tests/EventHubsContainerTest.cs
+++ b/tests/Testcontainers.EventHubs.Tests/EventHubsContainerTest.cs
@@ -108,7 +108,7 @@ public abstract class EventHubsContainerTest : IAsyncLifetime
             Network = new NetworkBuilder()
                 .Build();
 
-            Container = new AzuriteBuilder()
+            Container = new AzuriteBuilder("mcr.microsoft.com/azure-storage/azurite:3.28.0")
                 .WithNetwork(Network)
                 .WithNetworkAliases(AzuriteNetworkAlias)
                 .Build();

--- a/tests/Testcontainers.Platform.Linux.Tests/ConnectionStringProviderTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ConnectionStringProviderTest.cs
@@ -12,8 +12,7 @@ public static class ConnectionStringProviderTests
 
         public Configured()
         {
-            _container = new ContainerBuilder()
-                .WithImage(CommonImages.Alpine)
+            _container = new ContainerBuilder(CommonImages.Alpine)
                 .WithCommand(CommonCommands.SleepInfinity)
                 .WithConnectionStringProvider(_connectionStringProvider)
                 .Build();
@@ -42,8 +41,7 @@ public static class ConnectionStringProviderTests
 
     public sealed class NotConfigured : IAsyncLifetime
     {
-        private readonly IContainer _container = new ContainerBuilder()
-            .WithImage(CommonImages.Alpine)
+        private readonly IContainer _container = new ContainerBuilder(CommonImages.Alpine)
             .WithCommand(CommonCommands.SleepInfinity)
             .Build();
 

--- a/tests/Testcontainers.Platform.Linux.Tests/SocatContainerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/SocatContainerTest.cs
@@ -20,7 +20,7 @@ public sealed class SocatContainerTest : IAsyncLifetime
             .WithNetworkAliases(HelloWorldAlias)
             .Build();
 
-        _socatContainer = new SocatBuilder()
+        _socatContainer = new SocatBuilder("alpine/socat:1.7.4.3-r0")
             .WithNetwork(_network)
             .WithTarget(8080, HelloWorldAlias)
             .WithTarget(8081, HelloWorldAlias, 8080)

--- a/tests/Testcontainers.Platform.Linux.Tests/SocatContainerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/SocatContainerTest.cs
@@ -20,7 +20,7 @@ public sealed class SocatContainerTest : IAsyncLifetime
             .WithNetworkAliases(HelloWorldAlias)
             .Build();
 
-        _socatContainer = new SocatBuilder("alpine/socat:1.7.4.3-r0")
+        _socatContainer = new SocatBuilder(CommonImages.Socat)
             .WithNetwork(_network)
             .WithTarget(8080, HelloWorldAlias)
             .WithTarget(8081, HelloWorldAlias, 8080)

--- a/tests/Testcontainers.ServiceBus.Tests/DeclineLicenseAgreementTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/DeclineLicenseAgreementTest.cs
@@ -9,7 +9,7 @@ public sealed partial class DeclineLicenseAgreementTest
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void WithoutAcceptingLicenseAgreementThrowsArgumentException()
     {
-        var exception = Assert.Throws<ArgumentException>(() => new ServiceBusBuilder().Build());
+        var exception = Assert.Throws<ArgumentException>(() => new ServiceBusBuilder("mcr.microsoft.com/azure-messaging/servicebus-emulator:latest").Build());
         Assert.Matches(LicenseAgreementNotAccepted(), exception.Message);
     }
 
@@ -17,7 +17,7 @@ public sealed partial class DeclineLicenseAgreementTest
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void WithLicenseAgreementDeclinedThrowsArgumentException()
     {
-        var exception = Assert.Throws<ArgumentException>(() => new ServiceBusBuilder().WithAcceptLicenseAgreement(false).Build());
+        var exception = Assert.Throws<ArgumentException>(() => new ServiceBusBuilder("mcr.microsoft.com/azure-messaging/servicebus-emulator:latest").WithAcceptLicenseAgreement(false).Build());
         Assert.Matches(LicenseAgreementNotAccepted(), exception.Message);
     }
 }

--- a/tests/Testcontainers.ServiceBus.Tests/DeclineLicenseAgreementTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/DeclineLicenseAgreementTest.cs
@@ -9,7 +9,7 @@ public sealed partial class DeclineLicenseAgreementTest
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void WithoutAcceptingLicenseAgreementThrowsArgumentException()
     {
-        var exception = Assert.Throws<ArgumentException>(() => new ServiceBusBuilder("mcr.microsoft.com/azure-messaging/servicebus-emulator:latest").Build());
+        var exception = Assert.Throws<ArgumentException>(() => new ServiceBusBuilder(TestSession.GetImageFromDockerfile()).Build());
         Assert.Matches(LicenseAgreementNotAccepted(), exception.Message);
     }
 
@@ -17,7 +17,7 @@ public sealed partial class DeclineLicenseAgreementTest
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public void WithLicenseAgreementDeclinedThrowsArgumentException()
     {
-        var exception = Assert.Throws<ArgumentException>(() => new ServiceBusBuilder("mcr.microsoft.com/azure-messaging/servicebus-emulator:latest").WithAcceptLicenseAgreement(false).Build());
+        var exception = Assert.Throws<ArgumentException>(() => new ServiceBusBuilder(TestSession.GetImageFromDockerfile()).WithAcceptLicenseAgreement(false).Build());
         Assert.Matches(LicenseAgreementNotAccepted(), exception.Message);
     }
 }

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusContainerTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusContainerTest.cs
@@ -116,7 +116,7 @@ public abstract class ServiceBusContainerTest : IAsyncLifetime
             Network = new NetworkBuilder()
                 .Build();
 
-            Container = new MsSqlBuilder()
+            Container = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04")
                 .WithNetwork(Network)
                 .WithNetworkAliases(DatabaseNetworkAlias)
                 .Build();

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerMTls.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerMTls.cs
@@ -7,7 +7,7 @@ namespace DotNet.Testcontainers.Tests.Fixtures
   public abstract class DockerMTls : ProtectDockerDaemonSocket
   {
     public DockerMTls(string dockerImageVersion)
-      : base(new ContainerBuilder(new DockerImage("docker", null, dockerImageVersion + "-dind")))
+      : base(new ContainerBuilder("docker:" + dockerImageVersion + "-dind"))
     {
     }
 

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerMTls.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerMTls.cs
@@ -2,11 +2,12 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 {
   using System.Collections.Generic;
   using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Images;
 
   public abstract class DockerMTls : ProtectDockerDaemonSocket
   {
     public DockerMTls(string dockerImageVersion)
-      : base(new ContainerBuilder(), dockerImageVersion)
+      : base(new ContainerBuilder(new DockerImage("docker", null, dockerImageVersion + "-dind")))
     {
     }
 

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerTlsFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerTlsFixture.cs
@@ -9,7 +9,7 @@ namespace DotNet.Testcontainers.Tests.Fixtures
   public sealed class DockerTlsFixture : ProtectDockerDaemonSocket
   {
     public DockerTlsFixture()
-      : base(new ContainerBuilder(new DockerImage("docker", null, "29.0.0-dind"))
+      : base(new ContainerBuilder("docker:29.0.0-dind")
         .WithCommand("--tlsverify=false"))
     {
     }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerTlsFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerTlsFixture.cs
@@ -2,14 +2,15 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 {
   using System.Collections.Generic;
   using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Images;
   using JetBrains.Annotations;
 
   [UsedImplicitly]
   public sealed class DockerTlsFixture : ProtectDockerDaemonSocket
   {
     public DockerTlsFixture()
-      : base(new ContainerBuilder()
-        .WithCommand("--tlsverify=false"), "29.0.0")
+      : base(new ContainerBuilder(new DockerImage("docker", null, "29.0.0-dind"))
+        .WithCommand("--tlsverify=false"))
     {
     }
 

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
@@ -23,10 +23,9 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
     private readonly IContainer _container;
 
-    protected ProtectDockerDaemonSocket(ContainerBuilder containerConfiguration, string dockerImageVersion)
+    protected ProtectDockerDaemonSocket(ContainerBuilder containerConfiguration)
     {
       _container = containerConfiguration
-        .WithImage(new DockerImage("docker", null, dockerImageVersion + "-dind"))
         .WithPrivileged(true)
         .WithPortBinding(TlsPort, true)
         .WithBindMount(_hostCertsDirectoryPath, _containerCertsDirectoryPath, AccessMode.ReadWrite)

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/ProtectDockerDaemonSocket.cs
@@ -23,9 +23,9 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
     private readonly IContainer _container;
 
-    protected ProtectDockerDaemonSocket(ContainerBuilder containerConfiguration)
+    protected ProtectDockerDaemonSocket(ContainerBuilder containerBuilder)
     {
-      _container = containerConfiguration
+      _container = containerBuilder
         .WithPrivileged(true)
         .WithPortBinding(TlsPort, true)
         .WithBindMount(_hostCertsDirectoryPath, _containerCertsDirectoryPath, AccessMode.ReadWrite)

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -18,11 +18,12 @@ namespace DotNet.Testcontainers.Tests.Unit
   {
     public sealed class WithConfiguration
     {
-      [Fact]
-      public void ShouldThrowArgumentNullExceptionWhenBuildConfigurationHasNoImage()
-      {
-        Assert.Throws<ArgumentException>(() => _ = new ContainerBuilder().Build());
-      }
+      // This test will always pass, because we always set Image inside builder constructor.
+      // [Fact]
+      // public void ShouldThrowArgumentNullExceptionWhenBuildConfigurationHasNoImage()
+      // {
+      //   Assert.Throws<ArgumentException>(() => _ = new ContainerBuilder(CommonImages.Alpine).Build());
+      // }
 
       [Fact]
       public async Task GeneratedContainerName()

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -18,12 +18,13 @@ namespace DotNet.Testcontainers.Tests.Unit
   {
     public sealed class WithConfiguration
     {
-      // This test will always pass, because we always set Image inside builder constructor.
-      // [Fact]
-      // public void ShouldThrowArgumentNullExceptionWhenBuildConfigurationHasNoImage()
-      // {
-      //   Assert.Throws<ArgumentException>(() => _ = new ContainerBuilder(CommonImages.Alpine).Build());
-      // }
+      [Theory]
+      [InlineData(null)]
+      [InlineData("")]
+      public void ShouldThrowArgumentNullExceptionWhenContainerBuilderHasNoImage(string image)
+      {
+        Assert.Throws<ArgumentException>(() => _ = new ContainerBuilder(image));
+      }
 
       [Fact]
       public async Task GeneratedContainerName()

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -21,7 +21,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       [Theory]
       [InlineData(null)]
       [InlineData("")]
-      public void ShouldThrowArgumentNullExceptionWhenContainerBuilderHasNoImage(string image)
+      public void ShouldThrowArgumentExceptionWhenContainerBuilderHasNoImage(string image)
       {
         Assert.Throws<ArgumentException>(() => _ = new ContainerBuilder(image));
       }

--- a/tests/Testcontainers.Toxiproxy.Tests/ToxiproxyContainerTest.cs
+++ b/tests/Testcontainers.Toxiproxy.Tests/ToxiproxyContainerTest.cs
@@ -13,7 +13,7 @@ public sealed class ToxiproxyContainerTest : IAsyncLifetime
 
     public ToxiproxyContainerTest()
     {
-        _redisContainer = new RedisBuilder()
+        _redisContainer = new RedisBuilder("redis:7.0")
             .WithNetwork(_network)
             .WithNetworkAliases(RedisNetworkAlias)
             .Build();


### PR DESCRIPTION
## What does this PR do?

Fix some Builders we missed in PR #1584

## Why is it important?

This should have been part of PR #1584

## Related issues

#1584


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Container builders now require or accept explicit image parameters; several default images were pinned or updated and legacy parameterless constructors marked obsolete. Public constructor signatures were adjusted accordingly.

* **Tests**
  * Test fixtures and test cases updated to use the new image-based builder constructors and align with revised instantiation and startup behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->