### PR TITLE
feat: Require explicit container image in Testcontainers.Xunit

### DIFF
--- a/src/Testcontainers.Xunit/ContainerLifetime.cs
+++ b/src/Testcontainers.Xunit/ContainerLifetime.cs
@@ -16,7 +16,7 @@ public abstract class ContainerLifetime<TBuilderEntity, TContainerEntity> : IAsy
 
     protected ContainerLifetime(ILogger logger)
     {
-        _container = new Lazy<TContainerEntity>(() => Configure(new TBuilderEntity().WithLogger(logger)).Build());
+        _container = new Lazy<TContainerEntity>(() => Configure(Configure()).WithLogger(logger).Build());
     }
 
     /// <summary>
@@ -49,6 +49,25 @@ public abstract class ContainerLifetime<TBuilderEntity, TContainerEntity> : IAsy
 #endif
 
     /// <summary>
+    /// Configures the container instance.
+    /// </summary>
+    /// <example>
+    ///   <code>
+    ///   public class MariaDbRootUserFixture(IMessageSink messageSink) : DbContainerFixture&lt;MariaDbBuilder, MariaDbContainer&gt;(messageSink)
+    ///   {
+    ///     public override DbProviderFactory DbProviderFactory =&gt; MySqlConnectorFactory.Instance;
+    ///   <br />
+    ///     protected override MariaDbBuilder Configure()
+    ///     {
+    ///       return new MariaDbBuilder("mariadb:12").WithUsername("root");
+    ///     }
+    ///   }
+    ///   </code>
+    /// </example>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    protected virtual TBuilderEntity Configure() => new();
+
+    /// <summary>
     /// Extension method to further configure the container instance.
     /// </summary>
     /// <example>
@@ -66,6 +85,7 @@ public abstract class ContainerLifetime<TBuilderEntity, TContainerEntity> : IAsy
     /// </example>
     /// <param name="builder">The container builder to configure.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [Obsolete("This method is obsolete and will be removed. Use the parameterless Configure() method and create the builder explicitly instead.")]
     protected virtual TBuilderEntity Configure(TBuilderEntity builder)
     {
         return builder;

--- a/src/Testcontainers.Xunit/ContainerTest.cs
+++ b/src/Testcontainers.Xunit/ContainerTest.cs
@@ -14,5 +14,6 @@ public abstract class ContainerTest<TBuilderEntity, TContainerEntity>(ITestOutpu
     where TBuilderEntity : IContainerBuilder<TBuilderEntity, TContainerEntity, IContainerConfiguration>, new()
     where TContainerEntity : IContainer
 {
+    [Obsolete("This method is obsolete and will be removed. Use the parameterless Configure() method and create the builder explicitly instead.")]
     protected override TBuilderEntity Configure(TBuilderEntity builder) => configure != null ? configure(builder) : builder;
 }

--- a/tests/Testcontainers.Cassandra.Tests/CassandraContainerTest.cs
+++ b/tests/Testcontainers.Cassandra.Tests/CassandraContainerTest.cs
@@ -60,9 +60,6 @@ public abstract class CassandraContainerTest(CassandraContainerTest.CassandraDef
     public class CassandraDefaultFixture(IMessageSink messageSink)
         : DbContainerFixture<CassandraBuilder, CassandraContainer>(messageSink)
     {
-        protected override CassandraBuilder Configure(CassandraBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile());
-
         protected override CassandraBuilder Configure()
             => new CassandraBuilder(TestSession.GetImageFromDockerfile());
 

--- a/tests/Testcontainers.Cassandra.Tests/CassandraContainerTest.cs
+++ b/tests/Testcontainers.Cassandra.Tests/CassandraContainerTest.cs
@@ -63,6 +63,9 @@ public abstract class CassandraContainerTest(CassandraContainerTest.CassandraDef
         protected override CassandraBuilder Configure(CassandraBuilder builder)
             => builder.WithImage(TestSession.GetImageFromDockerfile());
 
+        protected override CassandraBuilder Configure()
+            => new CassandraBuilder(TestSession.GetImageFromDockerfile());
+
         public override DbProviderFactory DbProviderFactory
             => CqlProviderFactory.Instance;
     }
@@ -71,8 +74,8 @@ public abstract class CassandraContainerTest(CassandraContainerTest.CassandraDef
     public class CassandraWaitForDatabaseFixture(IMessageSink messageSink)
         : CassandraDefaultFixture(messageSink)
     {
-        protected override CassandraBuilder Configure(CassandraBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile()).WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
+        protected override CassandraBuilder Configure()
+            => base.Configure().WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
     }
 
     [UsedImplicitly]

--- a/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.cs
+++ b/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.cs
@@ -35,8 +35,8 @@ public abstract partial class ClickHouseContainerTest(ClickHouseContainerTest.Cl
     public class ClickHouseDefaultFixture(IMessageSink messageSink)
         : DbContainerFixture<ClickHouseBuilder, ClickHouseContainer>(messageSink)
     {
-        protected override ClickHouseBuilder Configure(ClickHouseBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile());
+        protected override ClickHouseBuilder Configure()
+            => new ClickHouseBuilder(TestSession.GetImageFromDockerfile());
 
         public override DbProviderFactory DbProviderFactory
             => ClickHouseConnectionFactory.Instance;
@@ -46,8 +46,8 @@ public abstract partial class ClickHouseContainerTest(ClickHouseContainerTest.Cl
     public class ClickHouseWaitForDatabaseFixture(IMessageSink messageSink)
         : ClickHouseDefaultFixture(messageSink)
     {
-        protected override ClickHouseBuilder Configure(ClickHouseBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile()).WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
+        protected override ClickHouseBuilder Configure()
+            => base.Configure().WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
     }
 
     [UsedImplicitly]

--- a/tests/Testcontainers.CockroachDb.Tests/CockroachDbContainerTest.cs
+++ b/tests/Testcontainers.CockroachDb.Tests/CockroachDbContainerTest.cs
@@ -35,8 +35,8 @@ public abstract class CockroachDbContainerTest(CockroachDbContainerTest.Cockroac
     public class CockroachDbDefaultFixture(IMessageSink messageSink)
         : DbContainerFixture<CockroachDbBuilder, CockroachDbContainer>(messageSink)
     {
-        protected override CockroachDbBuilder Configure(CockroachDbBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile());
+        protected override CockroachDbBuilder Configure()
+            => new CockroachDbBuilder(TestSession.GetImageFromDockerfile());
 
         public override DbProviderFactory DbProviderFactory
             => NpgsqlFactory.Instance;
@@ -46,8 +46,8 @@ public abstract class CockroachDbContainerTest(CockroachDbContainerTest.Cockroac
     public class CockroachDbWaitForDatabaseFixture(IMessageSink messageSink)
         : CockroachDbDefaultFixture(messageSink)
     {
-        protected override CockroachDbBuilder Configure(CockroachDbBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile()).WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
+        protected override CockroachDbBuilder Configure()
+            => base.Configure().WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
     }
 
     [UsedImplicitly]

--- a/tests/Testcontainers.Db2.Tests/Db2ContainerTest.cs
+++ b/tests/Testcontainers.Db2.Tests/Db2ContainerTest.cs
@@ -40,16 +40,16 @@ public abstract class Db2ContainerTest(Db2ContainerTest.Db2DefaultFixture fixtur
         public override DbProviderFactory DbProviderFactory
             => DB2Factory.Instance;
 
-        protected override Db2Builder Configure(Db2Builder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile()).WithAcceptLicenseAgreement(true);
+        protected override Db2Builder Configure()
+            => new Db2Builder(TestSession.GetImageFromDockerfile()).WithAcceptLicenseAgreement(true);
     }
 
     [UsedImplicitly]
     public class Db2WaitForDatabaseFixture(IMessageSink messageSink)
         : Db2DefaultFixture(messageSink)
     {
-        protected override Db2Builder Configure(Db2Builder builder)
-            => base.Configure(builder).WithImage(TestSession.GetImageFromDockerfile()).WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
+        protected override Db2Builder Configure()
+            => base.Configure().WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
     }
 
     [UsedImplicitly]

--- a/tests/Testcontainers.FirebirdSql.Tests/FirebirdSqlContainerTest.cs
+++ b/tests/Testcontainers.FirebirdSql.Tests/FirebirdSqlContainerTest.cs
@@ -35,8 +35,8 @@ public abstract class FirebirdSqlContainerTest(FirebirdSqlContainerTest.Firebird
     public class FirebirdSqlDefaultFixture(IMessageSink messageSink)
         : DbContainerFixture<FirebirdSqlBuilder, FirebirdSqlContainer>(messageSink)
     {
-        protected override FirebirdSqlBuilder Configure(FirebirdSqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile());
+        protected override FirebirdSqlBuilder Configure()
+            => new FirebirdSqlBuilder(TestSession.GetImageFromDockerfile());
 
         public override DbProviderFactory DbProviderFactory
             => FirebirdClientFactory.Instance;
@@ -46,40 +46,40 @@ public abstract class FirebirdSqlContainerTest(FirebirdSqlContainerTest.Firebird
     public class FirebirdSqlWaitForDatabaseFixture(IMessageSink messageSink)
         : FirebirdSqlDefaultFixture(messageSink)
     {
-        protected override FirebirdSqlBuilder Configure(FirebirdSqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile()).WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
+        protected override FirebirdSqlBuilder Configure()
+            => base.Configure().WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
     }
 
     [UsedImplicitly]
     public class FirebirdSql25ScFixture(IMessageSink messageSink)
         : FirebirdSqlDefaultFixture(messageSink)
     {
-        protected override FirebirdSqlBuilder Configure(FirebirdSqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile(stage: "fb2.5-sc"));
+        protected override FirebirdSqlBuilder Configure()
+            => new FirebirdSqlBuilder(TestSession.GetImageFromDockerfile(stage: "fb2.5-sc"));
     }
 
     [UsedImplicitly]
     public class FirebirdSql25SsFixture(IMessageSink messageSink)
         : FirebirdSqlDefaultFixture(messageSink)
     {
-        protected override FirebirdSqlBuilder Configure(FirebirdSqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile(stage: "fb2.5-ss"));
+        protected override FirebirdSqlBuilder Configure()
+            => new FirebirdSqlBuilder(TestSession.GetImageFromDockerfile(stage: "fb2.5-ss"));
     }
 
     [UsedImplicitly]
     public class FirebirdSql30Fixture(IMessageSink messageSink)
         : FirebirdSqlDefaultFixture(messageSink)
     {
-        protected override FirebirdSqlBuilder Configure(FirebirdSqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile(stage: "fb3.0"));
+        protected override FirebirdSqlBuilder Configure()
+            => new FirebirdSqlBuilder(TestSession.GetImageFromDockerfile(stage: "fb3.0"));
     }
 
     [UsedImplicitly]
     public class FirebirdSqlSysdbaFixture(IMessageSink messageSink)
         : FirebirdSqlDefaultFixture(messageSink)
     {
-        protected override FirebirdSqlBuilder Configure(FirebirdSqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile()).WithUsername("sysdba").WithPassword("some-password");
+        protected override FirebirdSqlBuilder Configure()
+            => base.Configure().WithUsername("sysdba").WithPassword("some-password");
     }
 
     [UsedImplicitly]

--- a/tests/Testcontainers.MariaDb.Tests/MariaDbContainerTest.cs
+++ b/tests/Testcontainers.MariaDb.Tests/MariaDbContainerTest.cs
@@ -35,8 +35,8 @@ public abstract class MariaDbContainerTest(MariaDbContainerTest.MariaDbDefaultFi
     public class MariaDbDefaultFixture(IMessageSink messageSink)
         : DbContainerFixture<MariaDbBuilder, MariaDbContainer>(messageSink)
     {
-        protected override MariaDbBuilder Configure(MariaDbBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile());
+        protected override MariaDbBuilder Configure()
+            => new MariaDbBuilder(TestSession.GetImageFromDockerfile());
 
         public override DbProviderFactory DbProviderFactory
             => MySqlConnectorFactory.Instance;
@@ -46,8 +46,8 @@ public abstract class MariaDbContainerTest(MariaDbContainerTest.MariaDbDefaultFi
     public class MariaDbWaitForDatabaseFixture(IMessageSink messageSink)
         : MariaDbDefaultFixture(messageSink)
     {
-        protected override MariaDbBuilder Configure(MariaDbBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile()).WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
+        protected override MariaDbBuilder Configure()
+            => base.Configure().WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
     }
 
     [UsedImplicitly]

--- a/tests/Testcontainers.Mosquitto.Tests/MosquittoContainerTest.cs
+++ b/tests/Testcontainers.Mosquitto.Tests/MosquittoContainerTest.cs
@@ -13,6 +13,9 @@ public abstract class MosquittoContainerTest : ContainerTest<MosquittoBuilder, M
     {
     }
 
+    protected override MosquittoBuilder Configure()
+        => new MosquittoBuilder(TestSession.GetImageFromDockerfile());
+
     protected abstract MqttClientOptions GetClientOptions();
 
     [Fact]
@@ -87,10 +90,8 @@ public abstract class MosquittoContainerTest : ContainerTest<MosquittoBuilder, M
     public sealed class TcpEncryptedUnauthenticatedConfiguration(ITestOutputHelper testOutputHelper)
         : MosquittoContainerTest(testOutputHelper)
     {
-        protected override MosquittoBuilder Configure(MosquittoBuilder builder)
-        {
-            return builder.WithImage(TestSession.GetImageFromDockerfile()).WithCertificate(Certificate, CertificateKey);
-        }
+        protected override MosquittoBuilder Configure()
+            => base.Configure().WithCertificate(Certificate, CertificateKey);
 
         protected override MqttClientOptions GetClientOptions()
         {
@@ -106,11 +107,6 @@ public abstract class MosquittoContainerTest : ContainerTest<MosquittoBuilder, M
     public sealed class WebSocketUnencryptedUnauthenticatedConfiguration(ITestOutputHelper testOutputHelper)
         : MosquittoContainerTest(testOutputHelper)
     {
-        protected override MosquittoBuilder Configure(MosquittoBuilder builder)
-        {
-            return builder.WithImage(TestSession.GetImageFromDockerfile());
-        }
-
         protected override MqttClientOptions GetClientOptions()
         {
             return new MqttClientOptionsBuilder()
@@ -123,10 +119,8 @@ public abstract class MosquittoContainerTest : ContainerTest<MosquittoBuilder, M
     public sealed class WebSocketEncryptedUnauthenticatedConfiguration(ITestOutputHelper testOutputHelper)
         : MosquittoContainerTest(testOutputHelper)
     {
-        protected override MosquittoBuilder Configure(MosquittoBuilder builder)
-        {
-            return builder.WithImage(TestSession.GetImageFromDockerfile()).WithCertificate(Certificate, CertificateKey);
-        }
+        protected override MosquittoBuilder Configure()
+            => base.Configure().WithCertificate(Certificate, CertificateKey);
 
         protected override MqttClientOptions GetClientOptions()
         {

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -37,8 +37,8 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
     public class MsSqlDefaultFixture(IMessageSink messageSink)
         : DbContainerFixture<MsSqlBuilder, MsSqlContainer>(messageSink)
     {
-        protected override MsSqlBuilder Configure(MsSqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile());
+        protected override MsSqlBuilder Configure()
+            => new MsSqlBuilder(TestSession.GetImageFromDockerfile());
 
         public override DbProviderFactory DbProviderFactory
             => SqlClientFactory.Instance;
@@ -48,8 +48,8 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
     public class MsSqlWaitForDatabaseFixture(IMessageSink messageSink)
         : MsSqlDefaultFixture(messageSink)
     {
-        protected override MsSqlBuilder Configure(MsSqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile()).WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
+        protected override MsSqlBuilder Configure()
+            => base.Configure().WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
     }
 
     [UsedImplicitly]

--- a/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
+++ b/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
@@ -35,8 +35,8 @@ public abstract class MySqlContainerTest(MySqlContainerTest.MySqlDefaultFixture 
     public class MySqlDefaultFixture(IMessageSink messageSink)
         : DbContainerFixture<MySqlBuilder, MySqlContainer>(messageSink)
     {
-        protected override MySqlBuilder Configure(MySqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile());
+        protected override MySqlBuilder Configure()
+            => new MySqlBuilder(TestSession.GetImageFromDockerfile());
 
         public override DbProviderFactory DbProviderFactory
             => MySqlConnectorFactory.Instance;
@@ -46,16 +46,16 @@ public abstract class MySqlContainerTest(MySqlContainerTest.MySqlDefaultFixture 
     public class MySqlWaitForDatabaseFixture(IMessageSink messageSink)
         : MySqlDefaultFixture(messageSink)
     {
-        protected override MySqlBuilder Configure(MySqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile()).WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
+        protected override MySqlBuilder Configure()
+            => base.Configure().WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
     }
 
     [UsedImplicitly]
     public class MySqlRootFixture(IMessageSink messageSink)
         : MySqlDefaultFixture(messageSink)
     {
-        protected override MySqlBuilder Configure(MySqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile()).WithUsername("root");
+        protected override MySqlBuilder Configure()
+            => base.Configure().WithUsername("root");
     }
 
     [UsedImplicitly]
@@ -63,8 +63,8 @@ public abstract class MySqlContainerTest(MySqlContainerTest.MySqlDefaultFixture 
         : MySqlDefaultFixture(messageSink)
     {
         // https://github.com/testcontainers/testcontainers-dotnet/issues/1142.
-        protected override MySqlBuilder Configure(MySqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile(stage: "mysql8.0.28"));
+        protected override MySqlBuilder Configure()
+            => new MySqlBuilder(TestSession.GetImageFromDockerfile(stage: "mysql8.0.28"));
     }
 
     [UsedImplicitly]

--- a/tests/Testcontainers.Oracle.Tests/OracleContainerTest.cs
+++ b/tests/Testcontainers.Oracle.Tests/OracleContainerTest.cs
@@ -36,8 +36,10 @@ public abstract class OracleContainerTest(OracleContainerTest.OracleFixture fixt
     {
         public override DbProviderFactory DbProviderFactory => OracleClientFactory.Instance;
 
-        protected override OracleBuilder Configure(OracleBuilder builder)
+        protected override OracleBuilder Configure()
         {
+            var builder = new OracleBuilder();
+
             if (edition == null && version == null)
             {
                 return Apply(builder, oracle => oracle);

--- a/tests/Testcontainers.Oracle.Tests/OracleContainerTest.cs
+++ b/tests/Testcontainers.Oracle.Tests/OracleContainerTest.cs
@@ -32,21 +32,14 @@ public abstract class OracleContainerTest(OracleContainerTest.OracleFixture fixt
         Assert.Empty(execResult.Stderr);
     }
 
-    public abstract class OracleFixture(IMessageSink messageSink, string edition, int? version, string database = null, bool waitForDatabase = false) : DbContainerFixture<OracleBuilder, OracleContainer>(messageSink)
+    public abstract class OracleFixture(IMessageSink messageSink, string edition, string version, string database = null, bool waitForDatabase = false) : DbContainerFixture<OracleBuilder, OracleContainer>(messageSink)
     {
         public override DbProviderFactory DbProviderFactory => OracleClientFactory.Instance;
 
         protected override OracleBuilder Configure()
         {
-            var builder = new OracleBuilder();
-
-            if (edition == null && version == null)
-            {
-                return Apply(builder, oracle => oracle);
-            }
-
-            var image = $"gvenzl/oracle-{edition}:{version}-slim-faststart";
-            return database == null ? Apply(builder, oracle => oracle.WithImage(image)) : Apply(builder, oracle => oracle.WithImage(image).WithDatabase(database));
+            var builder = new OracleBuilder($"gvenzl/oracle-{edition}:{version}-slim-faststart");
+            return database == null ? Apply(builder, oracle => oracle) : Apply(builder, oracle => oracle.WithDatabase(database));
         }
 
         private OracleBuilder Apply(OracleBuilder builder, Func<OracleBuilder, OracleBuilder> configure)
@@ -57,39 +50,39 @@ public abstract class OracleContainerTest(OracleContainerTest.OracleFixture fixt
 
 #if ORACLE_DEFAULT
     [UsedImplicitly] public sealed class OracleDefault(OracleDefaultFixture fixture) : OracleContainerTest(fixture), IClassFixture<OracleDefaultFixture>;
-    [UsedImplicitly] public sealed class OracleDefaultFixture(IMessageSink messageSink) : OracleFixture(messageSink, null, null);
+    [UsedImplicitly] public sealed class OracleDefaultFixture(IMessageSink messageSink) : OracleFixture(messageSink, "xe", "21.3.0");
 #endif
 
 #if ORACLE_11
     [UsedImplicitly] public sealed class Oracle11(Oracle11Fixture fixture) : OracleContainerTest(fixture), IClassFixture<Oracle11Fixture>;
-    [UsedImplicitly] public sealed class Oracle11Fixture(IMessageSink messageSink) : OracleFixture(messageSink, "xe", 11);
-    [UsedImplicitly] public sealed class Oracle11FixtureWaitForDatabase(IMessageSink messageSink) : OracleFixture(messageSink, "xe", 11, waitForDatabase: true);
+    [UsedImplicitly] public sealed class Oracle11Fixture(IMessageSink messageSink) : OracleFixture(messageSink, "xe", "11");
+    [UsedImplicitly] public sealed class Oracle11FixtureWaitForDatabase(IMessageSink messageSink) : OracleFixture(messageSink, "xe", "11", waitForDatabase: true);
 #endif
 
 #if ORACLE_18
     [UsedImplicitly] public sealed class Oracle18(Oracle18Fixture fixture) : OracleContainerTest(fixture), IClassFixture<Oracle18Fixture>;
     [UsedImplicitly] public sealed class Oracle18Default(Oracle18FixtureDefault fixture) : OracleContainerTest(fixture), IClassFixture<Oracle18FixtureDefault>;
     [UsedImplicitly] public sealed class Oracle18Scott(Oracle18FixtureScott fixture) : OracleContainerTest(fixture), IClassFixture<Oracle18FixtureScott>;
-    [UsedImplicitly] public sealed class Oracle18Fixture(IMessageSink messageSink) : OracleFixture(messageSink, "xe", 18);
-    [UsedImplicitly] public sealed class Oracle18FixtureDefault(IMessageSink messageSink) : OracleFixture(messageSink, "xe", 18, "XEPDB1", waitForDatabase: true);
-    [UsedImplicitly] public sealed class Oracle18FixtureScott(IMessageSink messageSink) : OracleFixture(messageSink, "xe", 18, "SCOTT");
+    [UsedImplicitly] public sealed class Oracle18Fixture(IMessageSink messageSink) : OracleFixture(messageSink, "xe", "18");
+    [UsedImplicitly] public sealed class Oracle18FixtureDefault(IMessageSink messageSink) : OracleFixture(messageSink, "xe", "18", "XEPDB1", waitForDatabase: true);
+    [UsedImplicitly] public sealed class Oracle18FixtureScott(IMessageSink messageSink) : OracleFixture(messageSink, "xe", "18", "SCOTT");
 #endif
 
 #if ORACLE_21
     [UsedImplicitly] public sealed class Oracle21(Oracle21Fixture fixture) : OracleContainerTest(fixture), IClassFixture<Oracle21Fixture>;
     [UsedImplicitly] public sealed class Oracle21Default(Oracle21FixtureDefault fixture) : OracleContainerTest(fixture), IClassFixture<Oracle21FixtureDefault>;
     [UsedImplicitly] public sealed class Oracle21Scott(Oracle21FixtureScott fixture) : OracleContainerTest(fixture), IClassFixture<Oracle21FixtureScott>;
-    [UsedImplicitly] public sealed class Oracle21Fixture(IMessageSink messageSink) : OracleFixture(messageSink, "xe", 21);
-    [UsedImplicitly] public sealed class Oracle21FixtureDefault(IMessageSink messageSink) : OracleFixture(messageSink, "xe", 21, "XEPDB1", waitForDatabase: true);
-    [UsedImplicitly] public sealed class Oracle21FixtureScott(IMessageSink messageSink) : OracleFixture(messageSink, "xe", 21, "SCOTT");
+    [UsedImplicitly] public sealed class Oracle21Fixture(IMessageSink messageSink) : OracleFixture(messageSink, "xe", "21");
+    [UsedImplicitly] public sealed class Oracle21FixtureDefault(IMessageSink messageSink) : OracleFixture(messageSink, "xe", "21", "XEPDB1", waitForDatabase: true);
+    [UsedImplicitly] public sealed class Oracle21FixtureScott(IMessageSink messageSink) : OracleFixture(messageSink, "xe", "21", "SCOTT");
 #endif
 
 #if ORACLE_23
     [UsedImplicitly] public sealed class Oracle23(Oracle23Fixture fixture) : OracleContainerTest(fixture), IClassFixture<Oracle23Fixture>;
     [UsedImplicitly] public sealed class Oracle23Default(Oracle23FixtureDefault fixture) : OracleContainerTest(fixture), IClassFixture<Oracle23FixtureDefault>;
     [UsedImplicitly] public sealed class Oracle23Scott(Oracle23FixtureScott fixture) : OracleContainerTest(fixture), IClassFixture<Oracle23FixtureScott>;
-    [UsedImplicitly] public sealed class Oracle23Fixture(IMessageSink messageSink) : OracleFixture(messageSink, "free", 23);
-    [UsedImplicitly] public sealed class Oracle23FixtureDefault(IMessageSink messageSink) : OracleFixture(messageSink, "free", 23, "FREEPDB1", waitForDatabase: true);
-    [UsedImplicitly] public sealed class Oracle23FixtureScott(IMessageSink messageSink) : OracleFixture(messageSink, "free", 23, "SCOTT");
+    [UsedImplicitly] public sealed class Oracle23Fixture(IMessageSink messageSink) : OracleFixture(messageSink, "free", "23");
+    [UsedImplicitly] public sealed class Oracle23FixtureDefault(IMessageSink messageSink) : OracleFixture(messageSink, "free", "23", "FREEPDB1", waitForDatabase: true);
+    [UsedImplicitly] public sealed class Oracle23FixtureScott(IMessageSink messageSink) : OracleFixture(messageSink, "free", "23", "SCOTT");
 #endif
 }

--- a/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
+++ b/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
@@ -69,8 +69,8 @@ public abstract class PostgreSqlContainerTest(PostgreSqlContainerTest.PostgreSql
     public class PostgreSqlDefaultFixture(IMessageSink messageSink)
         : DbContainerFixture<PostgreSqlBuilder, PostgreSqlContainer>(messageSink)
     {
-        protected override PostgreSqlBuilder Configure(PostgreSqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile());
+        protected override PostgreSqlBuilder Configure()
+            => new PostgreSqlBuilder(TestSession.GetImageFromDockerfile());
 
         public override DbProviderFactory DbProviderFactory
             => NpgsqlFactory.Instance;
@@ -80,8 +80,8 @@ public abstract class PostgreSqlContainerTest(PostgreSqlContainerTest.PostgreSql
     public class PostgreSqlWaitForDatabaseFixture(IMessageSink messageSink)
         : PostgreSqlDefaultFixture(messageSink)
     {
-        protected override PostgreSqlBuilder Configure(PostgreSqlBuilder builder)
-            => builder.WithImage(TestSession.GetImageFromDockerfile()).WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
+        protected override PostgreSqlBuilder Configure()
+            => base.Configure().WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
     }
 
     [UsedImplicitly]

--- a/tests/Testcontainers.Xunit.Tests/PostgreSqlContainer.cs
+++ b/tests/Testcontainers.Xunit.Tests/PostgreSqlContainer.cs
@@ -4,10 +4,9 @@ namespace Testcontainers.Xunit.Example3;
 public sealed partial class PostgreSqlContainerTest(ITestOutputHelper testOutputHelper)
     : DbContainerTest<PostgreSqlBuilder, PostgreSqlContainer>(testOutputHelper)
 {
-    protected override PostgreSqlBuilder Configure(PostgreSqlBuilder builder)
+    protected override PostgreSqlBuilder Configure()
     {
-        return builder
-            .WithImage("postgres:15.1")
+        return new PostgreSqlBuilder("postgres:15.1")
             .WithResourceMapping("Chinook_PostgreSql_AutoIncrementPKs.sql", "/docker-entrypoint-initdb.d/");
     }
 }

--- a/tests/Testcontainers.Xunit.Tests/RedisContainerTest`1.cs
+++ b/tests/Testcontainers.Xunit.Tests/RedisContainerTest`1.cs
@@ -4,10 +4,10 @@ namespace Testcontainers.Xunit.Example1;
 public sealed partial class RedisContainerTest(ITestOutputHelper testOutputHelper)
     : ContainerTest<RedisBuilder, RedisContainer>(testOutputHelper)
 {
-    protected override RedisBuilder Configure(RedisBuilder builder)
+    protected override RedisBuilder Configure()
     {
         // 👇 Configure your container instance here.
-        return builder.WithImage("redis:7.0");
+        return new RedisBuilder("redis:7.0");
     }
 }
 // # --8<-- [end:ConfigureRedisContainer]

--- a/tests/Testcontainers.Xunit.Tests/RedisContainerTest`2.cs
+++ b/tests/Testcontainers.Xunit.Tests/RedisContainerTest`2.cs
@@ -5,9 +5,9 @@ namespace Testcontainers.Xunit.Example2;
 public sealed class RedisContainerFixture(IMessageSink messageSink)
     : ContainerFixture<RedisBuilder, RedisContainer>(messageSink)
 {
-    protected override RedisBuilder Configure(RedisBuilder builder)
+    protected override RedisBuilder Configure()
     {
-        return builder.WithImage("redis:7.0");
+        return new RedisBuilder("redis:7.0");
     }
 }
 // # --8<-- [end:ConfigureRedisContainer]


### PR DESCRIPTION
## What does this PR do?

This pull request introduce a new parameterless `Configure()` method on the `ContainerLifetime` class, hence also on the derived `(Db)ContainerFixture` and `(Db)ContainerTest` classes.

It also makes the `TBuilderEntity Configure(TBuilderEntity builder)` method obsolete.

## Why is it important?

This matches the changes discussed in #1540 and introduced in #1584.

## Related issues

This is a follow-up to #1584. Closes #1598.

/cc @digital88

## How to test this PR

All relevant tests have been adapted to use the new parameterless `Configure()` method.

## Follow-ups

When the parameterless constructors (now obsolete) are eventually removed from the builders, the following changes will need to be performed.

1. Remove the `new()` constraint on `ContainerLifetime`, `ContainerFixture`, `ContainerTest`, `DbContainerFixture` and `DbContainerTest`
2. Make the `ContainerFixture` class abstract
3. Change `protected virtual TBuilderEntity Configure() => new();` to `protected abstract TBuilderEntity Configure();` on ContainerLifetime, forcing consumers to provide the image name/tag when creating builders.
4. Delete the obsolete methods: `protected virtual TBuilderEntity Configure(TBuilderEntity builder)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized container configuration to a parameterless builder initialization across fixtures, simplifying how builders are created and extended.

* **Bug Fixes**
  * Updated derived fixtures to obtain base configuration before applying additional options (e.g., wait strategies, credentials).

* **Documentation**
  * Added XML docs and examples for the new configuration extension point and marked the old overload as deprecated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->