### PR TITLE
fix(ServiceBus): Ignore runtime property to support reuse

### DIFF
--- a/src/Testcontainers.ServiceBus/ServiceBusConfiguration.cs
+++ b/src/Testcontainers.ServiceBus/ServiceBusConfiguration.cs
@@ -57,5 +57,6 @@ public sealed class ServiceBusConfiguration : ContainerConfiguration
     /// <summary>
     /// Gets the database container.
     /// </summary>
+    [JsonIgnore]
     public IDatabaseContainer DatabaseContainer { get; }
 }

--- a/src/Testcontainers.ServiceBus/Usings.cs
+++ b/src/Testcontainers.ServiceBus/Usings.cs
@@ -3,6 +3,7 @@ global using System.Collections.Generic;
 global using System.Diagnostics.CodeAnalysis;
 global using System.IO;
 global using System.Linq;
+global using System.Text.Json.Serialization;
 global using Docker.DotNet.Models;
 global using DotNet.Testcontainers.Builders;
 global using DotNet.Testcontainers.Configurations;


### PR DESCRIPTION
## What does this PR do?

Makes the configuration hash of ServiceBusContainer stable by removing the IDatabaseContainer from the hashed configuration.

## Why is it important?

The IDatabaseContainer contains runtime information about the database container such as the start time which changes everytime, resulting in an always changing configuration hash, which breaks the Resource Reuse feature for ServiceBus containers.

## Related issues

- Relates #1642

## How to test this PR

Since this concerns cross-execution tests, an automated test would become quite convoluted. The easiest way to test this is to temporarily modify the configurations on ServiceBusCustomMsSqlConfiguration and DatabaseFixture to both use .WithReuse(true) and running the test twice. The first execution should create the containers and the second should reuse them.

## Follow-ups

An analogous change needs to be made for EventHubs. I will do it in a separate PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Service Bus configuration JSON serialization handling to prevent unintended property export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->