### PR TITLE
fix(ServiceBus): Workaround health API timeout

### DIFF
--- a/src/Testcontainers.EventHubs/EventHubsBuilder.cs
+++ b/src/Testcontainers.EventHubs/EventHubsBuilder.cs
@@ -169,7 +169,8 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
             .WithPortBinding(EventHubsPort, true)
             .WithPortBinding(EventHubsHttpPort, true)
             .WithWaitStrategy(Wait.ForUnixContainer()
-                .AddCustomWaitStrategy(new WorkaroundGhIssue69())
+                // https://github.com/Azure/azure-event-hubs-emulator-installer/issues/69#issuecomment-3762895979.
+                .UntilMessageIsLogged("Emulator Service is Successfully Up!")
                 .UntilHttpRequestIsSucceeded(request =>
                     request.ForPort(EventHubsHttpPort).ForPath("/health")));
     }
@@ -190,20 +191,5 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
     protected override EventHubsBuilder Merge(EventHubsConfiguration oldValue, EventHubsConfiguration newValue)
     {
         return new EventHubsBuilder(new EventHubsConfiguration(oldValue, newValue));
-    }
-
-    /// <summary>
-    /// See GH issue: https://github.com/Azure/azure-event-hubs-emulator-installer/issues/69#issuecomment-3762895979.
-    /// </summary>
-    private sealed class WorkaroundGhIssue69 : IWaitUntil
-    {
-        /// <inheritdoc />
-        public async Task<bool> UntilAsync(IContainer container)
-        {
-            await Task.Delay(TimeSpan.FromSeconds(5))
-                .ConfigureAwait(false);
-
-            return true;
-        }
     }
 }

--- a/src/Testcontainers.EventHubs/Usings.cs
+++ b/src/Testcontainers.EventHubs/Usings.cs
@@ -5,7 +5,6 @@ global using System.Diagnostics.CodeAnalysis;
 global using System.Linq;
 global using System.Text;
 global using System.Text.Json;
-global using System.Threading.Tasks;
 global using Docker.DotNet.Models;
 global using DotNet.Testcontainers;
 global using DotNet.Testcontainers.Builders;

--- a/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
@@ -164,8 +164,10 @@ public sealed class ServiceBusBuilder : ContainerBuilder<ServiceBusBuilder, Serv
             .WithPortBinding(ServiceBusPort, true)
             .WithPortBinding(ServiceBusHttpPort, true)
             .WithEnvironment("SQL_WAIT_INTERVAL", "0")
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
-                request.ForPort(ServiceBusHttpPort).ForPath("/health")));
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .AddCustomWaitStrategy(new WorkaroundGhIssue69())
+                .UntilHttpRequestIsSucceeded(request =>
+                    request.ForPort(ServiceBusHttpPort).ForPath("/health")));
     }
 
     /// <inheritdoc />
@@ -184,5 +186,20 @@ public sealed class ServiceBusBuilder : ContainerBuilder<ServiceBusBuilder, Serv
     protected override ServiceBusBuilder Merge(ServiceBusConfiguration oldValue, ServiceBusConfiguration newValue)
     {
         return new ServiceBusBuilder(new ServiceBusConfiguration(oldValue, newValue));
+    }
+
+    /// <summary>
+    /// See GH issue: https://github.com/Azure/azure-event-hubs-emulator-installer/issues/69#issuecomment-3762895979.
+    /// </summary>
+    private sealed class WorkaroundGhIssue69 : IWaitUntil
+    {
+        /// <inheritdoc />
+        public async Task<bool> UntilAsync(IContainer container)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(5))
+                .ConfigureAwait(false);
+
+            return true;
+        }
     }
 }

--- a/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
@@ -165,7 +165,8 @@ public sealed class ServiceBusBuilder : ContainerBuilder<ServiceBusBuilder, Serv
             .WithPortBinding(ServiceBusHttpPort, true)
             .WithEnvironment("SQL_WAIT_INTERVAL", "0")
             .WithWaitStrategy(Wait.ForUnixContainer()
-                .AddCustomWaitStrategy(new WorkaroundGhIssue69())
+                // https://github.com/Azure/azure-event-hubs-emulator-installer/issues/69#issuecomment-3762895979.
+                .UntilMessageIsLogged("Emulator Service is Successfully Up!")
                 .UntilHttpRequestIsSucceeded(request =>
                     request.ForPort(ServiceBusHttpPort).ForPath("/health")));
     }
@@ -186,20 +187,5 @@ public sealed class ServiceBusBuilder : ContainerBuilder<ServiceBusBuilder, Serv
     protected override ServiceBusBuilder Merge(ServiceBusConfiguration oldValue, ServiceBusConfiguration newValue)
     {
         return new ServiceBusBuilder(new ServiceBusConfiguration(oldValue, newValue));
-    }
-
-    /// <summary>
-    /// See GH issue: https://github.com/Azure/azure-event-hubs-emulator-installer/issues/69#issuecomment-3762895979.
-    /// </summary>
-    private sealed class WorkaroundGhIssue69 : IWaitUntil
-    {
-        /// <inheritdoc />
-        public async Task<bool> UntilAsync(IContainer container)
-        {
-            await Task.Delay(TimeSpan.FromSeconds(5))
-                .ConfigureAwait(false);
-
-            return true;
-        }
     }
 }

--- a/src/Testcontainers.ServiceBus/Usings.cs
+++ b/src/Testcontainers.ServiceBus/Usings.cs
@@ -3,7 +3,6 @@ global using System.Collections.Generic;
 global using System.Diagnostics.CodeAnalysis;
 global using System.IO;
 global using System.Linq;
-global using System.Threading.Tasks;
 global using Docker.DotNet.Models;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Configurations;

--- a/src/Testcontainers.ServiceBus/Usings.cs
+++ b/src/Testcontainers.ServiceBus/Usings.cs
@@ -3,6 +3,7 @@ global using System.Collections.Generic;
 global using System.Diagnostics.CodeAnalysis;
 global using System.IO;
 global using System.Linq;
+global using System.Threading.Tasks;
 global using Docker.DotNet.Models;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Configurations;


### PR DESCRIPTION
## What does this PR do?

\-

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #1624

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Service Bus emulator startup health verification by adding log-based validation.
  * Simplified Event Hubs emulator initialization by removing legacy workarounds.

* **Chores**
  * Removed unused global imports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->