### PR TITLE
feat: Add Platform property to IImage interface

### DIFF
--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -2,6 +2,24 @@
 
 Testcontainers' generic container support offers the greatest flexibility and makes it easy to use virtually any container image in the context of a temporary test environment. To interact or exchange data with a container, Testcontainers provides `ContainerBuilder` to configure and create the resource.
 
+## Configure container image
+
+Use `WithImage(...)` to specify the container image.
+
+The simplest overload accepts a `string`:
+
+```csharp
+_ = new ContainerBuilder()
+  .WithImage("postgres:15.1");
+```
+
+For platform-specific scenarios, `WithImage` also accepts an `IImage`. Using the `DockerImage` implementation, you can explicitly set the platform:
+
+```csharp
+_ = new ContainerBuilder()
+  .WithImage(new DockerImage("postgres:15.1", "linux/amd64"));
+```
+
 ## Configure container start
 
 Both `ENTRYPOINT` and `CMD` allows you to configure an executable and parameters, that a container runs at the start. By default, a container will run whatever `ENTRYPOINT` or `CMD` is specified in the Docker container image. At least one of both configurations is necessary. The container builder implementation supports `WithEntrypoint(params string[])` and `WithCommand(params string[])` to set or override the executable. Ideally, the `ENTRYPOINT` should set the container's executable, whereas the `CMD` sets the default arguments for the `ENTRYPOINT`.

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -15,7 +15,7 @@ _ = new ContainerBuilder()
 
 For more advanced scenarios, `WithImage` also supports `IImage`, giving you more control over how the image is represented and its properties are resolved.
 
-If you need to target a specific platform, the `DockerImage` implementation provides an overload that lets you explicitly set the platform, such as `linux/amd64`.
+If you need to target a specific platform, the `DockerImage` implementation provides an overload that lets you explicitly set the platform, such as `linux/amd64`. By default, the container runtime uses the platform that matches the container host.
 
 ```csharp
 _ = new ContainerBuilder()
@@ -24,7 +24,7 @@ _ = new ContainerBuilder()
 
 !!!tip
 
-    A specifier has the format `<os>|<arch>|<os>/<arch>[/<variant>]`. The user can provide either the operating system or the architecture or both. For more details, [see containerd/platforms](https://github.com/containerd/platforms).
+    A specifier has the format `<os>|<arch>|<os>/<arch>[/<variant>]`. The user can provide either the operating system or the architecture or both. For more details, see [containerd/platforms](https://github.com/containerd/platforms).
 
 ## Configure container start
 

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -4,7 +4,7 @@ Testcontainers' generic container support offers the greatest flexibility and ma
 
 ## Configure container image
 
-Use `WithImage(...)` to specify the container image.
+To specify the container image, use `WithImage(...)`.
 
 The simplest overload accepts a `string`:
 
@@ -13,12 +13,18 @@ _ = new ContainerBuilder()
   .WithImage("postgres:15.1");
 ```
 
-For platform-specific scenarios, `WithImage` also accepts an `IImage`. Using the `DockerImage` implementation, you can explicitly set the platform:
+For more advanced scenarios, `WithImage` also supports `IImage`, giving you more control over how the image is represented and its properties are resolved.
+
+If you need to target a specific platform, the `DockerImage` implementation provides an overload that lets you explicitly set the platform, such as `linux/amd64`.
 
 ```csharp
 _ = new ContainerBuilder()
-  .WithImage(new DockerImage("postgres:15.1", "linux/amd64"));
+  .WithImage(new DockerImage("postgres:15.1", new Platform("linux/amd64")));
 ```
+
+!!!tip
+
+    A specifier has the format `<os>|<arch>|<os>/<arch>[/<variant>]`. The user can provide either the operating system or the architecture or both. For more details, [see containerd/platforms](https://github.com/containerd/platforms).
 
 ## Configure container start
 

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -202,6 +202,7 @@ namespace DotNet.Testcontainers.Clients
       var createParameters = new CreateContainerParameters
       {
         Image = configuration.Image.FullName,
+        Platform = configuration.Image.Platform,
         Name = configuration.Name,
         Hostname = configuration.Hostname,
         WorkingDir = configuration.WorkingDirectory,

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -60,6 +60,7 @@ namespace DotNet.Testcontainers.Clients
       var createParameters = new ImagesCreateParameters
       {
         FromImage = image.FullName,
+        Platform = image.Platform,
       };
 
       var authConfig = new AuthConfig

--- a/src/Testcontainers/Images/DockerImage.cs
+++ b/src/Testcontainers/Images/DockerImage.cs
@@ -31,12 +31,15 @@ namespace DotNet.Testcontainers.Images
     [CanBeNull]
     private readonly string _digest;
 
+    [CanBeNull]
+    private readonly string _platform;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerImage" /> class.
     /// </summary>
     /// <param name="image">The image.</param>
     public DockerImage(IImage image)
-      : this(image.Repository, image.Registry, image.Tag, image.Digest)
+      : this(image.Repository, image.Registry, image.Tag, image.Digest, image.Platform)
     {
     }
 
@@ -53,10 +56,30 @@ namespace DotNet.Testcontainers.Images
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerImage" /> class.
     /// </summary>
+    /// <remarks>
+    /// The supported format for <paramref name="platform" /> is <c>&lt;os&gt;|&lt;arch&gt;|&lt;os&gt;/&lt;arch&gt;[/&lt;variant&gt;]</c>.
+    /// You can provide the operating system, the architecture, or both.
+    /// For more details and examples, see <see href="https://github.com/containerd/platforms">containerd/platforms</see>.
+    /// </remarks>
+    /// <param name="image">The image.</param>
+    /// <param name="platform">The platform.</param>
+    /// <example><c>fedora/httpd:version1.0</c> where <c>fedora/httpd</c> is the repository and <c>version1.0</c> the tag.</example>
+    public DockerImage(
+      string image,
+      string platform)
+      : this(GetDockerImage(image))
+    {
+      _platform = TrimOrDefault(platform);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DockerImage" /> class.
+    /// </summary>
     /// <param name="repository">The repository.</param>
     /// <param name="registry">The registry.</param>
     /// <param name="tag">The tag.</param>
     /// <param name="digest">The digest.</param>
+    /// <param name="platform">The platform.</param>
     /// <param name="hubImageNamePrefix">The Docker Hub image name prefix.</param>
     /// <example><c>fedora/httpd:version1.0</c> where <c>fedora/httpd</c> is the repository and <c>version1.0</c> the tag.</example>
     public DockerImage(
@@ -64,12 +87,14 @@ namespace DotNet.Testcontainers.Images
       string registry = null,
       string tag = null,
       string digest = null,
+      string platform = null,
       string hubImageNamePrefix = null)
       : this(
         TrimOrDefault(repository),
         TrimOrDefault(registry),
         TrimOrDefault(tag, tag == null && digest == null ? LatestTag : null),
         TrimOrDefault(digest),
+        TrimOrDefault(platform),
         hubImageNamePrefix == null ? [] : hubImageNamePrefix.Trim(TrimChars).Split(SlashChar, 2, StringSplitOptions.RemoveEmptyEntries))
     {
     }
@@ -79,6 +104,7 @@ namespace DotNet.Testcontainers.Images
       string registry,
       string tag,
       string digest,
+      string platform,
       string[] substitutions)
     {
       _ = Guard.Argument(repository, nameof(repository))
@@ -109,6 +135,7 @@ namespace DotNet.Testcontainers.Images
 
       _tag = tag;
       _digest = digest;
+      _platform = platform;
     }
 
     /// <inheritdoc />
@@ -122,6 +149,9 @@ namespace DotNet.Testcontainers.Images
 
     /// <inheritdoc />
     public string Digest => _digest;
+
+    /// <inheritdoc />
+    public string Platform => _platform;
 
     /// <inheritdoc />
     public string FullName

--- a/src/Testcontainers/Images/DockerImage.cs
+++ b/src/Testcontainers/Images/DockerImage.cs
@@ -56,20 +56,15 @@ namespace DotNet.Testcontainers.Images
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerImage" /> class.
     /// </summary>
-    /// <remarks>
-    /// The supported format for <paramref name="platform" /> is <c>&lt;os&gt;|&lt;arch&gt;|&lt;os&gt;/&lt;arch&gt;[/&lt;variant&gt;]</c>.
-    /// You can provide the operating system, the architecture, or both.
-    /// For more details and examples, see <see href="https://github.com/containerd/platforms">containerd/platforms</see>.
-    /// </remarks>
     /// <param name="image">The image.</param>
     /// <param name="platform">The platform.</param>
     /// <example><c>fedora/httpd:version1.0</c> where <c>fedora/httpd</c> is the repository and <c>version1.0</c> the tag.</example>
     public DockerImage(
       string image,
-      string platform)
+      Platform platform)
       : this(GetDockerImage(image))
     {
-      _platform = TrimOrDefault(platform);
+      _platform = platform.Value;
     }
 
     /// <summary>

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -401,7 +401,7 @@ namespace DotNet.Testcontainers.Images
 
       if (quote != null)
       {
-        throw new FormatException($"Unmatched {quote} quote starting at position {start - 1} in line: '{line}'.");
+        throw new FormatException($"Unmatched {quote} quote in line: '{line}'.");
       }
 
       if (line.Length > start)
@@ -426,7 +426,7 @@ namespace DotNet.Testcontainers.Images
       else
       {
         var name = trimmed.Substring(0, eqIndex);
-        var value = trimmed.Substring(eqIndex + 1).Trim(' ', '"', '\'');
+        var value = trimmed.Substring(eqIndex + 1).Trim().Trim('"', '\'');
         return (name, value);
       }
     }

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -162,13 +162,13 @@ namespace DotNet.Testcontainers.Images
         .ToArray();
 
       var images = fromMatches
-        .Select(match => (Arg: match.Groups[argGroup], Image: match.Groups[imageGroup]))
-        .Select(item => (Arg: ReplaceVariables(item.Arg.Value, args), Image: ReplaceVariables(item.Image.Value, args)))
+        .Select(match => (FromArgs: match.Groups[argGroup], Image: match.Groups[imageGroup]))
+        .Select(item => (FromArgs: ReplaceVariables(item.FromArgs.Value, args), Image: ReplaceVariables(item.Image.Value, args)))
         .Where(item => !item.Image.Any(char.IsUpper))
         .Where(item => !stages.Contains(item.Image))
         .Select(item =>
         {
-          var fromArgs = ParseFromArgs(item.Arg).ToDictionary(arg => arg.Name, arg => arg.Value);
+          var fromArgs = ParseFromArgs(item.FromArgs).ToDictionary(arg => arg.Name, arg => arg.Value);
           _ = fromArgs.TryGetValue("platform", out var platform);
           return new DockerImage(item.Image, new Platform(platform));
         })

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -170,7 +170,7 @@ namespace DotNet.Testcontainers.Images
         {
           var fromArgs = ParseFromArgs(item.Arg).ToDictionary(arg => arg.Name, arg => arg.Value);
           _ = fromArgs.TryGetValue("platform", out var platform);
-          return new DockerImage(item.Image, platform);
+          return new DockerImage(item.Image, new Platform(platform));
         })
         .ToArray();
 
@@ -339,11 +339,8 @@ namespace DotNet.Testcontainers.Images
     /// quotes (<c>'</c>) are supported. Whitespaces outside of quotes are
     /// treated as separators.
     ///
-    /// For example, the line:
-    /// <code>
-    ///   --pull=always --platform="linux/amd64"
-    /// </code>
-    /// becomes:
+    /// E.g., the line <c>--pull=always --platform="linux/amd64"</c> becomes:
+    ///
     /// <list type="bullet">
     ///   <item>
     ///     <description>
@@ -393,7 +390,7 @@ namespace DotNet.Testcontainers.Images
 
         if (i > start)
         {
-          yield return ParseFlag(line.Substring(start, i - start));
+          yield return ParseArg(line.Substring(start, i - start));
         }
 
         start = i + 1;
@@ -406,18 +403,18 @@ namespace DotNet.Testcontainers.Images
 
       if (line.Length > start)
       {
-        yield return ParseFlag(line.Substring(start));
+        yield return ParseArg(line.Substring(start));
       }
     }
 
     /// <summary>
-    /// Splits a single flag token into a flag name and an optional value.
+    /// Splits a single arg into flag name and an optional value.
     /// </summary>
-    /// <param name="flag">A single flag token, optionally containing an equals sign and value.</param>
+    /// <param name="arg">A single arg, optionally containing an equals sign and value.</param>
     /// <returns>A tuple containing the flag name and its value, or <c>null</c> if no value is specified.</returns>
-    private static (string Name, string Value) ParseFlag(string flag)
+    private static (string Name, string Value) ParseArg(string arg)
     {
-      var trimmed = flag.TrimStart('-');
+      var trimmed = arg.TrimStart('-');
       var eqIndex = trimmed.IndexOf('=');
       if (eqIndex == -1)
       {

--- a/src/Testcontainers/Images/FutureDockerImage.cs
+++ b/src/Testcontainers/Images/FutureDockerImage.cs
@@ -69,6 +69,16 @@ namespace DotNet.Testcontainers.Images
     }
 
     /// <inheritdoc />
+    public string Platform
+    {
+      get
+      {
+        ThrowIfResourceNotFound();
+        return _configuration.Image.Platform;
+      }
+    }
+
+    /// <inheritdoc />
     public string FullName
     {
       get

--- a/src/Testcontainers/Images/IImage.cs
+++ b/src/Testcontainers/Images/IImage.cs
@@ -37,9 +37,8 @@ namespace DotNet.Testcontainers.Images
     /// Gets the platform.
     /// </summary>
     /// <remarks>
-    /// The supported format is <c>&lt;os&gt;|&lt;arch&gt;|&lt;os&gt;/&lt;arch&gt;[/&lt;variant&gt;]</c>.
-    /// You can provide the operating system, the architecture, or both.
-    /// For more details and examples, see <see href="https://github.com/containerd/platforms">containerd/platforms</see>.
+    /// The supported format for a platform value is:
+    /// <c>&lt;os&gt;|&lt;arch&gt;|&lt;os&gt;/&lt;arch&gt;[/&lt;variant&gt;]</c>.
     /// </remarks>
     [CanBeNull]
     string Platform { get; }

--- a/src/Testcontainers/Images/IImage.cs
+++ b/src/Testcontainers/Images/IImage.cs
@@ -34,6 +34,17 @@ namespace DotNet.Testcontainers.Images
     string Digest { get; }
 
     /// <summary>
+    /// Gets the platform.
+    /// </summary>
+    /// <remarks>
+    /// The supported format is <c>&lt;os&gt;|&lt;arch&gt;|&lt;os&gt;/&lt;arch&gt;[/&lt;variant&gt;]</c>.
+    /// You can provide the operating system, the architecture, or both.
+    /// For more details and examples, see <see href="https://github.com/containerd/platforms">containerd/platforms</see>.
+    /// </remarks>
+    [CanBeNull]
+    string Platform { get; }
+
+    /// <summary>
     /// Gets the full image name.
     /// </summary>
     /// <remarks>

--- a/src/Testcontainers/Images/IImageExtensions.cs
+++ b/src/Testcontainers/Images/IImageExtensions.cs
@@ -27,7 +27,7 @@ namespace DotNet.Testcontainers.Images
         return image;
       }
 
-      return new DockerImage(image.Repository, image.Registry, image.Tag, image.Digest, TestcontainersSettings.HubImageNamePrefix);
+      return new DockerImage(image.Repository, image.Registry, image.Tag, image.Digest, image.Platform, TestcontainersSettings.HubImageNamePrefix);
     }
   }
 }

--- a/src/Testcontainers/Images/Platform.cs
+++ b/src/Testcontainers/Images/Platform.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNet.Testcontainers.Images
+namespace DotNet.Testcontainers.Images
 {
   using JetBrains.Annotations;
 

--- a/src/Testcontainers/Images/Platform.cs
+++ b/src/Testcontainers/Images/Platform.cs
@@ -1,0 +1,38 @@
+﻿namespace DotNet.Testcontainers.Images
+{
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Represents a container platform identifier.
+  /// </summary>
+  /// <remarks>
+  /// The supported format for a platform value is:
+  /// <c>&lt;os&gt;|&lt;arch&gt;|&lt;os&gt;/&lt;arch&gt;[/&lt;variant&gt;]</c>.
+  ///
+  /// You can provide either the operating system or the architecture or both.
+  /// For more details, see <see href="https://github.com/containerd/platforms">containerd/platforms</see>.
+  /// </remarks>
+  [PublicAPI]
+  public readonly struct Platform
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Platform" /> struct.
+    /// </summary>
+    /// <param name="value">The platform identifier.</param>
+    [PublicAPI]
+    public Platform(string value)
+    {
+    }
+
+    /// <summary>
+    /// Gets the platform identifier.
+    /// </summary>
+    /// <remarks>
+    /// A string representing the container platform in <c>containerd/platforms</c> format, or
+    /// <c>null</c> if no platform was specified.
+    /// </remarks>
+    [PublicAPI]
+    [CanBeNull]
+    public string Value { get; }
+  }
+}

--- a/src/Testcontainers/Images/Platform.cs
+++ b/src/Testcontainers/Images/Platform.cs
@@ -22,6 +22,7 @@
     [PublicAPI]
     public Platform(string value)
     {
+      Value = value;
     }
 
     /// <summary>

--- a/tests/Testcontainers.Tests/Assets/pullBaseImages/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/pullBaseImages/Dockerfile
@@ -1,4 +1,6 @@
 ARG REPO=mcr.microsoft.com/dotnet/aspnet
+ARG PLATFORM=linux/arm64
+
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 FROM mcr.microsoft.com/dotnet/runtime:8.0 AS runtime
 FROM build
@@ -8,7 +10,10 @@ FROM ${REPO}:8.0-noble
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
 
 # https://github.com/testcontainers/testcontainers-dotnet/issues/993.
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0
+FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0
+FROM --platform=$PLATFORM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0
+FROM --platform="linux/arm/v6" mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0
+FROM --platform='linux/arm/v7' mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0
 
 # https://github.com/testcontainers/testcontainers-dotnet/issues/1030.
 FROM mcr.microsoft.com/dotnet/sdk:$SDK_VERSION_8_0 AS build_sdk_8_0

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerMTls.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerMTls.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 {
   using System.Collections.Generic;
   using DotNet.Testcontainers.Builders;
-  using DotNet.Testcontainers.Images;
 
   public abstract class DockerMTls : ProtectDockerDaemonSocket
   {

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerTlsFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerTlsFixture.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 {
   using System.Collections.Generic;
   using DotNet.Testcontainers.Builders;
-  using DotNet.Testcontainers.Images;
   using JetBrains.Annotations;
 
   [UsedImplicitly]

--- a/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixture.cs
@@ -37,8 +37,8 @@ namespace DotNet.Testcontainers.Tests.Fixtures
       Add(new DockerImageFixtureSerializable(new DockerImage(FedoraHttpd, PortSeparatorRegistry, CustomTag1, null)), $"{PortSeparatorRegistry}/{FedoraHttpd}:{CustomTag1}", $"{PortSeparatorRegistry}/{FedoraHttpd}:{CustomTag1}");
       Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, DotSeparatorRegistry, SemVerTag, Digest)), $"{DotSeparatorRegistry}/{FooBarBaz}:{SemVerTag}@{Digest}", $"{DotSeparatorRegistry}/{FooBarBaz}:{SemVerTag}@{Digest}");
       Add(new DockerImageFixtureSerializable(new DockerImage(FooBarBaz, DotSeparatorRegistry, null, Digest)), $"{DotSeparatorRegistry}/{FooBarBaz}@{Digest}", $"{DotSeparatorRegistry}/{FooBarBaz}@{Digest}");
-      Add(new DockerImageFixtureSerializable(new DockerImage(BarBaz, null, null, null, HubImageNamePrefixImplicitLibrary)), $"{HubImageNamePrefixImplicitLibrary}/{BarBaz}", $"{HubImageNamePrefixImplicitLibrary}/{BarBaz}:{LatestTag}");
-      Add(new DockerImageFixtureSerializable(new DockerImage(BarBaz, null, null, null, HubImageNamePrefixExplicitLibrary)), $"{HubImageNamePrefixExplicitLibrary}/{BarBaz}", $"{HubImageNamePrefixExplicitLibrary}/{BarBaz}:{LatestTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(BarBaz, null, null, null, null, HubImageNamePrefixImplicitLibrary)), $"{HubImageNamePrefixImplicitLibrary}/{BarBaz}", $"{HubImageNamePrefixImplicitLibrary}/{BarBaz}:{LatestTag}");
+      Add(new DockerImageFixtureSerializable(new DockerImage(BarBaz, null, null, null, null, HubImageNamePrefixExplicitLibrary)), $"{HubImageNamePrefixExplicitLibrary}/{BarBaz}", $"{HubImageNamePrefixExplicitLibrary}/{BarBaz}:{LatestTag}");
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixtureSerializable.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/DockerImageFixtureSerializable.cs
@@ -22,7 +22,8 @@ namespace DotNet.Testcontainers.Tests.Fixtures
       var registry = info.GetValue<string>("Registry");
       var tag = info.GetValue<string>("Tag");
       var digest = info.GetValue<string>("Digest");
-      Image = new DockerImage(repository, registry, tag, digest);
+      var platform = info.GetValue<string>("Platform");
+      Image = new DockerImage(repository, registry, tag, digest, platform);
     }
 
     public void Serialize(IXunitSerializationInfo info)
@@ -31,6 +32,7 @@ namespace DotNet.Testcontainers.Tests.Fixtures
       info.AddValue("Registry", Image.Registry);
       info.AddValue("Tag", Image.Tag);
       info.AddValue("Digest", Image.Digest);
+      info.AddValue("Platform", Image.Platform);
     }
   }
 }

--- a/tests/Testcontainers.Tests/Fixtures/Images/HealthCheckFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Images/HealthCheckFixture.cs
@@ -23,6 +23,8 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 
     public string Digest => _image.Digest;
 
+    public string Platform => _image.Platform;
+
     public string FullName => _image.FullName;
 
     public string GetHostname()

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerRegistryAuthenticationProviderTest.cs
@@ -48,7 +48,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     public void GetHostnameFromHubImageNamePrefix(string repository, string tag)
     {
       const string hubImageNamePrefix = "myregistry.azurecr.io";
-      IImage image = new DockerImage(repository, null, tag, null, hubImageNamePrefix);
+      IImage image = new DockerImage(repository, null, tag, null, null, hubImageNamePrefix);
       Assert.Equal(hubImageNamePrefix, image.GetHostname());
     }
 

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -4,7 +4,6 @@ namespace DotNet.Testcontainers.Tests.Unit
   using System.Collections.Generic;
   using System.Collections.ObjectModel;
   using System.IO;
-  using System.Linq;
   using System.Text;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Builders;
@@ -23,13 +22,16 @@ namespace DotNet.Testcontainers.Tests.Unit
       // Given
       var expected = new[]
       {
-        "mcr.microsoft.com/dotnet/sdk:8.0",
-        "mcr.microsoft.com/dotnet/runtime:8.0",
-        "mcr.microsoft.com/dotnet/aspnet:8.0-jammy",
-        "mcr.microsoft.com/dotnet/aspnet:8.0-noble",
-        "mcr.microsoft.com/dotnet/aspnet:8.0-alpine",
-        "mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0",
-        "mcr.microsoft.com/dotnet/sdk:8.0.414",
+        new DockerImage("mcr.microsoft.com/dotnet/sdk:8.0"),
+        new DockerImage("mcr.microsoft.com/dotnet/runtime:8.0"),
+        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-jammy"),
+        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-noble"),
+        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-alpine"),
+        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", "linux/amd64"),
+        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", "linux/arm64"),
+        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", "linux/arm/v6"),
+        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", "linux/arm/v7"),
+        new DockerImage("mcr.microsoft.com/dotnet/sdk:8.0.414"),
       };
 
       IImage image = new DockerImage("localhost/testcontainers", Guid.NewGuid().ToString("D"), string.Empty);
@@ -44,7 +46,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var actual = dockerfileArchive.GetBaseImages();
 
       // Then
-      Assert.Equal(expected, actual.Select(baseImage => baseImage.FullName));
+      Assert.Equivalent(expected, actual);
     }
 
     [Fact]

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -27,10 +27,10 @@ namespace DotNet.Testcontainers.Tests.Unit
         new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-jammy"),
         new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-noble"),
         new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-alpine"),
-        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", "linux/amd64"),
-        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", "linux/arm64"),
-        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", "linux/arm/v6"),
-        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", "linux/arm/v7"),
+        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", new Platform("linux/amd64")),
+        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", new Platform("linux/arm64")),
+        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", new Platform("linux/arm/v6")),
+        new DockerImage("mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0", new Platform("linux/arm/v7")),
         new DockerImage("mcr.microsoft.com/dotnet/sdk:8.0.414"),
       };
 

--- a/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
@@ -70,6 +70,20 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [Fact]
+    public void Platform_PlatformIsLinuxAmd64_ReturnsLinuxAmd64()
+    {
+      // Given
+      const string platform = "linux/amd64";
+      IImage dockerImage = new DockerImage("foo", platform);
+
+      // When
+      var result = dockerImage.Platform;
+
+      // Then
+      Assert.Equal(platform, result);
+    }
+
+    [Fact]
     public void MatchLatestOrNightly_TagIsLatest_ReturnsTrue()
     {
       // Given

--- a/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
@@ -73,14 +73,14 @@ namespace DotNet.Testcontainers.Tests.Unit
     public void Platform_PlatformIsLinuxAmd64_ReturnsLinuxAmd64()
     {
       // Given
-      const string platform = "linux/amd64";
-      IImage dockerImage = new DockerImage("foo", platform);
+      const string linuxAmd64 = "linux/amd64";
+      IImage dockerImage = new DockerImage("foo", new Platform(linuxAmd64));
 
       // When
       var result = dockerImage.Platform;
 
       // Then
-      Assert.Equal(platform, result);
+      Assert.Equal(linuxAmd64, result);
     }
 
     [Fact]

--- a/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/TestcontainersImageTest.cs
@@ -70,17 +70,33 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [Fact]
-    public void Platform_PlatformIsLinuxAmd64_ReturnsLinuxAmd64()
+    public void Platform_NoPlatformSpecified_ReturnsNull()
     {
       // Given
-      const string linuxAmd64 = "linux/amd64";
-      IImage dockerImage = new DockerImage("foo", new Platform(linuxAmd64));
+      IImage dockerImage = new DockerImage("foo");
 
       // When
       var result = dockerImage.Platform;
 
       // Then
-      Assert.Equal(linuxAmd64, result);
+      Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("linux/amd64")]
+    [InlineData("linux/arm64")]
+    [InlineData("linux/arm/v6")]
+    [InlineData("linux/arm/v7")]
+    public void Platform_PlatformSpecified_ReturnsPlatform(string platform)
+    {
+      // Given
+      IImage dockerImage = new DockerImage("foo", new Platform(platform));
+
+      // When
+      var result = dockerImage.Platform;
+
+      // Then
+      Assert.Equal(platform, result);
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

This PR extends the `IImage` interface by adding the `Platform` property. The new property allows developers to specify which platform the container runtime should pull the image for. This is especially important on macOS (Apple Silicon), where some images are not natively available for the host architecture.

When using the Docker Engine API, the runtime does not automatically fall back, e.g. for `linux/arm64` to `linux/amd64`. This is the client's responsibility.

The new property makes it possible to explicitly set the platform when creating a new `IImage` instance using the `DockerImage` implementation, for example:

`_ = new DockerImage("postgres:15.1", "linux/amd64")`

The platform flag is also evaluated when building an image. If the platform is specified in a `Dockerfile`, Testcontainers now respects it and pulls the correct image.

@0xced LMKWYT

## Why is it important?

The PR allows pulling images that do not match the container runtime host architecture.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1587

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-aware image support added across the API, including a Platform type for explicit architecture targeting (e.g., linux/amd64, linux/arm64, linux/arm/v6, linux/arm/v7).
  * Dockerfile parsing now recognizes FROM-ARG/platform entries to derive image platforms.

* **Bug Fixes**
  * Platform is propagated to image pull/create and container creation requests for correct platform selection.

* **Documentation**
  * Guidance added for configuring container images with platform-aware options and spec format.

* **Tests**
  * Updated and added tests for platform parsing, serialization, selection, and behavior.

* **Chores**
  * Minor test cleanup (removed unused imports).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->