### PR TITLE
chore: Pin Docker Engine API for GH workflow to 1.47

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,7 +22,8 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_USE_POLLING_FILE_WATCHER: true
   NUGET_XMLDOC_MODE: skip
-  TZ: CET # https://stackoverflow.com/q/53510011
+  # https://stackoverflow.com/q/53510011.
+  TZ: CET
 
 jobs:
   collect-test-projects:
@@ -59,6 +60,10 @@ jobs:
         test-projects: ${{ fromJSON(needs.collect-test-projects.outputs.test-projects) }}
 
     runs-on: ${{ matrix.test-projects.runs-on }}
+
+    env:
+      # Lowest API version that GitHub runners support.
+      DOCKER_API_VERSION: 1.47
 
     steps:
       - name: Checkout Repository
@@ -170,7 +175,7 @@ jobs:
         run: ./build.sh --target=Publish
         shell: bash
 
-      # Cake sets the semVer environment variable
+      # Cake sets the semVer environment variable.
       - uses: release-drafter/release-drafter@v6
         with:
           version: ${{ env.semVer }}

--- a/docs/custom_configuration/index.md
+++ b/docs/custom_configuration/index.md
@@ -16,7 +16,7 @@ Testcontainers supports various configurations to set up your test environment. 
 | `docker.socket.override`        | `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`        | The file path to the Docker daemon socket that is used by Ryuk (resource reaper).                                         | `/var/run/docker.sock`       |
 | `ryuk.disabled`                 | `TESTCONTAINERS_RYUK_DISABLED`                 | Disables Ryuk (resource reaper).                                                                                          | `false`                      |
 | `ryuk.container.privileged`     | `TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED`     | Runs Ryuk (resource reaper) in privileged mode.                                                                           | `true`                       |
-| `ryuk.container.image`          | `TESTCONTAINERS_RYUK_CONTAINER_IMAGE`          | The Ryuk (resource reaper) Docker image.                                                                                  | `testcontainers/ryuk:0.12.0` |
+| `ryuk.container.image`          | `TESTCONTAINERS_RYUK_CONTAINER_IMAGE`          | The Ryuk (resource reaper) Docker image.                                                                                  | `testcontainers/ryuk:0.14.0` |
 | `hub.image.name.prefix`         | `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX`         | The name to use for substituting the Docker Hub registry part of the image name.                                          | -                            |
 | `wait.strategy.retries`         | `TESTCONTAINERS_WAIT_STRATEGY_RETRIES`         | The wait strategy retry count.                                                                                            | `infinite`                   |
 | `wait.strategy.interval`        | `TESTCONTAINERS_WAIT_STRATEGY_INTERVAL`        | The wait strategy interval<sup>1</sup>.                                                                                   | `00:00:01`                   |
@@ -107,7 +107,7 @@ In .NET logging usually goes through the test framework. Testcontainers is not a
     [testcontainers.org 00:00:00.47] Searching Docker registry credential in CredsStore
     [testcontainers.org 00:00:00.47] Searching Docker registry credential in Auths
     [testcontainers.org 00:00:00.51] Docker registry credential https://index.docker.io/v1/ found
-    [testcontainers.org 00:00:03.16] Docker image testcontainers/ryuk:0.3.4 created
+    [testcontainers.org 00:00:03.16] Docker image testcontainers/ryuk:0.14.0 created
     [testcontainers.org 00:00:03.24] Docker container b6fad46fbcec84625281c1401ec91158b25cad6495fa612274af7c920abec14e created
     [testcontainers.org 00:00:03.29] Start Docker container b6fad46fbcec84625281c1401ec91158b25cad6495fa612274af7c920abec14e
     [testcontainers.org 00:00:06.18] Docker image alpine:latest created

--- a/docs/test_frameworks/xunit_net.md
+++ b/docs/test_frameworks/xunit_net.md
@@ -44,7 +44,7 @@ PS C:\Sources\dotnet\testcontainers-dotnet> docker ps
 CONTAINER ID   IMAGE                       COMMAND                  CREATED
 be115f3df138   redis:7.0                   "docker-entrypoint.s…"   3 seconds ago
 59349127f8c0   redis:7.0                   "docker-entrypoint.s…"   4 seconds ago
-45fa02b3e997   testcontainers/ryuk:0.9.0   "/bin/ryuk"              4 seconds ago
+45fa02b3e997   testcontainers/ryuk:0.14.0   "/bin/ryuk"             4 seconds ago
 ```
 
 ## Creating a shared test context
@@ -78,7 +78,7 @@ The output of `docker ps` shows that, instead of two Redis containers, only one 
 PS C:\Sources\dotnet\testcontainers-dotnet> docker ps
 CONTAINER ID   IMAGE                       COMMAND                  CREATED
 d29a393816ce   redis:7.0                   "docker-entrypoint.s…"   3 seconds ago
-e878f0b8f4bc   testcontainers/ryuk:0.9.0   "/bin/ryuk"              3 seconds ago
+e878f0b8f4bc   testcontainers/ryuk:0.14.0   "/bin/ryuk"             3 seconds ago
 ```
 
 To use a single container fixture across all tests of a test-assembly (using xUnit.net v3 or an extension), add the `[assembly: AssemblyFixture(typeof(TContainerFixtureEntity))]` annotation referring to your subclass to the assembly. The fixture can then be injected into test class constructors (as shown above), or accessed using the `TestContext.Current.GetFixture<TContainerFixtureEntity>()` method (v3 only) in any test.


### PR DESCRIPTION
## What does this PR do?

The PR overrides the default pinned Docker Engine API version (`1.44`), which was set due to the recent Docker Engine v29 release. This version should match the supported Docker.DotNet version to ensure the client aligns with the server API in the future.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect Ryuk container image version 0.14.0 across configuration and test framework examples.

* **Chores**
  * Updated CI/CD configuration with Docker API version 1.47.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->