### PR TITLE
fix(EventHubs): Ignore runtime property to support reuse

### DIFF
--- a/src/Testcontainers.EventHubs/EventHubsConfiguration.cs
+++ b/src/Testcontainers.EventHubs/EventHubsConfiguration.cs
@@ -61,6 +61,7 @@ public sealed class EventHubsConfiguration : ContainerConfiguration
     /// <summary>
     /// Gets the Azurite container.
     /// </summary>
+    [JsonIgnore]
     public AzuriteContainer AzuriteContainer { get; }
 
     /// <summary>

--- a/src/Testcontainers.EventHubs/Usings.cs
+++ b/src/Testcontainers.EventHubs/Usings.cs
@@ -5,6 +5,7 @@ global using System.Diagnostics.CodeAnalysis;
 global using System.Linq;
 global using System.Text;
 global using System.Text.Json;
+global using System.Text.Json.Serialization;
 global using Docker.DotNet.Models;
 global using DotNet.Testcontainers;
 global using DotNet.Testcontainers.Builders;


### PR DESCRIPTION
## What does this PR do?

Makes the configuration hash of EventHubsContainer stable by removing the AzeriteContainer from the hashed configuration.

## Why is it important?

The AzeriteContainer contains runtime information about the database container such as the start time which changes everytime, resulting in an always changing configuration hash, which breaks the Resource Reuse feature for EventHubs containers.

## Related issues

- Closes #1642

## How to test this PR

Since this concerns cross-execution tests, an automated test would become quite convoluted. The easiest way to test this is to temporarily modify the configurations on EventHubsCustomAzuriteConfiguration and DatabaseFixture to both use .WithReuse(true) and running the test twice. The first execution should create the containers and the second should reuse them.

## Follow-ups

Issue #1642 can be closed after this and #1643 are merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JSON serialization configuration for EventHubsConfiguration to exclude the AzuriteContainer property from serialization output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->