### PR TITLE
chore: Bump Docker Engine API to 1.52

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -63,7 +63,7 @@ jobs:
 
     env:
       # Lowest API version that GitHub runners support.
-      DOCKER_API_VERSION: 1.47
+      DOCKER_API_VERSION: 1.52
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## What does this PR do?

The GitHub-hosted runners have updated Docker. The Docker Engine is now v29, which corresponds to the Docker Engine API 1.52. This PR updates the CI configuration to bump the pinned version. This version is now the one Docker.DotNet is built against. No version downgrade.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/actions/runner-images/issues/13474

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure version to improve build reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->