### PR TITLE
chore: Update examples to use TC for .NET 4.10.0

### DIFF
--- a/examples/Flyway/Directory.Packages.props
+++ b/examples/Flyway/Directory.Packages.props
@@ -6,7 +6,7 @@
     <ItemGroup>
         <!-- Unit and integration test dependencies: -->
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.7.0"/>
+        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
         <PackageVersion Include="xunit" Version="2.9.2"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->

--- a/examples/Flyway/tests/Flyway.Tests/DbFixture.cs
+++ b/examples/Flyway/tests/Flyway.Tests/DbFixture.cs
@@ -19,8 +19,7 @@ public sealed class DbFixture : IAsyncLifetime
         // as soon as the database is ready. Once the migration is finished, the Flyway
         // container exits, and the database container becomes available for tests.
 
-        _postgreSqlContainer = new PostgreSqlBuilder()
-            .WithImage("postgres:15-alpine")
+        _postgreSqlContainer = new PostgreSqlBuilder("postgres:15-alpine")
             .WithNetwork(_network)
             .WithNetworkAliases(nameof(_postgreSqlContainer))
             .Build();
@@ -30,8 +29,7 @@ public sealed class DbFixture : IAsyncLifetime
         // the files are available as soon as the container starts. Flyway will
         // automatically pick them up and start the database migration process.
 
-        _flywayContainer = new ContainerBuilder()
-            .WithImage("flyway/flyway:9-alpine")
+        _flywayContainer = new ContainerBuilder("flyway/flyway:9-alpine")
             .WithResourceMapping("migrate/", "/flyway/sql/")
             .WithCommand("-url=jdbc:postgresql://" + nameof(_postgreSqlContainer) + "/")
             .WithCommand("-user=" + PostgreSqlBuilder.DefaultUsername)
@@ -40,7 +38,7 @@ public sealed class DbFixture : IAsyncLifetime
             .WithCommand("migrate")
             .WithNetwork(_network)
             .DependsOn(_postgreSqlContainer)
-            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new MigrationCompleted()))
+            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new MigrationCompleted(), o => o.WithMode(WaitStrategyMode.OneShot)))
             .Build();
     }
 

--- a/examples/Respawn/Directory.Packages.props
+++ b/examples/Respawn/Directory.Packages.props
@@ -6,11 +6,11 @@
     <ItemGroup>
         <!-- Unit and integration test dependencies: -->
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.7.0"/>
+        <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
         <PackageVersion Include="xunit" Version="2.9.2"/>
         <!-- Third-party client dependencies to connect and interact with the containers: -->
         <PackageVersion Include="Npgsql" Version="6.0.11"/>
-        <PackageVersion Include="Respawn" Version="6.2.1"/>
+        <PackageVersion Include="Respawn" Version="7.0.0"/>
     </ItemGroup>
 </Project>

--- a/examples/Respawn/tests/Respawn.Tests/DbFixture.cs
+++ b/examples/Respawn/tests/Respawn.Tests/DbFixture.cs
@@ -10,8 +10,7 @@ public sealed class DbFixture : IAsyncLifetime
         // Testcontainers starts the dependent database (PostgreSQL) and copies the SQL scripts
         // to the container before it starts. The PostgreSQL container runs the scripts
         // automatically during startup, creating the database schema.
-        _postgreSqlContainer = new PostgreSqlBuilder()
-            .WithImage("postgres:15-alpine")
+        _postgreSqlContainer = new PostgreSqlBuilder("postgres:15-alpine")
             .WithResourceMapping("migrate/", "/docker-entrypoint-initdb.d/")
             .Build();
     }

--- a/examples/WeatherForecast/Directory.Packages.props
+++ b/examples/WeatherForecast/Directory.Packages.props
@@ -4,13 +4,13 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.13"/>
-    <PackageVersion Include="Microsoft.Fast.Components.FluentUI" Version="3.5.5"/>
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.1"/>
+    <PackageVersion Include="Microsoft.Fast.Components.FluentUI" Version="3.8.0"/>
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0"/>
     <!-- Unit and integration test dependencies: -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.13"/>
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.7.0"/>
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1"/>
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.10.0"/>
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
     <PackageVersion Include="xunit" Version="2.9.2"/>
     <!-- Third-party client dependencies to connect and interact with the containers: -->

--- a/examples/WeatherForecast/Dockerfile
+++ b/examples/WeatherForecast/Dockerfile
@@ -10,7 +10,7 @@ RUN dotnet restore $CSPROJ_FILE_PATH
 
 RUN dotnet publish $CSPROJ_FILE_PATH --configuration Release --framework net10.0 --runtime linux-x64 --self-contained false --output out /p:DebugType=None /p:DebugSymbols=false
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
 ARG RESOURCE_REAPER_SESSION_ID="00000000-0000-0000-0000-000000000000"
 LABEL "org.testcontainers.resource-reaper-session"=$RESOURCE_REAPER_SESSION_ID
 WORKDIR /app

--- a/examples/WeatherForecast/src/WeatherForecast/DatabaseContainer.cs
+++ b/examples/WeatherForecast/src/WeatherForecast/DatabaseContainer.cs
@@ -2,7 +2,7 @@ namespace WeatherForecast;
 
 public sealed class DatabaseContainer : IHostedService
 {
-  private readonly PostgreSqlContainer _postgreSqlContainer = new PostgreSqlBuilder().Build();
+  private readonly PostgreSqlContainer _postgreSqlContainer = new PostgreSqlBuilder("postgres:15.1").Build();
 
   public Task StartAsync(CancellationToken cancellationToken)
   {

--- a/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecastTest.cs
+++ b/examples/WeatherForecast/tests/WeatherForecast.InProcess.Tests/WeatherForecastTest.cs
@@ -3,7 +3,7 @@ namespace WeatherForecast.InProcess.Tests;
 [UsedImplicitly]
 public sealed class WeatherForecastTest : IAsyncLifetime
 {
-  private readonly PostgreSqlContainer _postgreSqlContainer = new PostgreSqlBuilder().Build();
+  private readonly PostgreSqlContainer _postgreSqlContainer = new PostgreSqlBuilder("postgres:15.1").Build();
 
   public Task InitializeAsync()
   {

--- a/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecastContainer.cs
+++ b/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecastContainer.cs
@@ -3,7 +3,7 @@ namespace WeatherForecast.Tests;
 [UsedImplicitly]
 public sealed class WeatherForecastContainer : HttpClient, IAsyncLifetime
 {
-  private static readonly X509Certificate Certificate = new X509Certificate2(WeatherForecastImage.CertificateFilePath, WeatherForecastImage.CertificatePassword);
+  private static readonly X509Certificate Certificate = X509CertificateLoader.LoadPkcs12FromFile(WeatherForecastImage.CertificateFilePath, WeatherForecastImage.CertificatePassword);
 
   private static readonly WeatherForecastImage Image = new WeatherForecastImage();
 
@@ -27,13 +27,12 @@ public sealed class WeatherForecastContainer : HttpClient, IAsyncLifetime
     _weatherForecastNetwork = new NetworkBuilder()
       .Build();
 
-    _postgreSqlContainer = new PostgreSqlBuilder()
+    _postgreSqlContainer = new PostgreSqlBuilder("postgres:15.1")
       .WithNetwork(_weatherForecastNetwork)
       .WithNetworkAliases(weatherForecastStorage)
       .Build();
 
-    _weatherForecastContainer = new ContainerBuilder()
-      .WithImage(Image)
+    _weatherForecastContainer = new ContainerBuilder(Image)
       .WithNetwork(_weatherForecastNetwork)
       .WithPortBinding(WeatherForecastImage.HttpsPort, true)
       .WithEnvironment("ASPNETCORE_URLS", "https://+")

--- a/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecastImage.cs
+++ b/examples/WeatherForecast/tests/WeatherForecast.Tests/WeatherForecastImage.cs
@@ -21,6 +21,8 @@ public sealed class WeatherForecastImage : IImage, IAsyncLifetime
 
   public string Digest => _image.Digest;
 
+  public string Platform => _image.Platform;
+
   public string FullName => _image.FullName;
 
   public async Task InitializeAsync()


### PR DESCRIPTION
## What does this PR do?

This PR updates the .NET examples to the latest TC version (4.10.0) and removes obsolete API usage to follow best practices and serve as a good reference for using TC for .NET.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #1540

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NuGet package dependencies across example projects, including Testcontainers.PostgreSql, Entity Framework Core, Npgsql, and Fluent UI to latest versions
  * Updated Docker base image from ASP.NET 8.0 to 10.0 runtime in WeatherForecast example

* **New Features**
  * Added Platform property to image configuration in WeatherForecast example

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->