### PR TITLE
feat: Add Docker Engine v29 support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,8 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": true
     },
-    "ghcr.io/devcontainers/features/dotnet:2.4.0": {
-      "version": "9.0",
+    "ghcr.io/devcontainers/features/dotnet:2.4.1": {
+      "version": "10.0",
       "installUsingApt": false
     }
   },

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -30,7 +30,7 @@ jobs:
           pattern: Testcontainers*
 
       - name: Publish Test Report
-        uses: dorny/test-reporter@v2.1.1
+        uses: dorny/test-reporter@v2.3.0
         with:
           name: test-report
           path: '**/*.trx'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="3.130.0"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.130.0"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="3.131.1"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.131.1"/>
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
         <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1"/>
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3"/>

--- a/build/Tasks.cs
+++ b/build/Tasks.cs
@@ -16,7 +16,9 @@ public sealed class BuildContext(ICakeContext context) : FrostingContext(context
             Filter = Parameters.TestFilter,
             ResultsDirectory = Parameters.Paths.Directories.TestResultsDirectoryPath,
             ArgumentCustomization = args => args
-                .AppendSwitchQuoted("--blame-hang-timeout", "5m"),
+                // The windows-2025 GH-hosted runner no longer has cached images. Pulling the
+                // servercore:ltsc2025 image takes significantly longer.
+                .AppendSwitchQuoted("--blame-hang-timeout", "10m"),
         });
     }
 }

--- a/src/Testcontainers/Clients/ContainerConfigurationConverter.cs
+++ b/src/Testcontainers/Clients/ContainerConfigurationConverter.cs
@@ -97,7 +97,8 @@ namespace DotNet.Testcontainers.Clients
 
       public override IEnumerable<KeyValuePair<string, EndpointSettings>> Convert([CanBeNull] IEnumerable<INetwork> source)
       {
-        return source?.Select(network => new KeyValuePair<string, EndpointSettings>(network.Name, new EndpointSettings { Aliases = _configuration.NetworkAliases?.ToList() }));
+        var endpointSettings = new EndpointSettings { Aliases = _configuration.NetworkAliases?.ToList(), MacAddress = _configuration.MacAddress };
+        return source?.Select(network => new KeyValuePair<string, EndpointSettings>(network.Name, endpointSettings));
       }
     }
 

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -204,7 +204,6 @@ namespace DotNet.Testcontainers.Clients
         Image = configuration.Image.FullName,
         Name = configuration.Name,
         Hostname = configuration.Hostname,
-        MacAddress = configuration.MacAddress,
         WorkingDir = configuration.WorkingDirectory,
         Entrypoint = converter.Entrypoint,
         Cmd = converter.Command,

--- a/src/Testcontainers/Clients/TraceProgress.cs
+++ b/src/Testcontainers/Clients/TraceProgress.cs
@@ -1,6 +1,7 @@
 namespace DotNet.Testcontainers.Clients
 {
   using System;
+  using System.Text.Json;
   using Docker.DotNet.Models;
   using Microsoft.Extensions.Logging;
 
@@ -15,29 +16,40 @@ namespace DotNet.Testcontainers.Clients
 
     public void Report(JSONMessage value)
     {
-#pragma warning disable CA1848, CA2254
-
-      if (!string.IsNullOrWhiteSpace(value.Status))
+      if (value.Error != null)
       {
-        _logger.LogDebug(value.Status.TrimEnd());
+        _logger.LogError("ID={ID}: {Error}", value.ID, value.Error.Message);
+        return;
+      }
+
+      if (!_logger.IsEnabled(LogLevel.Debug))
+      {
+        return;
       }
 
       if (!string.IsNullOrWhiteSpace(value.Stream))
       {
-        _logger.LogDebug(value.Stream.TrimEnd());
+        _logger.LogDebug("{Stream}", value.Stream.Trim());
+        return;
       }
 
-      if (!string.IsNullOrWhiteSpace(value.ProgressMessage))
+      if (value.Progress != null && value.Progress.Total > 0)
       {
-        _logger.LogDebug(value.ProgressMessage.TrimEnd());
+        var percentage = (double)value.Progress.Current / value.Progress.Total * 100;
+        _logger.LogDebug("ID={ID}: {Status} {Percentage,6:F2}% ({Current}/{Total})", value.ID, value.Status, percentage, value.Progress.Current, value.Progress.Total);
+        return;
       }
 
-      if (!string.IsNullOrWhiteSpace(value.ErrorMessage))
+      if (!string.IsNullOrWhiteSpace(value.Status))
       {
-        _logger.LogError(value.ErrorMessage.TrimEnd());
+        _logger.LogDebug("ID={ID}: {Status}", value.ID, value.Status);
+        return;
       }
 
-#pragma warning restore CA1848, CA2254
+      if (value.Aux != null)
+      {
+        _logger.LogDebug("Auxiliary data: {ExtensionData}", JsonSerializer.Serialize(value.Aux.ExtensionData));
+      }
     }
   }
 }

--- a/src/Testcontainers/Configurations/AuthConfigs/DockerEndpointAuthenticationConfiguration.cs
+++ b/src/Testcontainers/Configurations/AuthConfigs/DockerEndpointAuthenticationConfiguration.cs
@@ -20,7 +20,7 @@ namespace DotNet.Testcontainers.Configurations
     // class or stop exposing the `TestcontainersSettings` properties publicly.
     // Instead, we could rely only on custom configurations via environment variables
     // or the properties file.
-    private static readonly TimeSpan NamedPipeConnectionTimeout = EnvironmentConfiguration.Instance.GetNamedPipeConnectionTimeout() ?? PropertiesFileConfiguration.Instance.GetNamedPipeConnectionTimeout() ?? TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan NamedPipeConnectionTimeout = EnvironmentConfiguration.Instance.GetNamedPipeConnectionTimeout() ?? PropertiesFileConfiguration.Instance.GetNamedPipeConnectionTimeout() ?? TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerEndpointAuthenticationConfiguration" /> struct.

--- a/src/Testcontainers/Containers/ExecResult.cs
+++ b/src/Testcontainers/Containers/ExecResult.cs
@@ -14,7 +14,7 @@ namespace DotNet.Testcontainers.Containers
     /// <param name="stdout">The stdout output.</param>
     /// <param name="stderr">The stderr output.</param>
     /// <param name="exitCode">The exit code.</param>
-    public ExecResult(string stdout, string stderr, long exitCode)
+    public ExecResult(string stdout, string stderr, long? exitCode)
     {
       Stdout = stdout;
       Stderr = stderr;
@@ -37,6 +37,6 @@ namespace DotNet.Testcontainers.Containers
     /// Gets the exit code.
     /// </summary>
     [PublicAPI]
-    public long ExitCode { get; }
+    public long? ExitCode { get; }
   }
 }

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -15,5 +15,5 @@ public static class CommonImages
 
     public static readonly IImage Nginx = new DockerImage("nginx:1.22");
 
-    public static readonly IImage ServerCore = new DockerImage("mcr.microsoft.com/windows/servercore:ltsc2022");
+    public static readonly IImage ServerCore = new DockerImage("mcr.microsoft.com/windows/servercore:ltsc2025");
 }

--- a/tests/Testcontainers.Platform.Windows.Tests/.runs-on
+++ b/tests/Testcontainers.Platform.Windows.Tests/.runs-on
@@ -1,1 +1,1 @@
-windows-2022
+windows-2025

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/TestcontainersContainerTest.cs
@@ -89,8 +89,12 @@ namespace DotNet.Testcontainers.Tests.Unit
         // Given
         const string macAddress = "92:95:5e:30:fe:6d";
 
+        await using var network = new NetworkBuilder()
+          .Build();
+
         await using var container = new ContainerBuilder(CommonImages.Alpine)
           .WithEntrypoint(CommonCommands.SleepInfinity)
+          .WithNetwork(network)
           .WithMacAddress(macAddress)
           .Build();
 


### PR DESCRIPTION
## What does this PR do?

This PR updates Docker.DotNet to a version compatible with Docker Engine v29. There is one caveat: Docker.DotNet does not properly support downgrading (pinning) the Docker Engine API. While version pinning is technically supported, the library does not include the required request/response types and APIs for older versions.

Each Docker.DotNet release is effectively compatible with a single Docker Engine API version, and the library does not support multiple versions at the same time. The updated version officially supports API version 1.52.

This has been a known issue for many years but fortunately hasn't caused major problems. In practice, the library has appeared "compatible" with different Docker Engine API versions because only a limited set of APIs is used.

In the future, I plan to change the underlying Docker.DotNet implementation to support multiple API versions, routing requests and responses to the correct types based on the selected endpoint version.

I ran extensive tests and didn't encounter any major issues. There were a few incompatibilities, but I was able to work around them in Testcontainers.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for nullable exit codes in container execution results.

* **Bug Fixes**
  * Improved network and MAC address configuration handling for containers.
  * Enhanced logging for Docker operations.

* **Chores**
  * Updated .NET version to 10.0 in development container.
  * Updated Windows Server image to ltsc2025.
  * Bumped package dependencies.
  * Increased test timeout and default connection timeout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->