### PR TITLE
feat: Add module connection string provider

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
     "ghcr.io/devcontainers/features/docker-in-docker:2": {
       "moby": true
     },
-    "ghcr.io/devcontainers/features/dotnet:2.4.1": {
+    "ghcr.io/devcontainers/features/dotnet:2.4.2": {
       "version": "10.0",
       "installUsingApt": false
     }

--- a/src/Testcontainers.ActiveMq/ActiveMqConnectionStringProvider.cs
+++ b/src/Testcontainers.ActiveMq/ActiveMqConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.ActiveMq;
+
+/// <summary>
+/// Provides the ActiveMq connection string.
+/// </summary>
+internal sealed class ActiveMqConnectionStringProvider : ContainerConnectionStringProvider<ArtemisContainer, ActiveMqConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBrokerAddress();
+    }
+}

--- a/src/Testcontainers.ActiveMq/ArtemisBuilder.cs
+++ b/src/Testcontainers.ActiveMq/ArtemisBuilder.cs
@@ -106,6 +106,7 @@ public sealed class ArtemisBuilder : ContainerBuilder<ArtemisBuilder, ArtemisCon
             .WithPortBinding(ArtemisConsolePort, true)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new ActiveMqConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("HTTP Server started"));
     }
 

--- a/src/Testcontainers.ArangoDb/ArangoDbBuilder.cs
+++ b/src/Testcontainers.ArangoDb/ArangoDbBuilder.cs
@@ -91,6 +91,7 @@ public sealed class ArangoDbBuilder : ContainerBuilder<ArangoDbBuilder, ArangoDb
         return base.Init()
             .WithPortBinding(ArangoDbPort, true)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new ArangoDbConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Have fun!"));
     }
 

--- a/src/Testcontainers.ArangoDb/ArangoDbConnectionStringProvider.cs
+++ b/src/Testcontainers.ArangoDb/ArangoDbConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.ArangoDb;
+
+/// <summary>
+/// Provides the ArangoDb connection string.
+/// </summary>
+internal sealed class ArangoDbConnectionStringProvider : ContainerConnectionStringProvider<ArangoDbContainer, ArangoDbConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetTransportAddress();
+    }
+}

--- a/src/Testcontainers.Azurite/AzuriteBuilder.cs
+++ b/src/Testcontainers.Azurite/AzuriteBuilder.cs
@@ -132,7 +132,8 @@ public sealed class AzuriteBuilder : ContainerBuilder<AzuriteBuilder, AzuriteCon
             .WithPortBinding(QueuePort, true)
             .WithPortBinding(TablePort, true)
             .WithEntrypoint("azurite")
-            .WithCommand("--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0");
+            .WithCommand("--blobHost", "0.0.0.0", "--queueHost", "0.0.0.0", "--tableHost", "0.0.0.0")
+            .WithConnectionStringProvider(new AzuriteConnectionStringProvider());
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Azurite/AzuriteConnectionStringProvider.cs
+++ b/src/Testcontainers.Azurite/AzuriteConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Azurite;
+
+/// <summary>
+/// Provides the Azurite connection string.
+/// </summary>
+internal sealed class AzuriteConnectionStringProvider : ContainerConnectionStringProvider<AzuriteContainer, AzuriteConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.BigQuery/BigQueryBuilder.cs
+++ b/src/Testcontainers.BigQuery/BigQueryBuilder.cs
@@ -88,6 +88,7 @@ public sealed class BigQueryBuilder : ContainerBuilder<BigQueryBuilder, BigQuery
         return base.Init()
             .WithPortBinding(BigQueryPort, true)
             .WithProject(DefaultProjectId)
+            .WithConnectionStringProvider(new BigQueryConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("(?s).*listening.*$"));
     }
 

--- a/src/Testcontainers.BigQuery/BigQueryConnectionStringProvider.cs
+++ b/src/Testcontainers.BigQuery/BigQueryConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.BigQuery;
+
+/// <summary>
+/// Provides the BigQuery connection string.
+/// </summary>
+internal sealed class BigQueryConnectionStringProvider : ContainerConnectionStringProvider<BigQueryContainer, BigQueryConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetEmulatorEndpoint();
+    }
+}

--- a/src/Testcontainers.Bigtable/BigtableBuilder.cs
+++ b/src/Testcontainers.Bigtable/BigtableBuilder.cs
@@ -77,6 +77,7 @@ public sealed class BigtableBuilder : ContainerBuilder<BigtableBuilder, Bigtable
             .WithPortBinding(BigtablePort, true)
             .WithEntrypoint("gcloud")
             .WithCommand("beta", "emulators", "bigtable", "start", "--host-port", "0.0.0.0:" + BigtablePort)
+            .WithConnectionStringProvider(new BigtableConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("(?s).*running.*$"));
     }
 

--- a/src/Testcontainers.Bigtable/BigtableConnectionStringProvider.cs
+++ b/src/Testcontainers.Bigtable/BigtableConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Bigtable;
+
+/// <summary>
+/// Provides the Bigtable connection string.
+/// </summary>
+internal sealed class BigtableConnectionStringProvider : ContainerConnectionStringProvider<BigtableContainer, BigtableConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetEmulatorEndpoint();
+    }
+}

--- a/src/Testcontainers.Cassandra/CassandraBuilder.cs
+++ b/src/Testcontainers.Cassandra/CassandraBuilder.cs
@@ -83,6 +83,7 @@ public sealed class CassandraBuilder : ContainerBuilder<CassandraBuilder, Cassan
             .WithEnvironment("CASSANDRA_SNITCH", "GossipingPropertyFileSnitch")
             .WithEnvironment("CASSANDRA_ENDPOINT_SNITCH", "GossipingPropertyFileSnitch")
             .WithEnvironment("CASSANDRA_DC", DefaultDatacenterName)
+            .WithConnectionStringProvider(new CassandraConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Startup complete"));
     }
 

--- a/src/Testcontainers.Cassandra/CassandraConnectionStringProvider.cs
+++ b/src/Testcontainers.Cassandra/CassandraConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Cassandra;
+
+/// <summary>
+/// Provides the Cassandra connection string.
+/// </summary>
+internal sealed class CassandraConnectionStringProvider : ContainerConnectionStringProvider<CassandraContainer, CassandraConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.ClickHouse/ClickHouseBuilder.cs
+++ b/src/Testcontainers.ClickHouse/ClickHouseBuilder.cs
@@ -120,6 +120,7 @@ public sealed class ClickHouseBuilder : ContainerBuilder<ClickHouseBuilder, Clic
             .WithDatabase(DefaultDatabase)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new ClickHouseConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPort(HttpPort).ForResponseMessageMatching(IsNodeReadyAsync)));
     }

--- a/src/Testcontainers.ClickHouse/ClickHouseConnectionStringProvider.cs
+++ b/src/Testcontainers.ClickHouse/ClickHouseConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.ClickHouse;
+
+/// <summary>
+/// Provides the ClickHouse connection string.
+/// </summary>
+internal sealed class ClickHouseConnectionStringProvider : ContainerConnectionStringProvider<ClickHouseContainer, ClickHouseConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.CockroachDb/CockroachDbBuilder.cs
+++ b/src/Testcontainers.CockroachDb/CockroachDbBuilder.cs
@@ -122,6 +122,7 @@ public sealed class CockroachDbBuilder : ContainerBuilder<CockroachDbBuilder, Co
             .WithPassword(DefaultPassword)
             .WithCommand("start-single-node")
             .WithCommand("--insecure")
+            .WithConnectionStringProvider(new CockroachDbConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPort(CockroachDbRestPort).ForPath("/health")));
     }

--- a/src/Testcontainers.CockroachDb/CockroachDbConnectionStringProvider.cs
+++ b/src/Testcontainers.CockroachDb/CockroachDbConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.CockroachDb;
+
+/// <summary>
+/// Provides the CockroachDb connection string.
+/// </summary>
+internal sealed class CockroachDbConnectionStringProvider : ContainerConnectionStringProvider<CockroachDbContainer, CockroachDbConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Consul/ConsulBuilder.cs
+++ b/src/Testcontainers.Consul/ConsulBuilder.cs
@@ -80,6 +80,7 @@ public sealed class ConsulBuilder : ContainerBuilder<ConsulBuilder, ConsulContai
             .WithPortBinding(ConsulGrpcPort, true)
             .WithCommand("agent", "-dev", "-client", "0.0.0.0")
             .WithCreateParameterModifier(cmd => cmd.HostConfig.CapAdd = new[] { "IPC_LOCK" })
+            .WithConnectionStringProvider(new ConsulConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPath("/v1/status/leader").ForPort(ConsulHttpPort)));
     }

--- a/src/Testcontainers.Consul/ConsulConnectionStringProvider.cs
+++ b/src/Testcontainers.Consul/ConsulConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Consul;
+
+/// <summary>
+/// Provides the Consul connection string.
+/// </summary>
+internal sealed class ConsulConnectionStringProvider : ContainerConnectionStringProvider<ConsulContainer, ConsulConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBaseAddress();
+    }
+}

--- a/src/Testcontainers.CosmosDb/CosmosDbBuilder.cs
+++ b/src/Testcontainers.CosmosDb/CosmosDbBuilder.cs
@@ -77,6 +77,7 @@ public sealed class CosmosDbBuilder : ContainerBuilder<CosmosDbBuilder, CosmosDb
     {
         return base.Init()
             .WithPortBinding(CosmosDbPort, true)
+            .WithConnectionStringProvider(new CosmosDbConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil()));
     }
 

--- a/src/Testcontainers.CosmosDb/CosmosDbConnectionStringProvider.cs
+++ b/src/Testcontainers.CosmosDb/CosmosDbConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.CosmosDb;
+
+/// <summary>
+/// Provides the CosmosDb connection string.
+/// </summary>
+internal sealed class CosmosDbConnectionStringProvider : ContainerConnectionStringProvider<CosmosDbContainer, CosmosDbConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.CouchDb/CouchDbBuilder.cs
+++ b/src/Testcontainers.CouchDb/CouchDbBuilder.cs
@@ -103,6 +103,7 @@ public sealed class CouchDbBuilder : ContainerBuilder<CouchDbBuilder, CouchDbCon
             .WithPortBinding(CouchDbPort, true)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new CouchDbConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPath("/").ForPort(CouchDbPort)));
     }

--- a/src/Testcontainers.CouchDb/CouchDbConnectionStringProvider.cs
+++ b/src/Testcontainers.CouchDb/CouchDbConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.CouchDb;
+
+/// <summary>
+/// Provides the CouchDb connection string.
+/// </summary>
+internal sealed class CouchDbConnectionStringProvider : ContainerConnectionStringProvider<CouchDbContainer, CouchDbConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Couchbase/CouchbaseBuilder.cs
+++ b/src/Testcontainers.Couchbase/CouchbaseBuilder.cs
@@ -175,6 +175,7 @@ public sealed class CouchbaseBuilder : ContainerBuilder<CouchbaseBuilder, Couchb
             .WithPortBinding(KvPort, true)
             .WithPortBinding(KvSslPort, true)
             .WithBucket(CouchbaseBucket.Default)
+            .WithConnectionStringProvider(new CouchbaseConnectionStringProvider())
             .WithStartupCallback(ConfigureCouchbaseAsync);
     }
 

--- a/src/Testcontainers.Couchbase/CouchbaseConnectionStringProvider.cs
+++ b/src/Testcontainers.Couchbase/CouchbaseConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Couchbase;
+
+/// <summary>
+/// Provides the Couchbase connection string.
+/// </summary>
+internal sealed class CouchbaseConnectionStringProvider : ContainerConnectionStringProvider<CouchbaseContainer, CouchbaseConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Db2/Db2Builder.cs
+++ b/src/Testcontainers.Db2/Db2Builder.cs
@@ -139,6 +139,7 @@ public sealed class Db2Builder : ContainerBuilder<Db2Builder, Db2Container, Db2C
         .WithUsername(DefaultUsername)
         .WithPassword(DefaultPassword)
         .WithPrivileged(true)
+        .WithConnectionStringProvider(new Db2ConnectionStringProvider())
         .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Setup has completed."));
 
     /// <inheritdoc />

--- a/src/Testcontainers.Db2/Db2ConnectionStringProvider.cs
+++ b/src/Testcontainers.Db2/Db2ConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Db2;
+
+/// <summary>
+/// Provides the Db2 connection string.
+/// </summary>
+internal sealed class Db2ConnectionStringProvider : ContainerConnectionStringProvider<Db2Container, Db2Configuration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.DynamoDb/DynamoDbBuilder.cs
+++ b/src/Testcontainers.DynamoDb/DynamoDbBuilder.cs
@@ -75,6 +75,7 @@ public sealed class DynamoDbBuilder : ContainerBuilder<DynamoDbBuilder, DynamoDb
     {
         return base.Init()
             .WithPortBinding(DynamoDbPort, true)
+            .WithConnectionStringProvider(new DynamoDbConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPath("/").ForPort(DynamoDbPort).ForStatusCode(HttpStatusCode.BadRequest)));
     }

--- a/src/Testcontainers.DynamoDb/DynamoDbConnectionStringProvider.cs
+++ b/src/Testcontainers.DynamoDb/DynamoDbConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.DynamoDb;
+
+/// <summary>
+/// Provides the DynamoDb connection string.
+/// </summary>
+internal sealed class DynamoDbConnectionStringProvider : ContainerConnectionStringProvider<DynamoDbContainer, DynamoDbConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Elasticsearch/ElasticsearchBuilder.cs
+++ b/src/Testcontainers.Elasticsearch/ElasticsearchBuilder.cs
@@ -107,7 +107,8 @@ public sealed class ElasticsearchBuilder : ContainerBuilder<ElasticsearchBuilder
             .WithPassword(DefaultPassword)
             .WithEnvironment("discovery.type", "single-node")
             .WithEnvironment("ingest.geoip.downloader.enabled", "false")
-            .WithResourceMapping(DefaultMemoryVmOption, ElasticsearchDefaultMemoryVmOptionFilePath);
+            .WithResourceMapping(DefaultMemoryVmOption, ElasticsearchDefaultMemoryVmOptionFilePath)
+            .WithConnectionStringProvider(new ElasticsearchConnectionStringProvider());
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Elasticsearch/ElasticsearchConnectionStringProvider.cs
+++ b/src/Testcontainers.Elasticsearch/ElasticsearchConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Elasticsearch;
+
+/// <summary>
+/// Provides the Elasticsearch connection string.
+/// </summary>
+internal sealed class ElasticsearchConnectionStringProvider : ContainerConnectionStringProvider<ElasticsearchContainer, ElasticsearchConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.EventHubs/EventHubsBuilder.cs
+++ b/src/Testcontainers.EventHubs/EventHubsBuilder.cs
@@ -168,6 +168,7 @@ public sealed class EventHubsBuilder : ContainerBuilder<EventHubsBuilder, EventH
         return base.Init()
             .WithPortBinding(EventHubsPort, true)
             .WithPortBinding(EventHubsHttpPort, true)
+            .WithConnectionStringProvider(new EventHubsConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer()
                 // https://github.com/Azure/azure-event-hubs-emulator-installer/issues/69#issuecomment-3762895979.
                 .UntilMessageIsLogged("Emulator Service is Successfully Up!")

--- a/src/Testcontainers.EventHubs/EventHubsConnectionStringProvider.cs
+++ b/src/Testcontainers.EventHubs/EventHubsConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.EventHubs;
+
+/// <summary>
+/// Provides the Event Hubs connection string.
+/// </summary>
+internal sealed class EventHubsConnectionStringProvider : ContainerConnectionStringProvider<EventHubsContainer, EventHubsConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.FakeGcsServer/FakeGcsServerBuilder.cs
+++ b/src/Testcontainers.FakeGcsServer/FakeGcsServerBuilder.cs
@@ -79,6 +79,7 @@ public sealed class FakeGcsServerBuilder : ContainerBuilder<FakeGcsServerBuilder
             .WithPortBinding(FakeGcsServerPort, true)
             .WithEntrypoint("/bin/sh", "-c")
             .WithCommand("while [ ! -f " + StartupScriptFilePath + " ]; do sleep 0.1; done; " + StartupScriptFilePath)
+            .WithConnectionStringProvider(new FakeGcsServerConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("server started"))
             .WithStartupCallback((container, ct) =>
             {

--- a/src/Testcontainers.FakeGcsServer/FakeGcsServerConnectionStringProvider.cs
+++ b/src/Testcontainers.FakeGcsServer/FakeGcsServerConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.FakeGcsServer;
+
+/// <summary>
+/// Provides the FakeGcsServer connection string.
+/// </summary>
+internal sealed class FakeGcsServerConnectionStringProvider : ContainerConnectionStringProvider<FakeGcsServerContainer, FakeGcsServerConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.FirebirdSql/FirebirdSqlBuilder.cs
+++ b/src/Testcontainers.FirebirdSql/FirebirdSqlBuilder.cs
@@ -121,6 +121,7 @@ public sealed class FirebirdSqlBuilder : ContainerBuilder<FirebirdSqlBuilder, Fi
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
             .WithResourceMapping(Encoding.Default.GetBytes(TestQueryString), "/home/firebird_check.sql")
+            .WithConnectionStringProvider(new FirebirdSqlConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilContainerIsHealthy());
     }
 

--- a/src/Testcontainers.FirebirdSql/FirebirdSqlConnectionStringProvider.cs
+++ b/src/Testcontainers.FirebirdSql/FirebirdSqlConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.FirebirdSql;
+
+/// <summary>
+/// Provides the FirebirdSql connection string.
+/// </summary>
+internal sealed class FirebirdSqlConnectionStringProvider : ContainerConnectionStringProvider<FirebirdSqlContainer, FirebirdSqlConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Firestore/FirestoreBuilder.cs
+++ b/src/Testcontainers.Firestore/FirestoreBuilder.cs
@@ -77,6 +77,7 @@ public sealed class FirestoreBuilder : ContainerBuilder<FirestoreBuilder, Firest
             .WithPortBinding(FirestorePort, true)
             .WithEntrypoint("gcloud")
             .WithCommand("beta", "emulators", "firestore", "start", "--host-port", "0.0.0.0:" + FirestorePort)
+            .WithConnectionStringProvider(new FirestoreConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("(?s).*running.*$"));
     }
 

--- a/src/Testcontainers.Firestore/FirestoreConnectionStringProvider.cs
+++ b/src/Testcontainers.Firestore/FirestoreConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Firestore;
+
+/// <summary>
+/// Provides the Firestore connection string.
+/// </summary>
+internal sealed class FirestoreConnectionStringProvider : ContainerConnectionStringProvider<FirestoreContainer, FirestoreConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetEmulatorEndpoint();
+    }
+}

--- a/src/Testcontainers.Grafana/GrafanaBuilder.cs
+++ b/src/Testcontainers.Grafana/GrafanaBuilder.cs
@@ -113,6 +113,7 @@ public sealed class GrafanaBuilder : ContainerBuilder<GrafanaBuilder, GrafanaCon
             .WithPortBinding(GrafanaPort, true)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new GrafanaConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPath("/api/health").ForPort(GrafanaPort)));
     }

--- a/src/Testcontainers.Grafana/GrafanaConnectionStringProvider.cs
+++ b/src/Testcontainers.Grafana/GrafanaConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Grafana;
+
+/// <summary>
+/// Provides the Grafana connection string.
+/// </summary>
+internal sealed class GrafanaConnectionStringProvider : ContainerConnectionStringProvider<GrafanaContainer, GrafanaConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBaseAddress();
+    }
+}

--- a/src/Testcontainers.InfluxDb/InfluxDbBuilder.cs
+++ b/src/Testcontainers.InfluxDb/InfluxDbBuilder.cs
@@ -154,6 +154,7 @@ public sealed class InfluxDbBuilder : ContainerBuilder<InfluxDbBuilder, InfluxDb
             .WithPassword(DefaultPassword)
             .WithOrganization(DefaultOrganization)
             .WithBucket(DefaultBucket)
+            .WithConnectionStringProvider(new InfluxDbConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPort(InfluxDbPort).ForPath("/ping").ForStatusCode(HttpStatusCode.NoContent)));
     }

--- a/src/Testcontainers.InfluxDb/InfluxDbConnectionStringProvider.cs
+++ b/src/Testcontainers.InfluxDb/InfluxDbConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.InfluxDb;
+
+/// <summary>
+/// Provides the InfluxDb connection string.
+/// </summary>
+internal sealed class InfluxDbConnectionStringProvider : ContainerConnectionStringProvider<InfluxDbContainer, InfluxDbConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetAddress();
+    }
+}

--- a/src/Testcontainers.Kafka/KafkaBuilder.cs
+++ b/src/Testcontainers.Kafka/KafkaBuilder.cs
@@ -264,7 +264,8 @@ public sealed class KafkaBuilder : ContainerBuilder<KafkaBuilder, KafkaContainer
             .WithEnvironment("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
             .WithEnvironment("CLUSTER_ID", ClusterId)
             .WithEntrypoint("/bin/sh", "-c")
-            .WithCommand($"while [ ! -f {StartupScriptFilePath} ]; do sleep 0.1; done; {StartupScriptFilePath}");
+            .WithCommand($"while [ ! -f {StartupScriptFilePath} ]; do sleep 0.1; done; {StartupScriptFilePath}")
+            .WithConnectionStringProvider(new KafkaConnectionStringProvider());
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Kafka/KafkaConnectionStringProvider.cs
+++ b/src/Testcontainers.Kafka/KafkaConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Kafka;
+
+/// <summary>
+/// Provides the Kafka connection string.
+/// </summary>
+internal sealed class KafkaConnectionStringProvider : ContainerConnectionStringProvider<KafkaContainer, KafkaConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBootstrapAddress();
+    }
+}

--- a/src/Testcontainers.Kafka/KafkaContainer.cs
+++ b/src/Testcontainers.Kafka/KafkaContainer.cs
@@ -17,15 +17,6 @@ public sealed class KafkaContainer : DockerContainer
     }
 
     /// <summary>
-    /// Gets the broker address.
-    /// </summary>
-    /// <returns>The broker address.</returns>
-    public string GetBootstrapAddress()
-    {
-        return new UriBuilder("PLAINTEXT", Hostname, GetMappedPublicPort(KafkaBuilder.KafkaPort)).ToString();
-    }
-
-    /// <summary>
     /// Gets a list of advertised listeners.
     /// </summary>
     public IEnumerable<string> AdvertisedListeners
@@ -34,5 +25,14 @@ public sealed class KafkaContainer : DockerContainer
         {
             return _configuration.AdvertisedListeners;
         }
+    }
+
+    /// <summary>
+    /// Gets the broker address.
+    /// </summary>
+    /// <returns>The broker address.</returns>
+    public string GetBootstrapAddress()
+    {
+        return new UriBuilder("PLAINTEXT", Hostname, GetMappedPublicPort(KafkaBuilder.KafkaPort)).ToString();
     }
 }

--- a/src/Testcontainers.Keycloak/KeycloakBuilder.cs
+++ b/src/Testcontainers.Keycloak/KeycloakBuilder.cs
@@ -139,7 +139,8 @@ public sealed class KeycloakBuilder : ContainerBuilder<KeycloakBuilder, Keycloak
             .WithPortBinding(KeycloakHealthPort, true)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
-            .WithEnvironment("KC_HEALTH_ENABLED", "true");
+            .WithEnvironment("KC_HEALTH_ENABLED", "true")
+            .WithConnectionStringProvider(new KeycloakConnectionStringProvider());
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Keycloak/KeycloakConnectionStringProvider.cs
+++ b/src/Testcontainers.Keycloak/KeycloakConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Keycloak;
+
+/// <summary>
+/// Provides the Keycloak connection string.
+/// </summary>
+internal sealed class KeycloakConnectionStringProvider : ContainerConnectionStringProvider<KeycloakContainer, KeycloakConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBaseAddress();
+    }
+}

--- a/src/Testcontainers.KurrentDb/KurrentDbBuilder.cs
+++ b/src/Testcontainers.KurrentDb/KurrentDbBuilder.cs
@@ -78,6 +78,7 @@ public sealed class KurrentDbBuilder : ContainerBuilder<KurrentDbBuilder, Kurren
             .WithEnvironment("KURRENTDB_RUN_PROJECTIONS", "All")
             .WithEnvironment("KURRENTDB_START_STANDARD_PROJECTIONS", "true")
             .WithEnvironment("KURRENTDB_INSECURE", "true")
+            .WithConnectionStringProvider(new KurrentDbConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilContainerIsHealthy());
     }
 

--- a/src/Testcontainers.KurrentDb/KurrentDbConnectionStringProvider.cs
+++ b/src/Testcontainers.KurrentDb/KurrentDbConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.KurrentDb;
+
+/// <summary>
+/// Provides the KurrentDb connection string.
+/// </summary>
+internal sealed class KurrentDbConnectionStringProvider : ContainerConnectionStringProvider<KurrentDbContainer, KurrentDbConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Kusto/KustoBuilder.cs
+++ b/src/Testcontainers.Kusto/KustoBuilder.cs
@@ -80,6 +80,7 @@ public sealed class KustoBuilder : ContainerBuilder<KustoBuilder, KustoContainer
         return base.Init()
             .WithPortBinding(KustoPort, true)
             .WithEnvironment("ACCEPT_EULA", "Y")
+            .WithConnectionStringProvider(new KustoConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request
                 .WithMethod(HttpMethod.Post)
                 .ForPort(KustoPort)

--- a/src/Testcontainers.Kusto/KustoConnectionStringProvider.cs
+++ b/src/Testcontainers.Kusto/KustoConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Kusto;
+
+/// <summary>
+/// Provides the Kusto connection string.
+/// </summary>
+internal sealed class KustoConnectionStringProvider : ContainerConnectionStringProvider<KustoContainer, KustoConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.LocalStack/LocalStackBuilder.cs
+++ b/src/Testcontainers.LocalStack/LocalStackBuilder.cs
@@ -75,6 +75,7 @@ public sealed class LocalStackBuilder : ContainerBuilder<LocalStackBuilder, Loca
     {
         return base.Init()
             .WithPortBinding(LocalStackPort, true)
+            .WithConnectionStringProvider(new LocalStackConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPath("/_localstack/health").ForPort(LocalStackPort)));
     }

--- a/src/Testcontainers.LocalStack/LocalStackConnectionStringProvider.cs
+++ b/src/Testcontainers.LocalStack/LocalStackConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.LocalStack;
+
+/// <summary>
+/// Provides the LocalStack connection string.
+/// </summary>
+internal sealed class LocalStackConnectionStringProvider : ContainerConnectionStringProvider<LocalStackContainer, LocalStackConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.LowkeyVault/LowkeyVaultBuilder.cs
+++ b/src/Testcontainers.LowkeyVault/LowkeyVaultBuilder.cs
@@ -95,6 +95,7 @@ public sealed class LowkeyVaultBuilder : ContainerBuilder<LowkeyVaultBuilder, Lo
             .WithPortBinding(LowkeyVaultPort, true)
             .WithPortBinding(LowkeyVaultTokenPort, true)
             .WithArguments(new[] { "--LOWKEY_VAULT_RELAXED_PORTS=true" })
+            .WithConnectionStringProvider(new LowkeyVaultConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("(?s).*Started LowkeyVaultApp.*$"));
     }
 

--- a/src/Testcontainers.LowkeyVault/LowkeyVaultConnectionStringProvider.cs
+++ b/src/Testcontainers.LowkeyVault/LowkeyVaultConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.LowkeyVault;
+
+/// <summary>
+/// Provides the Lowkey Vault connection string.
+/// </summary>
+internal sealed class LowkeyVaultConnectionStringProvider : ContainerConnectionStringProvider<LowkeyVaultContainer, LowkeyVaultConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBaseAddress();
+    }
+}

--- a/src/Testcontainers.MariaDb/MariaDbBuilder.cs
+++ b/src/Testcontainers.MariaDb/MariaDbBuilder.cs
@@ -122,6 +122,7 @@ public sealed class MariaDbBuilder : ContainerBuilder<MariaDbBuilder, MariaDbCon
             .WithDatabase(DefaultDatabase)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new MariaDbConnectionStringProvider())
             .WithStartupCallback((container, ct) => container.WriteConfigurationFileAsync(ct));
     }
 

--- a/src/Testcontainers.MariaDb/MariaDbConnectionStringProvider.cs
+++ b/src/Testcontainers.MariaDb/MariaDbConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.MariaDb;
+
+/// <summary>
+/// Provides the MariaDb connection string.
+/// </summary>
+internal sealed class MariaDbConnectionStringProvider : ContainerConnectionStringProvider<MariaDbContainer, MariaDbConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Milvus/MilvusBuilder.cs
+++ b/src/Testcontainers.Milvus/MilvusBuilder.cs
@@ -103,6 +103,7 @@ public sealed class MilvusBuilder : ContainerBuilder<MilvusBuilder, MilvusContai
             .WithEnvironment("ETCD_CONFIG_PATH", MilvusEtcdConfigFilePath)
             .WithEnvironment("ETCD_DATA_DIR", "/var/lib/milvus/etcd")
             .WithResourceMapping(EtcdConfig, MilvusEtcdConfigFilePath)
+            .WithConnectionStringProvider(new MilvusConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilContainerIsHealthy())
             .WithCreateParameterModifier(parameterModifier =>
                 parameterModifier.Healthcheck = Healthcheck.Instance);

--- a/src/Testcontainers.Milvus/MilvusConnectionStringProvider.cs
+++ b/src/Testcontainers.Milvus/MilvusConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Milvus;
+
+/// <summary>
+/// Provides the Milvus connection string.
+/// </summary>
+internal sealed class MilvusConnectionStringProvider : ContainerConnectionStringProvider<MilvusContainer, MilvusConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetEndpoint().ToString();
+    }
+}

--- a/src/Testcontainers.Minio/MinioBuilder.cs
+++ b/src/Testcontainers.Minio/MinioBuilder.cs
@@ -104,6 +104,7 @@ public sealed class MinioBuilder : ContainerBuilder<MinioBuilder, MinioContainer
             .WithCommand("server", "/data")
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new MinioConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPath("/minio/health/ready").ForPort(MinioPort)));
     }

--- a/src/Testcontainers.Minio/MinioConnectionStringProvider.cs
+++ b/src/Testcontainers.Minio/MinioConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Minio;
+
+/// <summary>
+/// Provides the Minio connection string.
+/// </summary>
+internal sealed class MinioConnectionStringProvider : ContainerConnectionStringProvider<MinioContainer, MinioConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -145,6 +145,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
             .WithPortBinding(MongoDbPort, true)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new MongoDbConnectionStringProvider())
             .WithStartupCallback(InitiateReplicaSetAsync);
     }
 

--- a/src/Testcontainers.MongoDb/MongoDbConnectionStringProvider.cs
+++ b/src/Testcontainers.MongoDb/MongoDbConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.MongoDb;
+
+/// <summary>
+/// Provides the MongoDb connection string.
+/// </summary>
+internal sealed class MongoDbConnectionStringProvider : ContainerConnectionStringProvider<MongoDbContainer, MongoDbConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Mosquitto/MosquittoBuilder.cs
+++ b/src/Testcontainers.Mosquitto/MosquittoBuilder.cs
@@ -150,6 +150,7 @@ public sealed class MosquittoBuilder : ContainerBuilder<MosquittoBuilder, Mosqui
         return base.Init()
             .WithPortBinding(MqttPort, true)
             .WithPortBinding(MqttWsPort, true)
+            .WithConnectionStringProvider(new MosquittoConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("mosquitto.*running"));
     }
 

--- a/src/Testcontainers.Mosquitto/MosquittoConnectionStringProvider.cs
+++ b/src/Testcontainers.Mosquitto/MosquittoConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Mosquitto;
+
+/// <summary>
+/// Provides the Mosquitto connection string.
+/// </summary>
+internal sealed class MosquittoConnectionStringProvider : ContainerConnectionStringProvider<MosquittoContainer, MosquittoConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -97,6 +97,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             .WithDatabase(DefaultDatabase)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new MsSqlConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil()));
     }
 

--- a/src/Testcontainers.MsSql/MsSqlConnectionStringProvider.cs
+++ b/src/Testcontainers.MsSql/MsSqlConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.MsSql;
+
+/// <summary>
+/// Provides the MsSql connection string.
+/// </summary>
+internal sealed class MsSqlConnectionStringProvider : ContainerConnectionStringProvider<MsSqlContainer, MsSqlConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.MySql/MySqlBuilder.cs
+++ b/src/Testcontainers.MySql/MySqlBuilder.cs
@@ -122,6 +122,7 @@ public sealed class MySqlBuilder : ContainerBuilder<MySqlBuilder, MySqlContainer
             .WithDatabase(DefaultDatabase)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new MySqlConnectionStringProvider())
             .WithStartupCallback((container, ct) => Task.WhenAll(container.CreateMySqlFilesDirectoryAsync(ct), container.WriteConfigurationFileAsync(ct)));
     }
 

--- a/src/Testcontainers.MySql/MySqlConnectionStringProvider.cs
+++ b/src/Testcontainers.MySql/MySqlConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.MySql;
+
+/// <summary>
+/// Provides the MySql connection string.
+/// </summary>
+internal sealed class MySqlConnectionStringProvider : ContainerConnectionStringProvider<MySqlContainer, MySqlConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Nats/NatsBuilder.cs
+++ b/src/Testcontainers.Nats/NatsBuilder.cs
@@ -109,6 +109,7 @@ public sealed class NatsBuilder : ContainerBuilder<NatsBuilder, NatsContainer, N
             .WithCommand("--jetstream")
             .WithCommand("--debug")
             .WithCommand("--trace")
+            .WithConnectionStringProvider(new NatsConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Server is ready"));
     }
 

--- a/src/Testcontainers.Nats/NatsConnectionStringProvider.cs
+++ b/src/Testcontainers.Nats/NatsConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Nats;
+
+/// <summary>
+/// Provides the NATS connection string.
+/// </summary>
+internal sealed class NatsConnectionStringProvider : ContainerConnectionStringProvider<NatsContainer, NatsConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Neo4j/Neo4jBuilder.cs
+++ b/src/Testcontainers.Neo4j/Neo4jBuilder.cs
@@ -159,6 +159,7 @@ public sealed class Neo4jBuilder : ContainerBuilder<Neo4jBuilder, Neo4jContainer
             .WithPortBinding(Neo4jHttpPort, true)
             .WithPortBinding(Neo4jBoltPort, true)
             .WithEnvironment("NEO4J_AUTH", "none")
+            .WithConnectionStringProvider(new Neo4jConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPath("/").ForPort(Neo4jHttpPort)));
     }

--- a/src/Testcontainers.Neo4j/Neo4jConnectionStringProvider.cs
+++ b/src/Testcontainers.Neo4j/Neo4jConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Neo4j;
+
+/// <summary>
+/// Provides the Neo4j connection string.
+/// </summary>
+internal sealed class Neo4jConnectionStringProvider : ContainerConnectionStringProvider<Neo4jContainer, Neo4jConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Ollama/OllamaBuilder.cs
+++ b/src/Testcontainers.Ollama/OllamaBuilder.cs
@@ -75,6 +75,7 @@ public sealed class OllamaBuilder : ContainerBuilder<OllamaBuilder, OllamaContai
     {
         return base.Init()
             .WithPortBinding(OllamaPort, true)
+            .WithConnectionStringProvider(new OllamaConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPath("/api/version").ForPort(OllamaPort)));
     }

--- a/src/Testcontainers.Ollama/OllamaConnectionStringProvider.cs
+++ b/src/Testcontainers.Ollama/OllamaConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Ollama;
+
+/// <summary>
+/// Provides the Ollama connection string.
+/// </summary>
+internal sealed class OllamaConnectionStringProvider : ContainerConnectionStringProvider<OllamaContainer, OllamaConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBaseAddress();
+    }
+}

--- a/src/Testcontainers.OpenSearch/OpenSearchBuilder.cs
+++ b/src/Testcontainers.OpenSearch/OpenSearchBuilder.cs
@@ -165,7 +165,8 @@ public sealed class OpenSearchBuilder : ContainerBuilder<OpenSearchBuilder, Open
             .WithEnvironment("discovery.type", "single-node")
             .WithSecurityEnabled()
             .WithUsername(DefaultUsername)
-            .WithPassword(DefaultPassword);
+            .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new OpenSearchConnectionStringProvider());
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.OpenSearch/OpenSearchConnectionStringProvider.cs
+++ b/src/Testcontainers.OpenSearch/OpenSearchConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.OpenSearch;
+
+/// <summary>
+/// Provides the OpenSearch connection string.
+/// </summary>
+internal sealed class OpenSearchConnectionStringProvider : ContainerConnectionStringProvider<OpenSearchContainer, OpenSearchConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Oracle/OracleBuilder.cs
+++ b/src/Testcontainers.Oracle/OracleBuilder.cs
@@ -132,6 +132,7 @@ public sealed class OracleBuilder : ContainerBuilder<OracleBuilder, OracleContai
             .WithPortBinding(OraclePort, true)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new OracleConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("DATABASE IS READY TO USE!"));
     }
 

--- a/src/Testcontainers.Oracle/OracleConnectionStringProvider.cs
+++ b/src/Testcontainers.Oracle/OracleConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Oracle;
+
+/// <summary>
+/// Provides the Oracle connection string.
+/// </summary>
+internal sealed class OracleConnectionStringProvider : ContainerConnectionStringProvider<OracleContainer, OracleConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Papercut/PapercutBuilder.cs
+++ b/src/Testcontainers.Papercut/PapercutBuilder.cs
@@ -78,6 +78,7 @@ public sealed class PapercutBuilder : ContainerBuilder<PapercutBuilder, Papercut
         return base.Init()
             .WithPortBinding(SmtpPort, true)
             .WithPortBinding(HttpPort, true)
+            .WithConnectionStringProvider(new PapercutConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPath("/health").ForPort(HttpPort).ForResponseMessageMatching(IsInstanceHealthyAsync)));
     }

--- a/src/Testcontainers.Papercut/PapercutConnectionStringProvider.cs
+++ b/src/Testcontainers.Papercut/PapercutConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Papercut;
+
+/// <summary>
+/// Provides the Papercut connection string.
+/// </summary>
+internal sealed class PapercutConnectionStringProvider : ContainerConnectionStringProvider<PapercutContainer, PapercutConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBaseAddress();
+    }
+}

--- a/src/Testcontainers.Playwright/PlaywrightBuilder.cs
+++ b/src/Testcontainers.Playwright/PlaywrightBuilder.cs
@@ -82,7 +82,8 @@ public sealed class PlaywrightBuilder : ContainerBuilder<PlaywrightBuilder, Play
             .WithEntrypoint("/bin/sh", "-c")
             // Extract the Playwright version from the container at startup.
             .WithCommand("npx -y playwright@$(sed --quiet 's/.*\\\"driverVersion\\\": *\"\\([^\"]*\\)\".*/\\1/p' ms-playwright/.docker-info) run-server --port " + PlaywrightPort)
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Listening on ws://localhost:8080/"));
+                .WithConnectionStringProvider(new PlaywrightConnectionStringProvider())
+                .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Listening on ws://localhost:8080/"));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Playwright/PlaywrightConnectionStringProvider.cs
+++ b/src/Testcontainers.Playwright/PlaywrightConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Playwright;
+
+/// <summary>
+/// Provides the Playwright connection string.
+/// </summary>
+internal sealed class PlaywrightConnectionStringProvider : ContainerConnectionStringProvider<PlaywrightContainer, PlaywrightConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.PostgreSql/PostgreSqlBuilder.cs
+++ b/src/Testcontainers.PostgreSql/PostgreSqlBuilder.cs
@@ -124,7 +124,8 @@ public sealed class PostgreSqlBuilder : ContainerBuilder<PostgreSqlBuilder, Post
             // Disable durability: https://www.postgresql.org/docs/current/non-durability.html.
             .WithCommand("-c", "fsync=off")
             .WithCommand("-c", "full_page_writes=off")
-            .WithCommand("-c", "synchronous_commit=off");
+            .WithCommand("-c", "synchronous_commit=off")
+            .WithConnectionStringProvider(new PostgreSqlConnectionStringProvider());
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.PostgreSql/PostgreSqlConnectionStringProvider.cs
+++ b/src/Testcontainers.PostgreSql/PostgreSqlConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.PostgreSql;
+
+/// <summary>
+/// Provides the PostgreSql connection string.
+/// </summary>
+internal sealed class PostgreSqlConnectionStringProvider : ContainerConnectionStringProvider<PostgreSqlContainer, PostgreSqlConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.PubSub/PubSubBuilder.cs
+++ b/src/Testcontainers.PubSub/PubSubBuilder.cs
@@ -77,6 +77,7 @@ public sealed class PubSubBuilder : ContainerBuilder<PubSubBuilder, PubSubContai
             .WithPortBinding(PubSubPort, true)
             .WithEntrypoint("gcloud")
             .WithCommand("beta", "emulators", "pubsub", "start", "--host-port", "0.0.0.0:" + PubSubPort)
+            .WithConnectionStringProvider(new PubSubConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("(?s).*started.*$"));
     }
 

--- a/src/Testcontainers.PubSub/PubSubConnectionStringProvider.cs
+++ b/src/Testcontainers.PubSub/PubSubConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.PubSub;
+
+/// <summary>
+/// Provides the PubSub connection string.
+/// </summary>
+internal sealed class PubSubConnectionStringProvider : ContainerConnectionStringProvider<PubSubContainer, PubSubConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetEmulatorEndpoint();
+    }
+}

--- a/src/Testcontainers.Pulsar/PulsarBuilder.cs
+++ b/src/Testcontainers.Pulsar/PulsarBuilder.cs
@@ -128,6 +128,7 @@ public sealed class PulsarBuilder : ContainerBuilder<PulsarBuilder, PulsarContai
             .WithFunctionsWorker(false)
             .WithEntrypoint("/bin/sh", "-c")
             .WithCommand("while [ ! -f " + StartupScriptFilePath + " ]; do sleep 0.1; done; " + StartupScriptFilePath)
+            .WithConnectionStringProvider(new PulsarConnectionStringProvider())
             .WithStartupCallback((container, ct) => container.CopyStartupScriptAsync(ct));
     }
 

--- a/src/Testcontainers.Pulsar/PulsarConnectionStringProvider.cs
+++ b/src/Testcontainers.Pulsar/PulsarConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Pulsar;
+
+/// <summary>
+/// Provides the Pulsar connection string.
+/// </summary>
+internal sealed class PulsarConnectionStringProvider : ContainerConnectionStringProvider<PulsarContainer, PulsarConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBrokerAddress();
+    }
+}

--- a/src/Testcontainers.Qdrant/QdrantBuilder.cs
+++ b/src/Testcontainers.Qdrant/QdrantBuilder.cs
@@ -112,7 +112,8 @@ public sealed class QdrantBuilder : ContainerBuilder<QdrantBuilder, QdrantContai
     {
         return base.Init()
             .WithPortBinding(QdrantHttpPort, true)
-            .WithPortBinding(QdrantGrpcPort, true);
+            .WithPortBinding(QdrantGrpcPort, true)
+            .WithConnectionStringProvider(new QdrantConnectionStringProvider());
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Qdrant/QdrantConnectionStringProvider.cs
+++ b/src/Testcontainers.Qdrant/QdrantConnectionStringProvider.cs
@@ -8,6 +8,6 @@ internal sealed class QdrantConnectionStringProvider : ContainerConnectionString
     /// <inheritdoc />
     protected override string GetHostConnectionString()
     {
-        return Container.GetGrpcConnectionString();
+        return Container.GetHttpConnectionString();
     }
 }

--- a/src/Testcontainers.Qdrant/QdrantConnectionStringProvider.cs
+++ b/src/Testcontainers.Qdrant/QdrantConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Qdrant;
+
+/// <summary>
+/// Provides the Qdrant connection string.
+/// </summary>
+internal sealed class QdrantConnectionStringProvider : ContainerConnectionStringProvider<QdrantContainer, QdrantConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetGrpcConnectionString();
+    }
+}

--- a/src/Testcontainers.RabbitMq/RabbitMqBuilder.cs
+++ b/src/Testcontainers.RabbitMq/RabbitMqBuilder.cs
@@ -103,6 +103,7 @@ public sealed class RabbitMqBuilder : ContainerBuilder<RabbitMqBuilder, RabbitMq
             .WithPortBinding(RabbitMqPort, true)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
+            .WithConnectionStringProvider(new RabbitMqConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Server startup complete"));
     }
 

--- a/src/Testcontainers.RabbitMq/RabbitMqConnectionStringProvider.cs
+++ b/src/Testcontainers.RabbitMq/RabbitMqConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.RabbitMq;
+
+/// <summary>
+/// Provides the RabbitMq connection string.
+/// </summary>
+internal sealed class RabbitMqConnectionStringProvider : ContainerConnectionStringProvider<RabbitMqContainer, RabbitMqConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.RavenDb/RavenDbBuilder.cs
+++ b/src/Testcontainers.RavenDb/RavenDbBuilder.cs
@@ -75,6 +75,7 @@ public sealed class RavenDbBuilder : ContainerBuilder<RavenDbBuilder, RavenDbCon
     {
         return base.Init()
             .WithPortBinding(RavenDbPort, true)
+            .WithConnectionStringProvider(new RavenDbConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Server started"));
     }
 

--- a/src/Testcontainers.RavenDb/RavenDbConnectionStringProvider.cs
+++ b/src/Testcontainers.RavenDb/RavenDbConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.RavenDb;
+
+/// <summary>
+/// Provides the RavenDb connection string.
+/// </summary>
+internal sealed class RavenDbConnectionStringProvider : ContainerConnectionStringProvider<RavenDbContainer, RavenDbConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Redis/RedisBuilder.cs
+++ b/src/Testcontainers.Redis/RedisBuilder.cs
@@ -75,6 +75,7 @@ public sealed class RedisBuilder : ContainerBuilder<RedisBuilder, RedisContainer
     {
         return base.Init()
             .WithPortBinding(RedisPort, true)
+            .WithConnectionStringProvider(new RedisConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("redis-cli", "ping"));
     }
 

--- a/src/Testcontainers.Redis/RedisConnectionStringProvider.cs
+++ b/src/Testcontainers.Redis/RedisConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Redis;
+
+/// <summary>
+/// Provides the Redis connection string.
+/// </summary>
+internal sealed class RedisConnectionStringProvider : ContainerConnectionStringProvider<RedisContainer, RedisConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Redpanda/RedpandaBuilder.cs
+++ b/src/Testcontainers.Redpanda/RedpandaBuilder.cs
@@ -82,6 +82,7 @@ public sealed class RedpandaBuilder : ContainerBuilder<RedpandaBuilder, Redpanda
             .WithPortBinding(RedpandaPort, true)
             .WithEntrypoint("/bin/sh", "-c")
             .WithCommand("while [ ! -f " + StartupScriptFilePath + " ]; do sleep 0.1; done; " + StartupScriptFilePath)
+            .WithConnectionStringProvider(new RedpandaConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Started Kafka API server"))
             .WithStartupCallback((container, ct) =>
             {

--- a/src/Testcontainers.Redpanda/RedpandaConnectionStringProvider.cs
+++ b/src/Testcontainers.Redpanda/RedpandaConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Redpanda;
+
+/// <summary>
+/// Provides the Redpanda connection string.
+/// </summary>
+internal sealed class RedpandaConnectionStringProvider : ContainerConnectionStringProvider<RedpandaContainer, RedpandaConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBootstrapAddress();
+    }
+}

--- a/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusBuilder.cs
@@ -164,6 +164,7 @@ public sealed class ServiceBusBuilder : ContainerBuilder<ServiceBusBuilder, Serv
             .WithPortBinding(ServiceBusPort, true)
             .WithPortBinding(ServiceBusHttpPort, true)
             .WithEnvironment("SQL_WAIT_INTERVAL", "0")
+            .WithConnectionStringProvider(new ServiceBusConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer()
                 // https://github.com/Azure/azure-event-hubs-emulator-installer/issues/69#issuecomment-3762895979.
                 .UntilMessageIsLogged("Emulator Service is Successfully Up!")

--- a/src/Testcontainers.ServiceBus/ServiceBusConnectionStringProvider.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.ServiceBus;
+
+/// <summary>
+/// Provides the Service Bus connection string.
+/// </summary>
+internal sealed class ServiceBusConnectionStringProvider : ContainerConnectionStringProvider<ServiceBusContainer, ServiceBusConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers.Typesense/TypesenseBuilder.cs
+++ b/src/Testcontainers.Typesense/TypesenseBuilder.cs
@@ -101,6 +101,7 @@ public sealed class TypesenseBuilder : ContainerBuilder<TypesenseBuilder, Typese
             .WithPortBinding(TypesensePort, true)
             .WithDataDirectory(DefaultDataDirectory)
             .WithApiKey(DefaultApiKey)
+            .WithConnectionStringProvider(new TypesenseConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPort(TypesensePort).ForPath("/health").ForResponseMessageMatching(IsNodeReadyAsync)));
     }

--- a/src/Testcontainers.Typesense/TypesenseConnectionStringProvider.cs
+++ b/src/Testcontainers.Typesense/TypesenseConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Typesense;
+
+/// <summary>
+/// Provides the Typesense connection string.
+/// </summary>
+internal sealed class TypesenseConnectionStringProvider : ContainerConnectionStringProvider<TypesenseContainer, TypesenseConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBaseAddress();
+    }
+}

--- a/src/Testcontainers.Weaviate/WeaviateBuilder.cs
+++ b/src/Testcontainers.Weaviate/WeaviateBuilder.cs
@@ -73,6 +73,7 @@ public sealed class WeaviateBuilder : ContainerBuilder<WeaviateBuilder, Weaviate
             .WithPortBinding(WeaviateGrpcPort, true)
             .WithEnvironment("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true")
             .WithEnvironment("PERSISTENCE_DATA_PATH", "/var/lib/weaviate")
+            .WithConnectionStringProvider(new WeaviateConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer()
                 .UntilInternalTcpPortIsAvailable(WeaviateHttpPort)
                 .UntilInternalTcpPortIsAvailable(WeaviateGrpcPort)

--- a/src/Testcontainers.Weaviate/WeaviateConnectionStringProvider.cs
+++ b/src/Testcontainers.Weaviate/WeaviateConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.Weaviate;
+
+/// <summary>
+/// Provides the Weaviate connection string.
+/// </summary>
+internal sealed class WeaviateConnectionStringProvider : ContainerConnectionStringProvider<WeaviateContainer, WeaviateConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetBaseAddress();
+    }
+}

--- a/src/Testcontainers.WebDriver/WebDriverBuilder.cs
+++ b/src/Testcontainers.WebDriver/WebDriverBuilder.cs
@@ -169,6 +169,7 @@ public sealed class WebDriverBuilder : ContainerBuilder<WebDriverBuilder, WebDri
             .WithNetworkAliases(WebDriverNetworkAlias)
             .WithPortBinding(WebDriverPort, true)
             .WithPortBinding(VncServerPort, true)
+            .WithConnectionStringProvider(new WebDriverConnectionStringProvider())
             .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
                 request.ForPath("/wd/hub/status").ForPort(WebDriverPort).ForResponseMessageMatching(IsGridReadyAsync)));
     }

--- a/src/Testcontainers.WebDriver/WebDriverConnectionStringProvider.cs
+++ b/src/Testcontainers.WebDriver/WebDriverConnectionStringProvider.cs
@@ -1,0 +1,13 @@
+namespace Testcontainers.WebDriver;
+
+/// <summary>
+/// Provides the WebDriver connection string.
+/// </summary>
+internal sealed class WebDriverConnectionStringProvider : ContainerConnectionStringProvider<WebDriverContainer, WebDriverConfiguration>
+{
+    /// <inheritdoc />
+    protected override string GetHostConnectionString()
+    {
+        return Container.GetConnectionString();
+    }
+}

--- a/src/Testcontainers/Builders/BuildConfiguration.cs
+++ b/src/Testcontainers/Builders/BuildConfiguration.cs
@@ -12,6 +12,18 @@ namespace DotNet.Testcontainers.Builders
   /// </summary>
   public static class BuildConfiguration
   {
+    private static class EmptyComposableEnumerableCache<T>
+    {
+      internal static readonly ComposableEnumerable<T> Instance
+        = new AppendEnumerable<T>(Array.Empty<T>());
+    }
+
+    private static class EmptyReadOnlyDictionaryCache<TKey, TValue>
+    {
+      internal static readonly IReadOnlyDictionary<TKey, TValue> Instance
+        = new ReadOnlyDictionary<TKey, TValue>(new Dictionary<TKey, TValue>());
+    }
+
     /// <summary>
     /// Returns the updated configuration value. If the new value is <c>null</c> or
     /// <c>default</c>, the old value is returned.
@@ -129,7 +141,7 @@ namespace DotNet.Testcontainers.Builders
       // the append implementation.
       if (newValue == null && oldValue == null)
       {
-        return new AppendEnumerable<T>(Array.Empty<T>());
+        return EmptyComposableEnumerableCache<T>.Instance;
       }
 
       if (newValue == null || oldValue == null)
@@ -155,7 +167,7 @@ namespace DotNet.Testcontainers.Builders
     {
       if (newValue == null && oldValue == null)
       {
-        return new ReadOnlyDictionary<TKey, TValue>(new Dictionary<TKey, TValue>());
+        return EmptyReadOnlyDictionaryCache<TKey, TValue>.Instance;
       }
 
       if (newValue == null)

--- a/tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs
+++ b/tests/Testcontainers.ActiveMq.Tests/ArtemisContainerTest.cs
@@ -73,6 +73,7 @@ public abstract class ArtemisContainerTest : IAsyncLifetime
             .ConfigureAwait(true);
 
         Assert.Equal(producedMessage.Text, receivedMessage.Body<string>());
+        Assert.Equal(_artemisContainer.GetBrokerAddress(), _artemisContainer.GetConnectionString());
     }
     // # --8<-- [end:EstablishConnection]
 

--- a/tests/Testcontainers.ArangoDb.Tests/ArangoDbContainerTest.cs
+++ b/tests/Testcontainers.ArangoDb.Tests/ArangoDbContainerTest.cs
@@ -32,5 +32,6 @@ public sealed class ArangoDbContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(HttpStatusCode.OK, response.Code);
+        Assert.Equal(_arangoDbContainer.GetTransportAddress(), _arangoDbContainer.GetConnectionString());
     }
 }

--- a/tests/Testcontainers.Azurite.Tests/AzuriteContainerTest.cs
+++ b/tests/Testcontainers.Azurite.Tests/AzuriteContainerTest.cs
@@ -36,6 +36,7 @@ public abstract class AzuriteContainerTest : IAsyncLifetime
 
         // Then
         Assert.False(HasError(properties));
+        Assert.Equal(_azuriteContainer.GetConnectionString(), _azuriteContainer.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.Azurite.Tests/Usings.cs
+++ b/tests/Testcontainers.Azurite.Tests/Usings.cs
@@ -7,5 +7,6 @@ global using Azure.Data.Tables;
 global using Azure.Storage.Blobs;
 global using Azure.Storage.Queues;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using Xunit;

--- a/tests/Testcontainers.BigQuery.Tests/BigQueryContainerTest.cs
+++ b/tests/Testcontainers.BigQuery.Tests/BigQueryContainerTest.cs
@@ -63,6 +63,7 @@ public sealed class BigQueryContainerTest : IAsyncLifetime
         Assert.Equal(expectedRow["player"], results.Single()["player"]);
         Assert.Equal(expectedRow["gameStarted"], results.Single()["gameStarted"]);
         Assert.Equal(expectedRow["score"], results.Single()["score"]);
+        Assert.Equal(_bigQueryContainer.GetEmulatorEndpoint(), _bigQueryContainer.GetConnectionString());
     }
 
     private sealed class Credential : ICredential

--- a/tests/Testcontainers.Bigtable.Tests/BigtableContainerTest.cs
+++ b/tests/Testcontainers.Bigtable.Tests/BigtableContainerTest.cs
@@ -57,5 +57,6 @@ public sealed class BigtableContainerTest : IAsyncLifetime
         Assert.Equal(projectId, actualTable.TableName.ProjectId);
         Assert.Equal(instanceId, actualTable.TableName.InstanceId);
         Assert.Equal(tableId, actualTable.TableName.TableId);
+        Assert.Equal(_bigtableContainer.GetEmulatorEndpoint(), _bigtableContainer.GetConnectionString());
     }
 }

--- a/tests/Testcontainers.Cassandra.Tests/CassandraContainerTest.cs
+++ b/tests/Testcontainers.Cassandra.Tests/CassandraContainerTest.cs
@@ -38,6 +38,7 @@ public abstract class CassandraContainerTest(CassandraContainerTest.CassandraDef
         Assert.True(rowSet.IsFullyFetched);
         Assert.Single(rows);
         Assert.Equal("COMPLETED", rows[0]["bootstrapped"]);
+        Assert.Equal(fixture.Container.GetConnectionString(), fixture.Container.GetConnectionString(ConnectionMode.Host));
     }
     // # --8<-- [end:UseCassandraContainer]
 

--- a/tests/Testcontainers.Cassandra.Tests/Usings.cs
+++ b/tests/Testcontainers.Cassandra.Tests/Usings.cs
@@ -6,6 +6,7 @@ global using Cassandra;
 global using Cassandra.Data;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using Testcontainers.Xunit;
 global using Xunit;

--- a/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.cs
+++ b/tests/Testcontainers.ClickHouse.Tests/ClickHouseContainerTest.cs
@@ -14,6 +14,7 @@ public abstract partial class ClickHouseContainerTest(ClickHouseContainerTest.Cl
 
         // Then
         Assert.Equal(ConnectionState.Open, connection.State);
+        Assert.Equal(fixture.Container.GetConnectionString(), fixture.Container.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.ClickHouse.Tests/Usings.cs
+++ b/tests/Testcontainers.ClickHouse.Tests/Usings.cs
@@ -4,6 +4,7 @@ global using System.Threading.Tasks;
 global using ClickHouse.Client.ADO;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using Testcontainers.Xunit;
 global using Xunit;

--- a/tests/Testcontainers.CockroachDb.Tests/CockroachDbContainerTest.cs
+++ b/tests/Testcontainers.CockroachDb.Tests/CockroachDbContainerTest.cs
@@ -14,6 +14,7 @@ public abstract class CockroachDbContainerTest(CockroachDbContainerTest.Cockroac
 
         // Then
         Assert.Equal(ConnectionState.Open, connection.State);
+        Assert.Equal(fixture.Container.GetConnectionString(), fixture.Container.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.CockroachDb.Tests/Usings.cs
+++ b/tests/Testcontainers.CockroachDb.Tests/Usings.cs
@@ -3,6 +3,7 @@ global using System.Data.Common;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using Npgsql;
 global using Testcontainers.Xunit;

--- a/tests/Testcontainers.Consul.Tests/ConsulContainerTest.cs
+++ b/tests/Testcontainers.Consul.Tests/ConsulContainerTest.cs
@@ -42,5 +42,6 @@ public sealed class ConsulContainerTest : IAsyncLifetime
         // Then
         Assert.Equal(HttpStatusCode.OK, actual.StatusCode);
         Assert.Equal(helloWorld, Encoding.Default.GetString(actual.Response.Value));
+        Assert.Equal(_consulContainer.GetBaseAddress(), _consulContainer.GetConnectionString());
     }
 }

--- a/tests/Testcontainers.CosmosDb.Tests/CosmosDbContainerTest.cs
+++ b/tests/Testcontainers.CosmosDb.Tests/CosmosDbContainerTest.cs
@@ -23,7 +23,7 @@ public sealed class CosmosDbContainerTest : IAsyncLifetime
         using var httpClient = _cosmosDbContainer.HttpClient;
 
         var cosmosClientOptions = new CosmosClientOptions();
-        cosmosClientOptions.ConnectionMode = ConnectionMode.Gateway;
+        cosmosClientOptions.ConnectionMode = CosmosConnectionMode.Gateway;
         cosmosClientOptions.HttpClientFactory = () => httpClient;
 
         using var cosmosClient = new CosmosClient(_cosmosDbContainer.GetConnectionString(), cosmosClientOptions);
@@ -34,5 +34,6 @@ public sealed class CosmosDbContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal("localhost", accountProperties.Id);
+        Assert.Equal(_cosmosDbContainer.GetConnectionString(), _cosmosDbContainer.GetConnectionString(TestcontainersConnectionMode.Host));
     }
 }

--- a/tests/Testcontainers.CosmosDb.Tests/Usings.cs
+++ b/tests/Testcontainers.CosmosDb.Tests/Usings.cs
@@ -2,3 +2,5 @@ global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
 global using Microsoft.Azure.Cosmos;
 global using Xunit;
+global using CosmosConnectionMode = Microsoft.Azure.Cosmos.ConnectionMode;
+global using TestcontainersConnectionMode = DotNet.Testcontainers.Configurations.ConnectionMode;

--- a/tests/Testcontainers.CouchDb.Tests/CouchDbContainerTest.cs
+++ b/tests/Testcontainers.CouchDb.Tests/CouchDbContainerTest.cs
@@ -28,5 +28,6 @@ public sealed class CouchDbContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(HttpStatusCode.Created, database.StatusCode);
+        Assert.Equal(_couchDbContainer.GetConnectionString(), _couchDbContainer.GetConnectionString(ConnectionMode.Host));
     }
 }

--- a/tests/Testcontainers.CouchDb.Tests/Usings.cs
+++ b/tests/Testcontainers.CouchDb.Tests/Usings.cs
@@ -1,5 +1,6 @@
 global using System.Net;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using MyCouch;
 global using Xunit;

--- a/tests/Testcontainers.Couchbase.Tests/CouchbaseContainerTest.cs
+++ b/tests/Testcontainers.Couchbase.Tests/CouchbaseContainerTest.cs
@@ -39,5 +39,6 @@ public sealed class CouchbaseContainerTest : IAsyncLifetime
         Assert.NotEmpty(ping.Id);
         Assert.NotEmpty(ping.Services);
         Assert.NotEmpty(bucket.Name);
+        Assert.Equal(_couchbaseContainer.GetConnectionString(), _couchbaseContainer.GetConnectionString(ConnectionMode.Host));
     }
 }

--- a/tests/Testcontainers.Couchbase.Tests/Usings.cs
+++ b/tests/Testcontainers.Couchbase.Tests/Usings.cs
@@ -2,4 +2,5 @@ global using System.Linq;
 global using System.Threading.Tasks;
 global using Couchbase;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using Xunit;

--- a/tests/Testcontainers.Db2.Tests/Db2ContainerTest.cs
+++ b/tests/Testcontainers.Db2.Tests/Db2ContainerTest.cs
@@ -15,6 +15,7 @@ public abstract class Db2ContainerTest(Db2ContainerTest.Db2DefaultFixture fixtur
 
         // Then
         Assert.Equal(ConnectionState.Open, connection.State);
+        Assert.Equal(fixture.Container.GetConnectionString(), fixture.Container.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.Db2.Tests/Usings.cs
+++ b/tests/Testcontainers.Db2.Tests/Usings.cs
@@ -5,6 +5,7 @@ global using System.Data.Common;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using IBM.Data.Db2;
 global using JetBrains.Annotations;
 global using Testcontainers.Xunit;

--- a/tests/Testcontainers.DynamoDb.Tests/DynamoDbContainerTest.cs
+++ b/tests/Testcontainers.DynamoDb.Tests/DynamoDbContainerTest.cs
@@ -37,6 +37,7 @@ public sealed class DynamoDbContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(HttpStatusCode.OK, tables.HttpStatusCode);
+        Assert.Equal(_dynamoDbContainer.GetConnectionString(), _dynamoDbContainer.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.DynamoDb.Tests/Usings.cs
+++ b/tests/Testcontainers.DynamoDb.Tests/Usings.cs
@@ -6,4 +6,5 @@ global using System.Threading.Tasks;
 global using Amazon.DynamoDBv2;
 global using Amazon.DynamoDBv2.Model;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using Xunit;

--- a/tests/Testcontainers.Elasticsearch.Tests/ElasticsearchContainerTest.cs
+++ b/tests/Testcontainers.Elasticsearch.Tests/ElasticsearchContainerTest.cs
@@ -39,6 +39,7 @@ public abstract class ElasticsearchContainerTest : IAsyncLifetime
 
         // Then
         Assert.True(response.IsValidResponse);
+        Assert.Equal(_elasticsearchContainer.GetConnectionString(), _elasticsearchContainer.GetConnectionString(ConnectionMode.Host));
     }
     // # --8<-- [end:UseElasticsearchContainer]
 

--- a/tests/Testcontainers.Elasticsearch.Tests/Usings.cs
+++ b/tests/Testcontainers.Elasticsearch.Tests/Usings.cs
@@ -1,6 +1,7 @@
 global using System;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using Elastic.Clients.Elasticsearch;
 global using Elastic.Transport;
 global using JetBrains.Annotations;

--- a/tests/Testcontainers.EventHubs.Tests/EventHubsContainerTest.cs
+++ b/tests/Testcontainers.EventHubs.Tests/EventHubsContainerTest.cs
@@ -63,6 +63,7 @@ public abstract class EventHubsContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(message, Encoding.UTF8.GetString(asyncEnumerator.Current.Data.Body.Span));
+        Assert.Equal(_eventHubsContainer.GetConnectionString(), _eventHubsContainer.GetConnectionString(ConnectionMode.Host));
     }
     // # --8<-- [end:UseEventHubsContainer]
 

--- a/tests/Testcontainers.EventHubs.Tests/Usings.cs
+++ b/tests/Testcontainers.EventHubs.Tests/Usings.cs
@@ -6,6 +6,7 @@ global using Azure.Messaging.EventHubs.Consumer;
 global using Azure.Messaging.EventHubs.Producer;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using DotNet.Testcontainers.Networks;
 global using JetBrains.Annotations;
 global using Testcontainers.Azurite;

--- a/tests/Testcontainers.FakeGcsServer.Tests/FakeGcsServerContainerTest.cs
+++ b/tests/Testcontainers.FakeGcsServer.Tests/FakeGcsServerContainerTest.cs
@@ -51,5 +51,6 @@ public sealed class FakeGcsServerContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(helloWorld, Encoding.Default.GetString(readStream.ToArray()));
+        Assert.Equal(_fakeGcsServerContainer.GetConnectionString(), _fakeGcsServerContainer.GetConnectionString(ConnectionMode.Host));
     }
 }

--- a/tests/Testcontainers.FakeGcsServer.Tests/Usings.cs
+++ b/tests/Testcontainers.FakeGcsServer.Tests/Usings.cs
@@ -3,5 +3,6 @@ global using System.IO;
 global using System.Text;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using Google.Cloud.Storage.V1;
 global using Xunit;

--- a/tests/Testcontainers.FirebirdSql.Tests/FirebirdSqlContainerTest.cs
+++ b/tests/Testcontainers.FirebirdSql.Tests/FirebirdSqlContainerTest.cs
@@ -14,6 +14,7 @@ public abstract class FirebirdSqlContainerTest(FirebirdSqlContainerTest.Firebird
 
         // Then
         Assert.Equal(ConnectionState.Open, connection.State);
+        Assert.Equal(fixture.Container.GetConnectionString(), fixture.Container.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.FirebirdSql.Tests/Usings.cs
+++ b/tests/Testcontainers.FirebirdSql.Tests/Usings.cs
@@ -3,6 +3,7 @@ global using System.Data.Common;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using FirebirdSql.Data.FirebirdClient;
 global using JetBrains.Annotations;
 global using Testcontainers.Xunit;

--- a/tests/Testcontainers.Firestore.Tests/FirestoreContainerTest.cs
+++ b/tests/Testcontainers.Firestore.Tests/FirestoreContainerTest.cs
@@ -46,5 +46,6 @@ public sealed class FirestoreContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(documentData, querySnapshot.Documents.Select(document => document.ConvertTo<Dictionary<string, string>>()).Single());
+        Assert.Equal(_firestoreContainer.GetEmulatorEndpoint(), _firestoreContainer.GetConnectionString());
     }
 }

--- a/tests/Testcontainers.Grafana.Tests/GrafanaContainerTest.cs
+++ b/tests/Testcontainers.Grafana.Tests/GrafanaContainerTest.cs
@@ -47,6 +47,7 @@ public abstract class GrafanaContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+        Assert.Equal(_grafanaContainer.GetBaseAddress(), _grafanaContainer.GetConnectionString());
     }
     // # --8<-- [end:UseGrafanaContainer]
 

--- a/tests/Testcontainers.InfluxDb.Tests/InfluxDbContainerTest.cs
+++ b/tests/Testcontainers.InfluxDb.Tests/InfluxDbContainerTest.cs
@@ -30,6 +30,7 @@ public sealed class InfluxDbContainerTest : IAsyncLifetime
 
         // Then
         Assert.True(result);
+        Assert.Equal(_influxDbContainer.GetAddress(), _influxDbContainer.GetConnectionString());
     }
 
     [Fact]

--- a/tests/Testcontainers.Kafka.Tests/KafkaContainerTest.cs
+++ b/tests/Testcontainers.Kafka.Tests/KafkaContainerTest.cs
@@ -56,6 +56,7 @@ public abstract class KafkaContainerTest : IAsyncLifetime
         // Then
         Assert.NotNull(result);
         Assert.Equal(message.Value, result.Message.Value);
+        Assert.Equal(_kafkaContainer.GetBootstrapAddress(), _kafkaContainer.GetConnectionString());
     }
 
     protected virtual ValueTask DisposeAsyncCore()

--- a/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
+++ b/tests/Testcontainers.Keycloak.Tests/KeycloakContainerTest.cs
@@ -37,6 +37,7 @@ public abstract class KeycloakContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+        Assert.Equal(_keycloakContainer.GetBaseAddress(), _keycloakContainer.GetConnectionString());
     }
 
     [Fact]

--- a/tests/Testcontainers.KurrentDb.Tests/KurrentDbContainerTest.cs
+++ b/tests/Testcontainers.KurrentDb.Tests/KurrentDbContainerTest.cs
@@ -41,5 +41,6 @@ public sealed class KurrentDbContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(eventType, resolvedEvent.Event.EventType);
+        Assert.Equal(_kurrentDbContainer.GetConnectionString(), _kurrentDbContainer.GetConnectionString(ConnectionMode.Host));
     }
 }

--- a/tests/Testcontainers.KurrentDb.Tests/Usings.cs
+++ b/tests/Testcontainers.KurrentDb.Tests/Usings.cs
@@ -2,5 +2,6 @@ global using System;
 global using System.Linq;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using KurrentDB.Client;
 global using Xunit;

--- a/tests/Testcontainers.Kusto.Tests/KustoContainerTest.cs
+++ b/tests/Testcontainers.Kusto.Tests/KustoContainerTest.cs
@@ -31,5 +31,6 @@ public sealed class KustoContainerTest : IAsyncLifetime
         // Then
         Assert.Equal("DatabaseName", dataReader.GetName(0));
         Assert.Equal("NetDefaultDB", dataReader.GetString(0));
+        Assert.Equal(_kustoContainer.GetConnectionString(), _kustoContainer.GetConnectionString(ConnectionMode.Host));
     }
 }

--- a/tests/Testcontainers.Kusto.Tests/Usings.cs
+++ b/tests/Testcontainers.Kusto.Tests/Usings.cs
@@ -1,5 +1,6 @@
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using Kusto.Data.Common;
 global using Kusto.Data.Net.Client;
 global using Xunit;

--- a/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTest.cs
+++ b/tests/Testcontainers.LocalStack.Tests/LocalStackContainerTest.cs
@@ -50,6 +50,7 @@ public abstract class LocalStackContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(HttpStatusCode.OK, logGroupResponse.HttpStatusCode);
+        Assert.Equal(_localStackContainer.GetConnectionString(), _localStackContainer.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.LocalStack.Tests/Usings.cs
+++ b/tests/Testcontainers.LocalStack.Tests/Usings.cs
@@ -11,5 +11,6 @@ global using Amazon.S3;
 global using Amazon.SimpleNotificationService;
 global using Amazon.SQS;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using Xunit;

--- a/tests/Testcontainers.LowkeyVault.Tests/LowkeyVaultContainerTest.cs
+++ b/tests/Testcontainers.LowkeyVault.Tests/LowkeyVaultContainerTest.cs
@@ -25,15 +25,13 @@ public abstract class LowkeyVaultContainerTest : IAsyncLifetime
     public async Task ServerCertificateValidationSucceedsWithTrustedCertificate()
     {
         // Given
-        var baseAddress = _lowkeyVaultContainer.GetBaseAddress();
-
         var certificates = await _lowkeyVaultContainer.GetCertificateAsync();
 
         using var httpMessageHandler = new HttpClientHandler();
         httpMessageHandler.ServerCertificateCustomValidationCallback = (_, cert, _, _) => certificates.IndexOf(cert) > -1;
 
         using var httpClient = new HttpClient(httpMessageHandler);
-        httpClient.BaseAddress = new Uri(baseAddress);
+        httpClient.BaseAddress = new Uri(_lowkeyVaultContainer.GetBaseAddress());
 
         // When
         using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "management/vault");
@@ -43,6 +41,7 @@ public abstract class LowkeyVaultContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(HttpStatusCode.OK, httpResponseMessage.StatusCode);
+        Assert.Equal(_lowkeyVaultContainer.GetBaseAddress(), _lowkeyVaultContainer.GetConnectionString());
     }
 
     [Fact]

--- a/tests/Testcontainers.MariaDb.Tests/MariaDbContainerTest.cs
+++ b/tests/Testcontainers.MariaDb.Tests/MariaDbContainerTest.cs
@@ -14,6 +14,7 @@ public abstract class MariaDbContainerTest(MariaDbContainerTest.MariaDbDefaultFi
 
         // Then
         Assert.Equal(ConnectionState.Open, connection.State);
+        Assert.Equal(fixture.Container.GetConnectionString(), fixture.Container.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.MariaDb.Tests/Usings.cs
+++ b/tests/Testcontainers.MariaDb.Tests/Usings.cs
@@ -3,6 +3,7 @@ global using System.Data.Common;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using MySqlConnector;
 global using Testcontainers.Xunit;

--- a/tests/Testcontainers.Milvus.Tests/MilvusContainerTest.cs
+++ b/tests/Testcontainers.Milvus.Tests/MilvusContainerTest.cs
@@ -36,6 +36,7 @@ public abstract class MilvusContainerTest : IAsyncLifetime
 
         // Then
         Assert.EndsWith(version, _milvusContainer.Image.Tag);
+        Assert.Equal(_milvusContainer.GetEndpoint().ToString(), _milvusContainer.GetConnectionString());
     }
 
     protected virtual ValueTask DisposeAsyncCore()

--- a/tests/Testcontainers.Minio.Tests/MinioContainerTest.cs
+++ b/tests/Testcontainers.Minio.Tests/MinioContainerTest.cs
@@ -31,6 +31,7 @@ public sealed class MinioContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(HttpStatusCode.OK, buckets.HttpStatusCode);
+        Assert.Equal(_minioContainer.GetConnectionString(), _minioContainer.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.Minio.Tests/Usings.cs
+++ b/tests/Testcontainers.Minio.Tests/Usings.cs
@@ -5,4 +5,5 @@ global using System.Threading.Tasks;
 global using Amazon.S3;
 global using Amazon.S3.Model;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using Xunit;

--- a/tests/Testcontainers.MongoDb.Tests/MongoDbContainerTest.cs
+++ b/tests/Testcontainers.MongoDb.Tests/MongoDbContainerTest.cs
@@ -39,6 +39,7 @@ public abstract class MongoDbContainerTest : IAsyncLifetime
 
         // Then
         Assert.Contains(databases.ToEnumerable(TestContext.Current.CancellationToken), database => database.TryGetValue("name", out var name) && "admin".Equals(name.AsString));
+        Assert.Equal(_mongoDbContainer.GetConnectionString(), _mongoDbContainer.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.MongoDb.Tests/Usings.cs
+++ b/tests/Testcontainers.MongoDb.Tests/Usings.cs
@@ -1,6 +1,7 @@
 global using System;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using MongoDB.Driver;
 global using Xunit;

--- a/tests/Testcontainers.Mosquitto.Tests/MosquittoContainerTest.cs
+++ b/tests/Testcontainers.Mosquitto.Tests/MosquittoContainerTest.cs
@@ -13,10 +13,10 @@ public abstract class MosquittoContainerTest : ContainerTest<MosquittoBuilder, M
     {
     }
 
+    protected abstract MqttClientOptions GetClientOptions();
+  
     protected override MosquittoBuilder Configure()
         => new MosquittoBuilder(TestSession.GetImageFromDockerfile());
-
-    protected abstract MqttClientOptions GetClientOptions();
 
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
@@ -31,6 +31,7 @@ public abstract class MosquittoContainerTest : ContainerTest<MosquittoBuilder, M
 
         // Then
         Assert.Equal(MqttClientConnectResultCode.Success, result.ResultCode);
+        Assert.Equal(Container.GetConnectionString(), Container.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.Mosquitto.Tests/Usings.cs
+++ b/tests/Testcontainers.Mosquitto.Tests/Usings.cs
@@ -2,6 +2,7 @@ global using System;
 global using System.IO;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using MQTTnet;
 global using Testcontainers.Xunit;

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -15,6 +15,7 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
 
         // Then
         Assert.Equal(ConnectionState.Open, connection.State);
+        Assert.Equal(fixture.Container.GetConnectionString(), fixture.Container.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.MsSql.Tests/Usings.cs
+++ b/tests/Testcontainers.MsSql.Tests/Usings.cs
@@ -3,6 +3,7 @@ global using System.Data.Common;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using Microsoft.Data.SqlClient;
 global using Testcontainers.Xunit;

--- a/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
+++ b/tests/Testcontainers.MySql.Tests/MySqlContainerTest.cs
@@ -14,6 +14,7 @@ public abstract class MySqlContainerTest(MySqlContainerTest.MySqlDefaultFixture 
 
         // Then
         Assert.Equal(ConnectionState.Open, connection.State);
+        Assert.Equal(fixture.Container.GetConnectionString(), fixture.Container.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.MySql.Tests/Usings.cs
+++ b/tests/Testcontainers.MySql.Tests/Usings.cs
@@ -3,6 +3,7 @@ global using System.Data.Common;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using MySqlConnector;
 global using Testcontainers.Xunit;

--- a/tests/Testcontainers.Nats.Tests/NatsContainerTest.cs
+++ b/tests/Testcontainers.Nats.Tests/NatsContainerTest.cs
@@ -63,6 +63,7 @@ public abstract class NatsContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(message, actualMessage);
+        Assert.Equal(_natsContainer.GetConnectionString(), _natsContainer.GetConnectionString(ConnectionMode.Host));
     }
 
     protected virtual ValueTask DisposeAsyncCore()

--- a/tests/Testcontainers.Nats.Tests/Usings.cs
+++ b/tests/Testcontainers.Nats.Tests/Usings.cs
@@ -4,6 +4,7 @@ global using System.Net.Http;
 global using System.Text;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using NATS.Client;
 global using Xunit;

--- a/tests/Testcontainers.Neo4j.Tests/Neo4jContainerTest.cs
+++ b/tests/Testcontainers.Neo4j.Tests/Neo4jContainerTest.cs
@@ -49,6 +49,7 @@ public abstract class Neo4jContainerTest : IAsyncLifetime
         // Then
         Assert.Equal(neo4jDatabase, session.SessionConfig.Database);
         Assert.Equal(Edition, edition);
+        Assert.Equal(_neo4jContainer.GetConnectionString(), _neo4jContainer.GetConnectionString(ConnectionMode.Host));
     }
     // # --8<-- [end:UseNeo4jContainer]
 

--- a/tests/Testcontainers.Neo4j.Tests/Usings.cs
+++ b/tests/Testcontainers.Neo4j.Tests/Usings.cs
@@ -1,6 +1,7 @@
 global using System;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using Neo4j.Driver;
 global using Xunit;

--- a/tests/Testcontainers.Ollama.Tests/OllamaContainerTest.cs
+++ b/tests/Testcontainers.Ollama.Tests/OllamaContainerTest.cs
@@ -38,5 +38,6 @@ public sealed class OllamaContainerTest : IAsyncLifetime
         // Then
         Assert.NotNull(embedResponse);
         Assert.NotEmpty(embedResponse.Embeddings);
+        Assert.Equal(_ollamaContainer.GetBaseAddress(), _ollamaContainer.GetConnectionString());
     }
 }

--- a/tests/Testcontainers.OpenSearch.Tests/OpenSearchContainerTest.cs
+++ b/tests/Testcontainers.OpenSearch.Tests/OpenSearchContainerTest.cs
@@ -41,6 +41,7 @@ public abstract class OpenSearchContainerTest : IAsyncLifetime
 
         // Then
         Assert.True(response.IsValid);
+        Assert.Equal(_openSearchContainer.GetConnectionString(), _openSearchContainer.GetConnectionString(ConnectionMode.Host));
     }
     // <!-- -8<- [end:PingExample] -->
 
@@ -150,6 +151,7 @@ public abstract class OpenSearchContainerTest : IAsyncLifetime
         {
             var connectionString = new Uri(_openSearchContainer.GetConnectionString());
             Assert.Equal(Uri.UriSchemeHttp, connectionString.Scheme);
+
             return new OpenSearchClient(connectionString);
         }
     }

--- a/tests/Testcontainers.OpenSearch.Tests/Usings.cs
+++ b/tests/Testcontainers.OpenSearch.Tests/Usings.cs
@@ -2,6 +2,7 @@ global using System;
 global using System.Linq;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using OpenSearch.Client;
 global using OpenSearch.Net;

--- a/tests/Testcontainers.Oracle.Tests/OracleContainerTest.cs
+++ b/tests/Testcontainers.Oracle.Tests/OracleContainerTest.cs
@@ -14,6 +14,7 @@ public abstract class OracleContainerTest(OracleContainerTest.OracleFixture fixt
 
         // Then
         Assert.Equal(ConnectionState.Open, connection.State);
+        Assert.Equal(fixture.Container.GetConnectionString(), fixture.Container.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.Oracle.Tests/Usings.cs
+++ b/tests/Testcontainers.Oracle.Tests/Usings.cs
@@ -4,6 +4,7 @@ global using System.Data.Common;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using Oracle.ManagedDataAccess.Client;
 global using Testcontainers.Xunit;

--- a/tests/Testcontainers.Papercut.Tests/PapercutContainerTest.cs
+++ b/tests/Testcontainers.Papercut.Tests/PapercutContainerTest.cs
@@ -38,29 +38,18 @@ public sealed class PapercutContainerTest : IAsyncLifetime
 
         // Then
         Assert.Single(messages, message => subject.Equals(message.Subject));
+        Assert.Equal(_papercutContainer.GetBaseAddress(), _papercutContainer.GetConnectionString());
     }
 
-    private readonly struct Message
+    private sealed record Message
     {
         [JsonConstructor]
         public Message(string id, string subject, string size, DateTime createdAt)
         {
-            Id = id;
             Subject = subject;
-            Size = size;
-            CreatedAt = createdAt;
         }
-
-        [JsonPropertyName("id")]
-        public string Id { get; }
 
         [JsonPropertyName("subject")]
         public string Subject { get; }
-
-        [JsonPropertyName("size")]
-        public string Size { get; }
-
-        [JsonPropertyName("createdAt")]
-        public DateTime CreatedAt { get; }
     }
 }

--- a/tests/Testcontainers.Papercut.Tests/PapercutContainerTest.cs
+++ b/tests/Testcontainers.Papercut.Tests/PapercutContainerTest.cs
@@ -43,8 +43,7 @@ public sealed class PapercutContainerTest : IAsyncLifetime
 
     private sealed record Message
     {
-        [JsonConstructor]
-        public Message(string id, string subject, string size, DateTime createdAt)
+        public Message(string subject)
         {
             Subject = subject;
         }

--- a/tests/Testcontainers.Playwright.Tests/PlaywrightContainerTest.cs
+++ b/tests/Testcontainers.Playwright.Tests/PlaywrightContainerTest.cs
@@ -65,6 +65,7 @@ public abstract class PlaywrightContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal("Hello world", headingElementText);
+        Assert.Equal(_playwrightContainer.GetConnectionString(), _playwrightContainer.GetConnectionString(ConnectionMode.Host));
     }
     // # --8<-- [end:UsePlaywrightContainer]
 

--- a/tests/Testcontainers.Playwright.Tests/Usings.cs
+++ b/tests/Testcontainers.Playwright.Tests/Usings.cs
@@ -2,6 +2,7 @@ global using System;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using DotNet.Testcontainers.Containers;
 global using JetBrains.Annotations;
 global using Xunit;

--- a/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
+++ b/tests/Testcontainers.PostgreSql.Tests/PostgreSqlContainerTest.cs
@@ -15,6 +15,7 @@ public abstract class PostgreSqlContainerTest(PostgreSqlContainerTest.PostgreSql
 
         // Then
         Assert.Equal(ConnectionState.Open, connection.State);
+        Assert.Equal(fixture.Container.GetConnectionString(), fixture.Container.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.PostgreSql.Tests/Usings.cs
+++ b/tests/Testcontainers.PostgreSql.Tests/Usings.cs
@@ -5,6 +5,7 @@ global using System.Threading;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using JetBrains.Annotations;
 global using Npgsql;
 global using Testcontainers.Xunit;

--- a/tests/Testcontainers.PubSub.Tests/PubSubContainerTest.cs
+++ b/tests/Testcontainers.PubSub.Tests/PubSubContainerTest.cs
@@ -67,5 +67,6 @@ public sealed class PubSubContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(helloPubSub, response.ReceivedMessages.Single().Message.Data.ToStringUtf8());
+        Assert.Equal(_pubSubContainer.GetEmulatorEndpoint(), _pubSubContainer.GetConnectionString());
     }
 }

--- a/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
+++ b/tests/Testcontainers.Pulsar.Tests/PulsarContainerTest.cs
@@ -74,6 +74,7 @@ public abstract class PulsarContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(helloPulsar, Encoding.Default.GetString(message.Data));
+        Assert.Equal(_pulsarContainer.GetBrokerAddress(), _pulsarContainer.GetConnectionString());
     }
     // # --8<-- [end:UsePulsarContainer]
 

--- a/tests/Testcontainers.Qdrant.Tests/QdrantDefaultContainerTest.cs
+++ b/tests/Testcontainers.Qdrant.Tests/QdrantDefaultContainerTest.cs
@@ -29,6 +29,7 @@ public sealed class QdrantDefaultContainerTest : IAsyncLifetime
 
         // Then
         Assert.NotEmpty(response.Title);
+        Assert.Equal(_qdrantContainer.GetGrpcConnectionString(), _qdrantContainer.GetConnectionString());
     }
     // # --8<-- [end:UseQdrantContainer]
 

--- a/tests/Testcontainers.Qdrant.Tests/QdrantDefaultContainerTest.cs
+++ b/tests/Testcontainers.Qdrant.Tests/QdrantDefaultContainerTest.cs
@@ -29,7 +29,7 @@ public sealed class QdrantDefaultContainerTest : IAsyncLifetime
 
         // Then
         Assert.NotEmpty(response.Title);
-        Assert.Equal(_qdrantContainer.GetGrpcConnectionString(), _qdrantContainer.GetConnectionString());
+        Assert.Equal(_qdrantContainer.GetHttpConnectionString(), _qdrantContainer.GetConnectionString());
     }
     // # --8<-- [end:UseQdrantContainer]
 

--- a/tests/Testcontainers.RabbitMq.Tests/RabbitMqContainerTest.cs
+++ b/tests/Testcontainers.RabbitMq.Tests/RabbitMqContainerTest.cs
@@ -29,6 +29,7 @@ public sealed class RabbitMqContainerTest : IAsyncLifetime
 
         // Then
         Assert.True(connection.IsOpen);
+        Assert.Equal(_rabbitMqContainer.GetConnectionString(), _rabbitMqContainer.GetConnectionString(ConnectionMode.Host));
     }
     // # --8<-- [end:UseRabbitMqContainer]
 }

--- a/tests/Testcontainers.RabbitMq.Tests/Usings.cs
+++ b/tests/Testcontainers.RabbitMq.Tests/Usings.cs
@@ -1,5 +1,6 @@
 global using System;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using RabbitMQ.Client;
 global using Xunit;

--- a/tests/Testcontainers.RavenDb.Tests/RavenDbContainerTest.cs
+++ b/tests/Testcontainers.RavenDb.Tests/RavenDbContainerTest.cs
@@ -29,5 +29,6 @@ public sealed class RavenDbContainerTest : IAsyncLifetime
 
         // Then
         Assert.Contains(buildNumber.ProductVersion, _ravenDbContainer.Image.Tag);
+        Assert.Equal(_ravenDbContainer.GetConnectionString(), _ravenDbContainer.GetConnectionString(ConnectionMode.Host));
     }
 }

--- a/tests/Testcontainers.RavenDb.Tests/Usings.cs
+++ b/tests/Testcontainers.RavenDb.Tests/Usings.cs
@@ -1,5 +1,6 @@
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using Raven.Client.Documents;
 global using Raven.Client.ServerWide.Operations;
 global using Xunit;

--- a/tests/Testcontainers.Redis.Tests/RedisContainerTest.cs
+++ b/tests/Testcontainers.Redis.Tests/RedisContainerTest.cs
@@ -21,6 +21,7 @@ public sealed class RedisContainerTest : IAsyncLifetime
     {
         using var connection = ConnectionMultiplexer.Connect(_redisContainer.GetConnectionString());
         Assert.True(connection.IsConnected);
+        Assert.Equal(_redisContainer.GetConnectionString(), _redisContainer.GetConnectionString(ConnectionMode.Host));
     }
 
     [Fact]

--- a/tests/Testcontainers.Redis.Tests/Usings.cs
+++ b/tests/Testcontainers.Redis.Tests/Usings.cs
@@ -1,4 +1,5 @@
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using StackExchange.Redis;
 global using Xunit;

--- a/tests/Testcontainers.Redpanda.Tests/RedpandaContainerTest.cs
+++ b/tests/Testcontainers.Redpanda.Tests/RedpandaContainerTest.cs
@@ -48,5 +48,6 @@ public sealed class RedpandaContainerTest : IAsyncLifetime
         // Then
         Assert.NotNull(result);
         Assert.Equal(message.Value, result.Message.Value);
+        Assert.Equal(_redpandaContainer.GetBootstrapAddress(), _redpandaContainer.GetConnectionString());
     }
 }

--- a/tests/Testcontainers.ServiceBus.Tests/ServiceBusContainerTest.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/ServiceBusContainerTest.cs
@@ -58,6 +58,7 @@ public abstract class ServiceBusContainerTest : IAsyncLifetime
         // Then
         Assert.NotNull(receivedMessage);
         Assert.Equal(helloServiceBus, receivedMessage.Body.ToString());
+        Assert.Equal(_serviceBusContainer.GetConnectionString(), _serviceBusContainer.GetConnectionString(ConnectionMode.Host));
     }
     // # --8<-- [end:UseServiceBusContainer]
 

--- a/tests/Testcontainers.ServiceBus.Tests/Usings.cs
+++ b/tests/Testcontainers.ServiceBus.Tests/Usings.cs
@@ -5,6 +5,7 @@ global using Azure.Messaging.ServiceBus;
 global using Azure.Messaging.ServiceBus.Administration;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using DotNet.Testcontainers.Networks;
 global using JetBrains.Annotations;
 global using Testcontainers.MsSql;

--- a/tests/Testcontainers.Typesense.Tests/TypesenseContainerTest.cs
+++ b/tests/Testcontainers.Typesense.Tests/TypesenseContainerTest.cs
@@ -33,5 +33,6 @@ public sealed class TypesenseContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal("[]", response);
+        Assert.Equal(_typesenseContainer.GetBaseAddress(), _typesenseContainer.GetConnectionString());
     }
 }

--- a/tests/Testcontainers.Weaviate.Tests/WeaviateContainerTest.cs
+++ b/tests/Testcontainers.Weaviate.Tests/WeaviateContainerTest.cs
@@ -29,5 +29,6 @@ public sealed class WeaviateContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+        Assert.Equal(_weaviateContainer.GetBaseAddress(), _weaviateContainer.GetConnectionString());
     }
 }

--- a/tests/Testcontainers.WebDriver.Tests/Usings.cs
+++ b/tests/Testcontainers.WebDriver.Tests/Usings.cs
@@ -3,6 +3,7 @@ global using System.IO;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Commons;
+global using DotNet.Testcontainers.Configurations;
 global using DotNet.Testcontainers.Containers;
 global using JetBrains.Annotations;
 global using OpenQA.Selenium.Chrome;

--- a/tests/Testcontainers.WebDriver.Tests/WebDriverContainerTest.cs
+++ b/tests/Testcontainers.WebDriver.Tests/WebDriverContainerTest.cs
@@ -51,6 +51,7 @@ public abstract class WebDriverContainerTest : IAsyncLifetime
 
         // Then
         Assert.Equal("Hello world", headingElementText);
+        Assert.Equal(_webDriverContainer.GetConnectionString(), _webDriverContainer.GetConnectionString(ConnectionMode.Host));
     }
 
     protected virtual async ValueTask DisposeAsyncCore()


### PR DESCRIPTION
## What does this PR do?

This PR adds a default connection string provider to the modules. The provider delegates the `GetConnectionString()` API to the module-specific method, ensuring all modules use a consistent approach to retrieving connection strings. For modules with multiple connection strings, only the primary connection string is resolved. Additional connection strings can be supported in future PRs using the named connection string feature (for this PR out-of-scope).

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #1630

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->
