### PR TITLE
fix: Do not set console buffer width (ConsoleLogger)

### DIFF
--- a/src/Testcontainers/Logger.cs
+++ b/src/Testcontainers/Logger.cs
@@ -2,7 +2,6 @@ namespace DotNet.Testcontainers
 {
   using System;
   using System.Diagnostics;
-  using System.Runtime.InteropServices;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
 
@@ -22,31 +21,31 @@ namespace DotNet.Testcontainers
   ///   internal sealed class UssDiscovery : ITestDiscoverer, ITestExecutor
   ///   {
   ///     private const string DllFileExtension = &quot;.dll&quot;;
-  ///
+  ///   <br />
   ///     private const string ExeFileExtension = &quot;.exe&quot;;
-  ///
+  ///   <br />
   ///     private const string ExecutorUri = &quot;executor://testcontainers.org/v1&quot;;
-  ///
+  ///   <br />
   ///     private const string Category = &quot;managed&quot;;
-  ///
+  ///   <br />
   ///     public void DiscoverTests(IEnumerable&lt;string&gt; sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
   ///     {
   ///     }
-  ///
+  ///   <br />
   ///     public void RunTests(IEnumerable&lt;TestCase&gt; tests, IRunContext runContext, IFrameworkHandle frameworkHandle)
   ///     {
   ///       SetLogger(frameworkHandle);
   ///     }
-  ///
+  ///   <br />
   ///     public void RunTests(IEnumerable&lt;string&gt; sources, IRunContext runContext, IFrameworkHandle frameworkHandle)
   ///     {
   ///       SetLogger(frameworkHandle);
   ///     }
-  ///
+  ///   <br />
   ///     public void Cancel()
   ///     {
   ///     }
-  ///
+  ///   <br />
   ///     private static void SetLogger(IMessageLogger logger)
   ///     {
   ///       // Set the TestcontainersSettings.Logger. Use a semaphore to block the test execution until the logger is set.
@@ -67,10 +66,6 @@ namespace DotNet.Testcontainers
 
     private ConsoleLogger()
     {
-      if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Console.IsOutputRedirected && !Console.IsErrorRedirected)
-      {
-        Console.BufferWidth = short.MaxValue - 1;
-      }
     }
 
     /// <summary>


### PR DESCRIPTION
## What does this PR do?

It looks like setting the console buffer width can cause issues in some environments, and according to the docs, using this API is not recommended. I no longer remember why we added it. I ran a few simple tests and didn't encounter any obvious issues, so I think it's safe to remove it to avoid potential problems.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1620

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified console logger implementation by removing Windows-specific buffer width handling.
  * Updated internal documentation formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->