### PR TITLE
(feat): Allow to copy tar stream to container before it starts.

### DIFF
--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -9,6 +9,7 @@ namespace DotNet.Testcontainers.Builders
   using System.Threading.Tasks;
   using Docker.DotNet.Models;
   using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Configurations.Containers;
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Images;
   using DotNet.Testcontainers.Networks;
@@ -269,6 +270,13 @@ namespace DotNet.Testcontainers.Builders
       {
         return WithResourceMapping(new UriResourceMapping(source, target, uid, gid, fileMode));
       }
+    }
+
+    /// <inheritdoc />
+    public TBuilderEntity WithCopyTarArchive(Stream tarArchive, string containerPath = "/")
+    {
+      var tarArchiveMappings = new[] { new TarArchiveMapping(tarArchive, containerPath) };
+      return Clone(new ContainerConfiguration(tarArchiveMappings: tarArchiveMappings));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -324,6 +324,14 @@ namespace DotNet.Testcontainers.Builders
     TBuilderEntity WithResourceMapping(Uri source, string target, uint uid = 0, uint gid = 0, UnixFileModes fileMode = Unix.FileMode644);
 
     /// <summary>
+    /// Copies a tar archive contents to the container before it starts.
+    /// </summary>
+    /// <param name="tarArchive">The <see cref="Stream"/> with the tar archive contents.</param>
+    /// <param name="containerPath">The path where tar archive contents should be placed.</param>
+    /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    TBuilderEntity WithCopyTarArchive(Stream tarArchive, string containerPath = "/");
+
+    /// <summary>
     /// Assigns the mount configuration to manage data in the container.
     /// </summary>
     /// <param name="mount">The mount configuration.</param>

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -326,6 +326,9 @@ namespace DotNet.Testcontainers.Builders
     /// <summary>
     /// Copies a tar archive contents to the container before it starts.
     /// </summary>
+    /// <remarks>
+    /// Set the <paramref name="tarArchive"/> property <see cref="Stream.Position"/> to 0 before calling this method.
+    /// </remarks>
     /// <param name="tarArchive">The <see cref="Stream"/> with the tar archive contents.</param>
     /// <param name="containerPath">The path where tar archive contents should be placed.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>

--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -34,6 +34,7 @@ namespace DotNet.Testcontainers.Builders
     /// <param name="acceptLicenseAgreement">A boolean value indicating whether the license agreement is accepted.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the module does not require a license agreement.</exception>
+    [PublicAPI]
     TBuilderEntity WithAcceptLicenseAgreement(bool acceptLicenseAgreement);
 
     /// <summary>
@@ -321,17 +322,25 @@ namespace DotNet.Testcontainers.Builders
     /// <param name="gid">The group ID to set for the copied file or directory. Defaults to 0 (root).</param>
     /// <param name="fileMode">The POSIX file mode permission.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
     TBuilderEntity WithResourceMapping(Uri source, string target, uint uid = 0, uint gid = 0, UnixFileModes fileMode = Unix.FileMode644);
 
     /// <summary>
     /// Copies a tar archive contents to the container before it starts.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Set the <paramref name="tarArchive"/> property <see cref="Stream.Position"/> to 0 before calling this method.
+    /// </para>
+    /// <para>
+    /// The caller retains ownership of the stream and is responsible for disposal.
+    /// The stream content is copied during container startup, so the stream must remain open and readable until the container starts.
+    /// </para>
     /// </remarks>
     /// <param name="tarArchive">The <see cref="Stream"/> with the tar archive contents.</param>
     /// <param name="containerPath">The path where tar archive contents should be placed.</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
+    [PublicAPI]
     TBuilderEntity WithCopyTarArchive(Stream tarArchive, string containerPath = "/");
 
     /// <summary>

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -1,16 +1,16 @@
 namespace DotNet.Testcontainers.Clients
 {
+  using Docker.DotNet;
+  using Docker.DotNet.Models;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Containers;
+  using Microsoft.Extensions.Logging;
   using System;
   using System.Collections.Generic;
   using System.Globalization;
   using System.IO;
   using System.Threading;
   using System.Threading.Tasks;
-  using Docker.DotNet;
-  using Docker.DotNet.Models;
-  using DotNet.Testcontainers.Configurations;
-  using DotNet.Testcontainers.Containers;
-  using Microsoft.Extensions.Logging;
 
   internal sealed class DockerContainerOperations : DockerApiClient, IDockerContainerOperations
   {
@@ -109,9 +109,9 @@ namespace DotNet.Testcontainers.Clients
       return DockerClient.Containers.RemoveContainerAsync(id, new ContainerRemoveParameters { Force = true, RemoveVolumes = true }, ct);
     }
 
-    public Task ExtractArchiveToContainerAsync(string id, string path, TarOutputMemoryStream tarStream, CancellationToken ct = default)
+    public Task ExtractArchiveToContainerAsync(string id, string path, Stream tarStream, CancellationToken ct = default)
     {
-      Logger.CopyArchiveToDockerContainer(id, tarStream.ContentLength);
+      Logger.CopyArchiveToDockerContainer(id, tarStream.Length);
 
       var copyToContainerParameters = new CopyToContainerParameters
       {

--- a/src/Testcontainers/Clients/IDockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/IDockerContainerOperations.cs
@@ -1,13 +1,13 @@
 namespace DotNet.Testcontainers.Clients
 {
+  using Docker.DotNet.Models;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Containers;
   using System;
   using System.Collections.Generic;
   using System.IO;
   using System.Threading;
   using System.Threading.Tasks;
-  using Docker.DotNet.Models;
-  using DotNet.Testcontainers.Configurations;
-  using DotNet.Testcontainers.Containers;
 
   internal interface IDockerContainerOperations : IHasListOperations<ContainerListResponse, ContainerInspectResponse>
   {
@@ -25,7 +25,7 @@ namespace DotNet.Testcontainers.Clients
 
     Task RemoveAsync(string id, CancellationToken ct = default);
 
-    Task ExtractArchiveToContainerAsync(string id, string path, TarOutputMemoryStream tarStream, CancellationToken ct = default);
+    Task ExtractArchiveToContainerAsync(string id, string path, Stream tarStream, CancellationToken ct = default);
 
     Task<Stream> GetArchiveFromContainerAsync(string id, string path, CancellationToken ct = default);
 

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -156,6 +156,16 @@ namespace DotNet.Testcontainers.Clients
     Task CopyAsync(string id, FileInfo source, string target, uint uid, uint gid, UnixFileModes fileMode, CancellationToken ct = default);
 
     /// <summary>
+    /// Copies a tar archive contents to the container.
+    /// </summary>
+    /// <param name="id">The container id.</param>
+    /// <param name="tarArchive">The <see cref="Stream"/> with the tar archive contents.</param>
+    /// <param name="containerPath">The path where tar archive contents should be placed.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when the tar archive has been copied.</returns>
+    Task CopyTarArchiveAsync(string id, Stream tarArchive, string containerPath = "/", CancellationToken ct = default);
+
+    /// <summary>
     /// Reads a file from the container.
     /// </summary>
     /// <param name="id">The container id.</param>

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -158,6 +158,9 @@ namespace DotNet.Testcontainers.Clients
     /// <summary>
     /// Copies a tar archive contents to the container.
     /// </summary>
+    /// <remarks>
+    /// Set the <paramref name="tarArchive"/> property <see cref="Stream.Position"/> to 0 before calling this method.
+    /// </remarks>
     /// <param name="id">The container id.</param>
     /// <param name="tarArchive">The <see cref="Stream"/> with the tar archive contents.</param>
     /// <param name="containerPath">The path where tar archive contents should be placed.</param>

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -159,7 +159,13 @@ namespace DotNet.Testcontainers.Clients
     /// Copies a tar archive contents to the container.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Set the <paramref name="tarArchive"/> property <see cref="Stream.Position"/> to 0 before calling this method.
+    /// </para>
+    /// <para>
+    /// The caller retains ownership of the stream and is responsible for disposal.
+    /// The stream content is copied during container startup, so the stream must remain open and readable until the container starts.
+    /// </para>
     /// </remarks>
     /// <param name="id">The container id.</param>
     /// <param name="tarArchive">The <see cref="Stream"/> with the tar archive contents.</param>

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -264,6 +264,13 @@ namespace DotNet.Testcontainers.Clients
     }
 
     /// <inheritdoc />
+    public async Task CopyTarArchiveAsync(string id, Stream tarArchive, string containerPath = "/", CancellationToken ct = default)
+    {
+      await Container.ExtractArchiveToContainerAsync(id, containerPath, tarArchive, ct)
+          .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
     public async Task<byte[]> ReadFileAsync(string id, string filePath, CancellationToken ct = default)
     {
       Stream tarStream;
@@ -350,6 +357,12 @@ namespace DotNet.Testcontainers.Clients
       if (configuration.ResourceMappings.Any())
       {
         await Task.WhenAll(configuration.ResourceMappings.Select(resourceMapping => CopyAsync(id, resourceMapping, ct)))
+          .ConfigureAwait(false);
+      }
+
+      if (configuration.TarArchiveMappings.Any())
+      {
+        await Task.WhenAll(configuration.TarArchiveMappings.Select(tarArchive => CopyTarArchiveAsync(id, tarArchive.TarArchive, tarArchive.ContainerPath, ct)))
           .ConfigureAwait(false);
       }
 

--- a/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
@@ -1,17 +1,18 @@
+using Docker.DotNet.Models;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations.Containers;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Images;
+using DotNet.Testcontainers.Networks;
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace DotNet.Testcontainers.Configurations
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Text.Json.Serialization;
-  using System.Threading;
-  using System.Threading.Tasks;
-  using Docker.DotNet.Models;
-  using DotNet.Testcontainers.Builders;
-  using DotNet.Testcontainers.Containers;
-  using DotNet.Testcontainers.Images;
-  using DotNet.Testcontainers.Networks;
-  using JetBrains.Annotations;
-
   /// <inheritdoc cref="IContainerConfiguration" />
   [PublicAPI]
   public class ContainerConfiguration : ResourceConfiguration<CreateContainerParameters>, IContainerConfiguration
@@ -42,6 +43,7 @@ namespace DotNet.Testcontainers.Configurations
     /// <param name="connectionStringProvider">The connection string provider.</param>
     /// <param name="autoRemove">A value indicating whether Docker removes the container after it exits or not.</param>
     /// <param name="privileged">A value indicating whether the privileged flag is set or not.</param>
+    /// <param name="tarArchiveMappings">A list of tar archive mappings.</param>
     public ContainerConfiguration(
       IImage image = null,
       Func<ImageInspectResponse, bool> imagePullPolicy = null,
@@ -65,7 +67,8 @@ namespace DotNet.Testcontainers.Configurations
       Func<IContainer, IContainerConfiguration, CancellationToken, Task> startupCallback = null,
       IConnectionStringProvider<IContainer, IContainerConfiguration> connectionStringProvider = null,
       bool? autoRemove = null,
-      bool? privileged = null)
+      bool? privileged = null,
+      IEnumerable<TarArchiveMapping> tarArchiveMappings = null)
     {
       AutoRemove = autoRemove;
       Privileged = privileged;
@@ -90,6 +93,7 @@ namespace DotNet.Testcontainers.Configurations
       WaitStrategies = waitStrategies;
       StartupCallback = startupCallback;
       ConnectionStringProvider = connectionStringProvider;
+      TarArchiveMappings = tarArchiveMappings;
     }
 
     /// <summary>
@@ -130,6 +134,7 @@ namespace DotNet.Testcontainers.Configurations
       ExposedPorts = BuildConfiguration.Combine(oldValue.ExposedPorts, newValue.ExposedPorts);
       PortBindings = BuildConfiguration.Combine(oldValue.PortBindings, newValue.PortBindings);
       ResourceMappings = BuildConfiguration.Combine(oldValue.ResourceMappings, newValue.ResourceMappings);
+      TarArchiveMappings = BuildConfiguration.Combine(oldValue.TarArchiveMappings, newValue.TarArchiveMappings);
       Containers = BuildConfiguration.Combine(oldValue.Containers, newValue.Containers);
       Mounts = BuildConfiguration.Combine(oldValue.Mounts, newValue.Mounts);
       Networks = BuildConfiguration.Combine(oldValue.Networks, newValue.Networks);
@@ -191,6 +196,10 @@ namespace DotNet.Testcontainers.Configurations
     /// <inheritdoc />
     [JsonIgnore]
     public IEnumerable<IResourceMapping> ResourceMappings { get; }
+
+    /// <inheritdoc />
+    [JsonIgnore]
+    public IEnumerable<TarArchiveMapping> TarArchiveMappings { get; }
 
     /// <inheritdoc />
     [JsonIgnore]

--- a/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/IContainerConfiguration.cs
@@ -1,14 +1,16 @@
 namespace DotNet.Testcontainers.Configurations
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Threading;
-  using System.Threading.Tasks;
   using Docker.DotNet.Models;
+  using DotNet.Testcontainers.Configurations.Containers;
   using DotNet.Testcontainers.Containers;
   using DotNet.Testcontainers.Images;
   using DotNet.Testcontainers.Networks;
   using JetBrains.Annotations;
+  using System;
+  using System.Collections.Generic;
+  using System.IO;
+  using System.Threading;
+  using System.Threading.Tasks;
 
   /// <summary>
   /// A container configuration.
@@ -85,6 +87,11 @@ namespace DotNet.Testcontainers.Configurations
     /// Gets a list of resource mappings.
     /// </summary>
     IEnumerable<IResourceMapping> ResourceMappings { get; }
+
+    /// <summary>
+    /// Gets a list of tar archive mappings.
+    /// </summary>
+    IEnumerable<TarArchiveMapping> TarArchiveMappings { get; }
 
     /// <summary>
     /// Gets a list of dependent containers.

--- a/src/Testcontainers/Configurations/Containers/TarArchiveMapping.cs
+++ b/src/Testcontainers/Configurations/Containers/TarArchiveMapping.cs
@@ -1,0 +1,17 @@
+using System.IO;
+
+namespace DotNet.Testcontainers.Configurations.Containers
+{
+  public sealed record TarArchiveMapping
+  {
+    public TarArchiveMapping(Stream tarArchive, string containerPath)
+    {
+      TarArchive = tarArchive;
+      ContainerPath = containerPath;
+    }
+
+    public Stream TarArchive { get; }
+
+    public string ContainerPath { get; }
+  }
+}

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -152,28 +152,28 @@ namespace DotNet.Testcontainers.Containers
           case "http":
           case "https":
           case "tcp":
-          {
-            return dockerEndpoint.Host;
-          }
+            {
+              return dockerEndpoint.Host;
+            }
 
           case "npipe":
           case "unix":
-          {
-            const string localhost = "127.0.0.1";
-
-            if (!Exists())
             {
-              return localhost;
-            }
+              const string localhost = "127.0.0.1";
 
-            if (!_client.IsRunningInsideDocker)
-            {
-              return localhost;
-            }
+              if (!Exists())
+              {
+                return localhost;
+              }
 
-            var endpointSettings = _container.NetworkSettings.Networks.First().Value;
-            return endpointSettings.Gateway;
-          }
+              if (!_client.IsRunningInsideDocker)
+              {
+                return localhost;
+              }
+
+              var endpointSettings = _container.NetworkSettings.Networks.First().Value;
+              return endpointSettings.Gateway;
+            }
 
           default:
             throw new InvalidOperationException($"Docker endpoint {dockerEndpoint} is not supported.");
@@ -404,6 +404,12 @@ namespace DotNet.Testcontainers.Containers
     public Task CopyAsync(DirectoryInfo source, string target, uint uid = 0, uint gid = 0, UnixFileModes fileMode = Unix.FileMode644, CancellationToken ct = default)
     {
       return _client.CopyAsync(Id, source, target, uid, gid, fileMode, ct);
+    }
+
+    /// <inheritdoc />
+    public Task CopyTarArchiveAsync(Stream tarArchive, string containerPath = "/", CancellationToken ct = default)
+    {
+      return _client.CopyTarArchiveAsync(Id, tarArchive, containerPath, ct);
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -301,6 +301,15 @@ namespace DotNet.Testcontainers.Containers
     Task CopyAsync(FileInfo source, string target, uint uid = 0, uint gid = 0, UnixFileModes fileMode = Unix.FileMode644, CancellationToken ct = default);
 
     /// <summary>
+    /// Copies a tar archive contents to the container.
+    /// </summary>
+    /// <param name="tarArchive">The <see cref="Stream"/> with the tar archive contents.</param>
+    /// <param name="containerPath">The path where tar archive contents should be placed.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A task that completes when the tar archive has been copied.</returns>
+    Task CopyTarArchiveAsync(Stream tarArchive, string containerPath = "/", CancellationToken ct = default);
+
+    /// <summary>
     /// Reads a file from the container.
     /// </summary>
     /// <param name="filePath">An absolute path or a name value within the container.</param>

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -304,7 +304,13 @@ namespace DotNet.Testcontainers.Containers
     /// Copies a tar archive contents to the container.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Set the <paramref name="tarArchive"/> property <see cref="Stream.Position"/> to 0 before calling this method.
+    /// </para>
+    /// <para>
+    /// The caller retains ownership of the stream and is responsible for disposal.
+    /// The stream content is copied during container startup, so the stream must remain open and readable until the container starts.
+    /// </para>
     /// </remarks>
     /// <param name="tarArchive">The <see cref="Stream"/> with the tar archive contents.</param>
     /// <param name="containerPath">The path where tar archive contents should be placed.</param>

--- a/src/Testcontainers/Containers/IContainer.cs
+++ b/src/Testcontainers/Containers/IContainer.cs
@@ -303,6 +303,9 @@ namespace DotNet.Testcontainers.Containers
     /// <summary>
     /// Copies a tar archive contents to the container.
     /// </summary>
+    /// <remarks>
+    /// Set the <paramref name="tarArchive"/> property <see cref="Stream.Position"/> to 0 before calling this method.
+    /// </remarks>
     /// <param name="tarArchive">The <see cref="Stream"/> with the tar archive contents.</param>
     /// <param name="containerPath">The path where tar archive contents should be placed.</param>
     /// <param name="ct">Cancellation token.</param>

--- a/tests/Testcontainers.Platform.Linux.Tests/CopyTarArchiveTests.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/CopyTarArchiveTests.cs
@@ -1,0 +1,156 @@
+﻿using ICSharpCode.SharpZipLib.Core;
+using System.Formats.Tar;
+
+namespace Testcontainers.Tests
+{
+    public class CopyTarArchiveTests : FileTestBase
+    {
+        public CopyTarArchiveTests() : base()
+        {
+        }
+
+        [Fact]
+        public async Task Should_Copy_TarArchive_ToContainer_BigFile_SystemIO()
+        {
+            const long fiveMb = 5L * 1024L * 1024L;
+            const long fiveGb = fiveMb * 1024L;
+
+            // Given
+            using (var fs = new FileStream(_testFile.FullName, FileMode.Open, FileAccess.Write, FileShare.ReadWrite))
+            {
+                fs.SetLength(fiveMb); // change for fiveGb
+                fs.Close();
+            }
+
+            var targetDirectoryPath1 = string.Join("/", string.Empty, "tmp", string.Empty);
+
+            var targetFilePaths = new List<string>();
+            targetFilePaths.Add(Path.Combine(targetDirectoryPath1, _testFile.Name));
+
+            var bufferFilePath = Path.Combine(_testFile.Directory.Parent.FullName, Path.GetRandomFileName());
+
+            using var memStore = new FileStream(bufferFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+            await TarFile.CreateFromDirectoryAsync(_testFile.Directory.FullName, memStore, false, TestContext.Current.CancellationToken);
+            await memStore.FlushAsync(TestContext.Current.CancellationToken);
+            memStore.Position = 0;
+
+            var container = new ContainerBuilder(CommonImages.Alpine)
+                .WithEntrypoint(CommonCommands.SleepInfinity)
+                .WithCopyTarArchive(memStore, targetDirectoryPath1)
+                .Build();
+
+            // When
+            await container.StartAsync(TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+
+            // Then
+            var execResults = await Task.WhenAll(targetFilePaths.Select(containerFilePath => container.ExecAsync(new[] { "test", "-f", containerFilePath }, TestContext.Current.CancellationToken)))
+                .ConfigureAwait(true);
+
+            Assert.All(execResults, result => Assert.Equal(0, result.ExitCode));
+
+            // add proper cleanup in case of test failure?
+            if (File.Exists(bufferFilePath))
+                File.Delete(bufferFilePath);
+        }
+
+        [Fact]
+        public async Task Should_Copy_TarArchive_ToContainer_SystemIO()
+        {
+            // Given
+            var targetDirectoryPath1 = string.Join("/", string.Empty, "tmp", string.Empty);
+
+            var targetFilePaths = new List<string>();
+            targetFilePaths.Add(Path.Combine(targetDirectoryPath1, _testFile.Name));
+
+            using var memStore = new MemoryStream(); // the underlying storage for tar archive, can be any Stream.
+            await TarFile.CreateFromDirectoryAsync(_testFile.Directory.FullName, memStore, false, TestContext.Current.CancellationToken);
+            memStore.Position = 0; // must rewind underlying Stream to start position before copying
+
+            var container = new ContainerBuilder(CommonImages.Alpine)
+                .WithEntrypoint(CommonCommands.SleepInfinity)
+                .WithCopyTarArchive(memStore, targetDirectoryPath1) // this will copy the Stream with tar archive contents in container just before the container startup
+                .Build();
+
+            // When
+            await container.StartAsync(TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+
+            // Then
+            var execResults = await Task.WhenAll(targetFilePaths.Select(containerFilePath => container.ExecAsync(new[] { "test", "-f", containerFilePath }, TestContext.Current.CancellationToken)))
+                .ConfigureAwait(true);
+
+            Assert.All(execResults, result => Assert.Equal(0, result.ExitCode));
+        }
+
+        [Fact]
+        public async Task Should_Copy_TarArchive_ToContainer_SharpZipLib()
+        {
+            static string ToTarArchivePath(string s)
+            {
+                return PathUtils.DropPathRoot(s).Replace(Path.DirectorySeparatorChar, '/');
+            }
+
+            // Given
+            var targetFilePath1 = string.Join("/", string.Empty, "tmp", Guid.NewGuid(), _testFile.Name);
+            var targetFilePath2 = string.Join("/", string.Empty, "tmp", Guid.NewGuid(), _testFile.Name);
+
+            var targetFilePaths = new List<string>();
+            targetFilePaths.Add(targetFilePath1);
+            targetFilePaths.Add(targetFilePath2);
+            if (OperatingSystem.IsWindows())
+            {
+                targetFilePaths.Add(ToTarArchivePath(_testFile.FullName));
+            }
+
+            using var memStore = new MemoryStream(); // the underlying storage for tar archive, can be any Stream.
+            using var tarArchive = TarArchive.CreateOutputTarArchive(memStore, Encoding.UTF8);
+            tarArchive.IsStreamOwner = false; // setting this property to false is required for copying underlying Stream into container later.
+
+            // entry #1 from the file on host disk, using full path to file
+            var entry1 = ICSharpCode.SharpZipLib.Tar.TarEntry.CreateEntryFromFile(_testFile.FullName);
+            // explicitly set a path for file in container to targetFilePath1
+            entry1.Name = targetFilePath1;
+            tarArchive.WriteEntry(entry1, false);
+
+            // entry #2
+            var entry2 = ICSharpCode.SharpZipLib.Tar.TarEntry.CreateEntryFromFile(_testFile.FullName);
+            entry2.Name = targetFilePath2;
+            // custom userid:groupid
+            entry2.UserId = 1000;
+            entry2.GroupId = 1000;
+            tarArchive.WriteEntry(entry2, false);
+
+            if (OperatingSystem.IsWindows())
+            {
+                // entry #3
+                var entry3 = ICSharpCode.SharpZipLib.Tar.TarEntry.CreateEntryFromFile(_testFile.FullName);
+                // on Windows entry5.Name will be without C:\\ prefix
+                tarArchive.WriteEntry(entry3, false);
+            }
+
+            // close the TarArchive, forcing it to write all neccessary data as bytes into underlying Stream
+            tarArchive.Close();
+            memStore.Position = 0; // must rewind underlying Stream to start position before copying
+
+            var container = new ContainerBuilder(CommonImages.Alpine)
+                .WithEntrypoint(CommonCommands.SleepInfinity)
+                .WithCopyTarArchive(memStore) // this will copy the Stream with tar archive contents in container just before the container startup
+                .Build();
+
+            // When
+            await container.StartAsync(TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+
+            // Then
+            var execResults = await Task.WhenAll(targetFilePaths.Select(containerFilePath => container.ExecAsync(new[] { "test", "-f", containerFilePath }, TestContext.Current.CancellationToken)))
+                .ConfigureAwait(true);
+
+            Assert.All(execResults, result => Assert.Equal(0, result.ExitCode));
+
+            // check that uid is correct
+            var result = await container.ExecAsync(new[] { "stat", "-c", "'%u'", targetFilePath2 }, TestContext.Current.CancellationToken);
+            Assert.Equal("'1000'\n", result.Stdout);
+        }
+    }
+}

--- a/tests/Testcontainers.Platform.Linux.Tests/CopyTarArchiveTests.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/CopyTarArchiveTests.cs
@@ -29,14 +29,14 @@ namespace Testcontainers.Tests
 
             var bufferFilePath = Path.Combine(_testFile.Directory.Parent.FullName, Path.GetRandomFileName());
 
-            using var memStore = new FileStream(bufferFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
-            await TarFile.CreateFromDirectoryAsync(_testFile.Directory.FullName, memStore, false, TestContext.Current.CancellationToken);
-            await memStore.FlushAsync(TestContext.Current.CancellationToken);
-            memStore.Position = 0;
+            using var tarBuffer = new FileStream(bufferFilePath, FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite);
+            await TarFile.CreateFromDirectoryAsync(_testFile.Directory.FullName, tarBuffer, false, TestContext.Current.CancellationToken);
+            await tarBuffer.FlushAsync(TestContext.Current.CancellationToken);
+            tarBuffer.Position = 0;
 
-            var container = new ContainerBuilder(CommonImages.Alpine)
+            await using var container = new ContainerBuilder(CommonImages.Alpine)
                 .WithEntrypoint(CommonCommands.SleepInfinity)
-                .WithCopyTarArchive(memStore, targetDirectoryPath1)
+                .WithCopyTarArchive(tarBuffer, targetDirectoryPath1)
                 .Build();
 
             // When
@@ -67,7 +67,7 @@ namespace Testcontainers.Tests
             await TarFile.CreateFromDirectoryAsync(_testFile.Directory.FullName, memStore, false, TestContext.Current.CancellationToken);
             memStore.Position = 0; // must rewind underlying Stream to start position before copying
 
-            var container = new ContainerBuilder(CommonImages.Alpine)
+            await using var container = new ContainerBuilder(CommonImages.Alpine)
                 .WithEntrypoint(CommonCommands.SleepInfinity)
                 .WithCopyTarArchive(memStore, targetDirectoryPath1) // this will copy the Stream with tar archive contents in container just before the container startup
                 .Build();
@@ -133,7 +133,7 @@ namespace Testcontainers.Tests
             tarArchive.Close();
             memStore.Position = 0; // must rewind underlying Stream to start position before copying
 
-            var container = new ContainerBuilder(CommonImages.Alpine)
+            await using var container = new ContainerBuilder(CommonImages.Alpine)
                 .WithEntrypoint(CommonCommands.SleepInfinity)
                 .WithCopyTarArchive(memStore) // this will copy the Stream with tar archive contents in container just before the container startup
                 .Build();

--- a/tests/Testcontainers.Platform.Linux.Tests/FileTestBase.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/FileTestBase.cs
@@ -1,0 +1,48 @@
+﻿namespace Testcontainers.Tests
+{
+    public abstract class FileTestBase : IDisposable
+    {
+        protected readonly FileInfo _testFile = new FileInfo(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"), Path.GetRandomFileName()));
+
+        private bool _disposed;
+
+        protected FileTestBase()
+        {
+            _ = Directory.CreateDirectory(_testFile.Directory!.FullName);
+
+            using var fileStream = _testFile.Open(FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
+            fileStream.WriteByte(13);
+        }
+
+        ~FileTestBase()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void DisposeManagedResources()
+        {
+            _testFile.Directory!.Delete(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                DisposeManagedResources();
+            }
+
+            _disposed = true;
+        }
+    }
+}

--- a/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/TarOutputMemoryStreamTest.cs
@@ -1,43 +1,20 @@
 namespace Testcontainers.Tests;
 
-public abstract class TarOutputMemoryStreamTest : IDisposable
+public abstract class TarOutputMemoryStreamTest : FileTestBase
 {
     private const string TargetDirectoryPath = "/tmp";
 
     private readonly TarOutputMemoryStream _tarOutputMemoryStream = new TarOutputMemoryStream(TargetDirectoryPath, NullLogger.Instance);
 
-    private readonly FileInfo _testFile = new FileInfo(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"), Path.GetRandomFileName()));
-
-    private bool _disposed;
-
-    protected TarOutputMemoryStreamTest()
+    protected TarOutputMemoryStreamTest() : base()
     {
-        _ = Directory.CreateDirectory(_testFile.Directory!.FullName);
-
-        using var fileStream = _testFile.Open(FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
-        fileStream.WriteByte(13);
     }
 
-    public void Dispose()
+    protected override void DisposeManagedResources()
     {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
+        base.DisposeManagedResources();
 
-    protected virtual void Dispose(bool disposing)
-    {
-        if (_disposed)
-        {
-            return;
-        }
-
-        if (disposing)
-        {
-            _tarOutputMemoryStream.Dispose();
-            _testFile.Directory!.Delete(true);
-        }
-
-        _disposed = true;
+        _tarOutputMemoryStream.Dispose();
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

This PR adds a new method to `ContainerBuilder` which allows to copy a `Stream` containing tar archive into container, leveraging already available method `IDockerContainerOperations.ExtractArchiveToContainerAsync`. I changed `IDockerContainerOperations.ExtractArchiveToContainerAsync` signature to match underlying `Docker.Dotnet` API which takes a base `Stream` instead of `TarOutputmemoryStream`.

The catch is that the user must build tar stream on it's own.

At first I was thinking about adding some class/methods to allow users build tar archive stream using TC library, but then I decided not to because:

- There is a couple of options to create tar archive, which gives users more freedom to choose from.
- This is not something I think TC library should do out of the box anyway (not in our "domain").
- We currently use `SharpZipLib` library in TC internals, but it looks like stopped being maintained. Probably not a good idea to create more functionality on top of it. Not using this library further may also allow us to drop it as a dependency later.
- The `SharpZipLib` API is not that trivial to build custom functionality on top of.
- I made some tests which show how to create and manipulate tar archives using `SharpZipLib` library and built-in `System.IO` (starting from NET 7). We may add this tests as a documentation to show users some guidance.

Should close https://github.com/testcontainers/testcontainers-dotnet/issues/1180

Also may help in cases like this: https://github.com/testcontainers/testcontainers-dotnet/issues/1486

## Why is it important?

This change will allow uses to add arbitrary files and directories to container. The existing API `WithResourceMapping` currently have some limitations:

- it will not copy files larger than ~2Gb.
- some overloads inner implementation differs from other overloads, users have to carefully read each overload method documentation (some overloads assume `target` is directory path, other assume it's file path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream-based tar archive copy support: copy tar archives into containers with configurable target path and new public APIs and configuration options to declare tar-archive resource mappings.
  * Containers now process tar-archive mappings during startup and runtime copy workflows.

* **Tests**
  * Added end-to-end tests covering tar archive copies using FileStream, MemoryStream, and library-generated tars; verify files inside containers and UID handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->