### PR TITLE
fix(ResourceReaper): Set wait strategy

### DIFF
--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -304,6 +304,7 @@ namespace DotNet.Testcontainers.Containers
 
         using (var tcpClient = new TcpClient())
         {
+          tcpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
           tcpClient.LingerState = DiscardAllPendingData;
 
           try

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -56,14 +56,15 @@ namespace DotNet.Testcontainers.Containers
     private ResourceReaper(Guid sessionId, IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig, IImage resourceReaperImage, IMount dockerSocket, ILogger logger, bool requiresPrivilegedMode)
     {
       _resourceReaperContainer = new ContainerBuilder(resourceReaperImage)
-        .WithName($"testcontainers-ryuk-{sessionId:D}")
         .WithDockerEndpoint(dockerEndpointAuthConfig)
+        .WithName($"testcontainers-ryuk-{sessionId:D}")
         .WithPrivileged(requiresPrivilegedMode)
         .WithAutoRemove(true)
         .WithCleanUp(false)
         .WithPortBinding(TestcontainersSettings.ResourceReaperPublicHostPort.Invoke(dockerEndpointAuthConfig), RyukPort)
         .WithMount(dockerSocket)
         .WithLogger(logger)
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Started"))
         .Build();
 
       SessionId = sessionId;
@@ -364,7 +365,7 @@ namespace DotNet.Testcontainers.Containers
 #pragma warning restore S907
                   }
 
-                  var indexOfNewLine = Array.IndexOf(readBytes, (byte)'\n');
+                  var indexOfNewLine = Array.IndexOf(readBytes, (byte)'\n', 0, numberOfBytes);
 
                   if (indexOfNewLine == -1)
                   {
@@ -389,7 +390,9 @@ namespace DotNet.Testcontainers.Containers
                       .ConfigureAwait(false);
 #endif
 
-                    hasAcknowledge = "ack".Equals(Encoding.ASCII.GetString(messageBuffer.ToArray()), StringComparison.OrdinalIgnoreCase);
+                    var buffer = messageBuffer.GetBuffer();
+
+                    hasAcknowledge = "ack".Equals(Encoding.ASCII.GetString(buffer, 0, (int)messageBuffer.Length), StringComparison.OrdinalIgnoreCase);
                     messageBuffer.SetLength(0);
                   }
                 }


### PR DESCRIPTION
## What does this PR do?

The PR adds a wait strategy to the resource reaper configuration. The current retry implementation doesn't seem to work reliably in some environments. It's also no longer necessary, and much of the existing resource reaper implementation can be refactored, replaced, and simplified using the module API. Something I'll do in the future.

Adding the wait strategy ensures the container and service are fully up and accepting connections, making it more reliable to establish and maintain the Ryuk connection.

## Why is it important?

Makes sure users don't run into issues when the sidecar container Ryuk starts.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1631

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container readiness detection to avoid startup races.
  * More reliable socket communication and buffer parsing to reduce connection and parsing errors.

* **Improvements**
  * Better detection and fallback for Docker socket location with an override option.
  * Strengthened TCP handling for more robust connection stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->