### PR TITLE
feat(ServiceBus): Add method to get HTTP connection string

### DIFF
--- a/src/Testcontainers.ServiceBus/ServiceBusContainer.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusContainer.cs
@@ -29,8 +29,10 @@ public sealed class ServiceBusContainer : DockerContainer
 
     /// <summary>
     /// Gets the Service Bus HTTP connection string.
-    /// This connection string is intended for use with the ServiceBusAdministrationClient.
     /// </summary>
+    /// <remarks>
+    /// This connection string is intended for use with the ServiceBusAdministrationClient.
+    /// </remarks>
     /// <returns>The Service Bus HTTP connection string.</returns>
     public string GetHttpConnectionString()
     {

--- a/src/Testcontainers.ServiceBus/ServiceBusContainer.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusContainer.cs
@@ -26,4 +26,19 @@ public sealed class ServiceBusContainer : DockerContainer
         properties.Add("UseDevelopmentEmulator", "true");
         return string.Join(";", properties.Select(property => string.Join("=", property.Key, property.Value)));
     }
+
+    /// <summary>
+    /// Gets the Service Bus HTTP connection string.
+    /// The connection string to use, for instance, in the ServiceBusAdministrationClient.
+    /// </summary>
+    /// <returns>The Service Bus HTTP connection string.</returns>
+    public string GetHttpConnectionString()
+    {
+        var properties = new Dictionary<string, string>();
+        properties.Add("Endpoint", new UriBuilder("sb", Hostname, GetMappedPublicPort(ServiceBusBuilder.ServiceBusHttpPort)).ToString());
+        properties.Add("SharedAccessKeyName", "RootManageSharedAccessKey");
+        properties.Add("SharedAccessKey", "SAS_KEY_VALUE");
+        properties.Add("UseDevelopmentEmulator", "true");
+        return string.Join(";", properties.Select(property => string.Join("=", property.Key, property.Value)));
+    }
 }

--- a/src/Testcontainers.ServiceBus/ServiceBusContainer.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusContainer.cs
@@ -29,7 +29,7 @@ public sealed class ServiceBusContainer : DockerContainer
 
     /// <summary>
     /// Gets the Service Bus HTTP connection string.
-    /// The connection string to use, for instance, in the ServiceBusAdministrationClient.
+    /// This connection string is intended for use with the ServiceBusAdministrationClient.
     /// </summary>
     /// <returns>The Service Bus HTTP connection string.</returns>
     public string GetHttpConnectionString()

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
@@ -32,14 +32,13 @@ public abstract class ServiceBusAdministrationClientTest : IAsyncLifetime
 
 
     [UsedImplicitly]
-    public sealed class ServiceBusDefaultMsSqlConfiguration : ServiceBusAdministrationClientTest
+    public sealed class ServiceBusDefaultConfiguration : ServiceBusAdministrationClientTest
     {
-        public ServiceBusDefaultMsSqlConfiguration()
+        public ServiceBusDefaultConfiguration()
             : base(new ServiceBusBuilder(TestSession.GetImageFromDockerfile())
                 .WithAcceptLicenseAgreement(true)
                 .Build())
-        {
-        }
+        { }
     }
 
 

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
@@ -1,5 +1,3 @@
-using Azure.Messaging.ServiceBus.Administration;
-
 namespace Testcontainers.ServiceBus;
 
 public abstract class ServiceBusAdministrationClientTest : IAsyncLifetime
@@ -25,26 +23,13 @@ public abstract class ServiceBusAdministrationClientTest : IAsyncLifetime
         GC.SuppressFinalize(this);
     }
 
-    protected virtual ValueTask DisposeAsyncCore()
-    {
-        return _serviceBusContainer.DisposeAsync();
-    }
-
-    [UsedImplicitly]
-    public sealed class ServiceBusDefaultConfiguration : ServiceBusAdministrationClientTest
-    {
-        public ServiceBusDefaultConfiguration()
-            : base(new ServiceBusBuilder(TestSession.GetImageFromDockerfile())
-                .WithAcceptLicenseAgreement(true)
-                .Build())
-        { }
-    }
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task CreateQueueViaServiceBusAdministrationClient()
     {
         // Given
         const string helloServiceBus = "Hello, Service Bus!";
+
         var queueName = $"sample-queue-{Guid.NewGuid()}";
 
         // By default, the emulator uses the following configuration:
@@ -71,5 +56,21 @@ public abstract class ServiceBusAdministrationClientTest : IAsyncLifetime
 
         // Then
         Assert.Equal(helloServiceBus, receivedMessage.Body.ToString());
+    }
+
+    protected virtual ValueTask DisposeAsyncCore()
+    {
+        return _serviceBusContainer.DisposeAsync();
+    }
+
+    [UsedImplicitly]
+    public sealed class ServiceBusDefaultMsSqlConfiguration : ServiceBusAdministrationClientTest
+    {
+        public ServiceBusDefaultMsSqlConfiguration()
+            : base(new ServiceBusBuilder(TestSession.GetImageFromDockerfile())
+                .WithAcceptLicenseAgreement(true)
+                .Build())
+        {
+        }
     }
 }

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
@@ -1,6 +1,6 @@
 using Azure.Messaging.ServiceBus.Administration;
 
-namespace Testcontainers.ServiceBus.Tests;
+namespace Testcontainers.ServiceBus;
 
 public abstract class ServiceBusAdministrationClientTest : IAsyncLifetime
 {

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
@@ -30,7 +30,6 @@ public abstract class ServiceBusAdministrationClientTest : IAsyncLifetime
         return _serviceBusContainer.DisposeAsync();
     }
 
-
     [UsedImplicitly]
     public sealed class ServiceBusDefaultConfiguration : ServiceBusAdministrationClientTest
     {

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
@@ -39,8 +39,6 @@ public abstract class ServiceBusAdministrationClientTest : IAsyncLifetime
                 .Build())
         { }
     }
-
-
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task CreateQueueViaServiceBusAdministrationClient()

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
@@ -1,0 +1,79 @@
+using Azure.Messaging.ServiceBus.Administration;
+
+namespace Testcontainers.ServiceBus.Tests;
+
+public abstract class ServiceBusAdministrationClientTest : IAsyncLifetime
+{
+    private readonly ServiceBusContainer _serviceBusContainer;
+
+    private ServiceBusAdministrationClientTest(ServiceBusContainer serviceBusContainer)
+    {
+        _serviceBusContainer = serviceBusContainer;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _serviceBusContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeAsyncCore()
+            .ConfigureAwait(false);
+
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual ValueTask DisposeAsyncCore()
+    {
+        return _serviceBusContainer.DisposeAsync();
+    }
+
+
+    [UsedImplicitly]
+    public sealed class ServiceBusDefaultMsSqlConfiguration : ServiceBusAdministrationClientTest
+    {
+        public ServiceBusDefaultMsSqlConfiguration()
+            : base(new ServiceBusBuilder(TestSession.GetImageFromDockerfile())
+                .WithAcceptLicenseAgreement(true)
+                .Build())
+        {
+        }
+    }
+
+
+    [Fact]
+    [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+    public async Task CreateQueueViaServiceBusAdministrationClient()
+    {
+        // Given
+        const string helloServiceBus = "Hello, Service Bus!";
+        var queueName = $"sample-queue-{Guid.NewGuid()}";
+
+        // By default, the emulator uses the following configuration:
+        // https://learn.microsoft.com/en-us/azure/service-bus-messaging/test-locally-with-service-bus-emulator?tabs=automated-script#interact-with-the-emulator.
+
+        var message = new ServiceBusMessage(helloServiceBus);
+
+        await using var client = new ServiceBusClient(_serviceBusContainer.GetConnectionString());
+        var adminClient = new ServiceBusAdministrationClient(_serviceBusContainer.GetHttpConnectionString());
+
+        var sender = client.CreateSender(queueName);
+
+        var receiver = client.CreateReceiver(queueName);
+
+        // When
+        await adminClient.CreateQueueAsync(new CreateQueueOptions(queueName), TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        await sender.SendMessageAsync(message, TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        var receivedMessage = await receiver.ReceiveMessageAsync(cancellationToken: TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Equal(helloServiceBus, receivedMessage.Body.ToString());
+    }
+}

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusAdministrationClientTest.cs
@@ -55,6 +55,7 @@ public abstract class ServiceBusAdministrationClientTest : IAsyncLifetime
             .ConfigureAwait(true);
 
         // Then
+        Assert.NotNull(receivedMessage);
         Assert.Equal(helloServiceBus, receivedMessage.Body.ToString());
     }
 

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusContainerTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusContainerTest.cs
@@ -56,6 +56,7 @@ public abstract class ServiceBusContainerTest : IAsyncLifetime
             .ConfigureAwait(true);
 
         // Then
+        Assert.NotNull(receivedMessage);
         Assert.Equal(helloServiceBus, receivedMessage.Body.ToString());
     }
     // # --8<-- [end:UseServiceBusContainer]

--- a/tests/Testcontainers.ServiceBus.Tests/Usings.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/Usings.cs
@@ -2,6 +2,7 @@ global using System;
 global using System.Text.RegularExpressions;
 global using System.Threading.Tasks;
 global using Azure.Messaging.ServiceBus;
+global using Azure.Messaging.ServiceBus.Administration;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
 global using DotNet.Testcontainers.Networks;


### PR DESCRIPTION
## What does this PR do?

Added a new method to retrieve the HTTP connection string from Azure Service Bus.


## Why is it important?

Azure Service Bus released a new version of the emulator image with support for ServiceBusAdministrationClient when the connection is made through the HTTP endpoint. So it's useful to have a method to build it based on the internal state of the container

[Announcement](https://techcommunity.microsoft.com/blog/messagingonazureblog/introducing-administration-client-support-for-the-azure-service-bus-emulator/4486433)
[ConnectionStrings](https://learn.microsoft.com/en-us/azure/service-bus-messaging/test-locally-with-service-bus-emulator?tabs=automated-script#choosing-the-right-connection-string)


## How to test this PR

```csharp
var adminClient = new ServiceBusAdministrationClient(_serviceBusContainer.GetHttpConnectionString());
await adminClient.CreateQueueAsync(new CreateQueueOptions("<queue-name>"));
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public method that returns an HTTP-style Service Bus connection string (includes HTTP port and related fields).

* **Tests**
  * Added integration tests for Service Bus administration and runtime: create queue, send/receive message, end-to-end verification.
  * Added a global using for Service Bus administration APIs in the test project.
  * Strengthened tests with a null-check for received messages before asserting payload.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->