### PR TITLE
fix(EventHubs): Workaround health API timeout

### DIFF
--- a/src/Testcontainers.EventHubs/EventHubsBuilder.cs
+++ b/src/Testcontainers.EventHubs/EventHubsBuilder.cs
@@ -168,8 +168,10 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
         return base.Init()
             .WithPortBinding(EventHubsPort, true)
             .WithPortBinding(EventHubsHttpPort, true)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
-                request.ForPort(EventHubsHttpPort).ForPath("/health")));
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .AddCustomWaitStrategy(new WorkaroundGhIssue69())
+                .UntilHttpRequestIsSucceeded(request =>
+                    request.ForPort(EventHubsHttpPort).ForPath("/health")));
     }
 
     /// <inheritdoc />
@@ -188,5 +190,20 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
     protected override EventHubsBuilder Merge(EventHubsConfiguration oldValue, EventHubsConfiguration newValue)
     {
         return new EventHubsBuilder(new EventHubsConfiguration(oldValue, newValue));
+    }
+
+    /// <summary>
+    /// See GH issue: https://github.com/Azure/azure-event-hubs-emulator-installer/issues/69#issuecomment-3762895979.
+    /// </summary>
+    private sealed class WorkaroundGhIssue69 : IWaitUntil
+    {
+        /// <inheritdoc />
+        public async Task<bool> UntilAsync(IContainer container)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5))
+                .ConfigureAwait(false);
+
+            return true;
+        }
     }
 }

--- a/src/Testcontainers.EventHubs/Usings.cs
+++ b/src/Testcontainers.EventHubs/Usings.cs
@@ -5,6 +5,7 @@ global using System.Diagnostics.CodeAnalysis;
 global using System.Linq;
 global using System.Text;
 global using System.Text.Json;
+global using System.Threading.Tasks;
 global using Docker.DotNet.Models;
 global using DotNet.Testcontainers;
 global using DotNet.Testcontainers.Builders;


### PR DESCRIPTION
## What does this PR do?

Since the EventHubs image is not versioned, we unfortunately ran into an issue with the latest release. It appears that the health API call fails when the HTTP request is sent too early, causing the client to time out.

While we could catch the timeout or cancellation exception and retry once, the default HTTP timeout is 100 seconds, which would make users wait unnecessarily. It would be better for the EventHubs team to address this issue properly.

The same issue also occurs when using the CLI.

You can find more information here: https://github.com/Azure/azure-event-hubs-emulator-installer/issues/69#issuecomment-3762895979.

## Why is it important?

Unblock our CI.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Event Hubs container initialization reliability with an enhanced wait strategy that now includes a startup delay before performing health status checks. This addresses timing-related issues that could prevent containers from starting properly and ensures more stable and predictable initialization behavior across deployment and integration testing workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->