### PR TITLE
fix: Do not enforce policies for admins

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Default owners for all paths in this repository.
 
-* @testcontainers/dotnet-team
+* @HofmeisterAn
 
 # Documentation can additionally be reviewed by OSS maintainers.
 
-/docs/ @testcontainers/oss-team
+/docs/ @testcontainers/dotnet-team

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -144,9 +144,6 @@ teams:
   - name: dotnet-team
     permission: admin
 
-  - name: oss-team
-    permission: maintain
-
     # The permission to grant the team. Can be one of:
     # * `pull` - can pull, but not push to or administer this repository.
     # * `push` - can pull and push, but not administer this repository.
@@ -178,7 +175,7 @@ branches:
         # Required. The list of status checks to require in order to merge into this branch
         contexts: [ test-report ]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: true
+      enforce_admins: false
       # Prevent merge commits from being pushed to matching branches
       required_linear_history: true
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
@@ -210,7 +207,7 @@ branches:
         # Required. The list of status checks to require in order to merge into this branch
         contexts: [ test-report ]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: true
+      enforce_admins: false
       # Prevent merge commits from being pushed to matching branches
       required_linear_history: true
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.


### PR DESCRIPTION
## What does this PR do?

With the integration of the OpenSSF Scorecard, we updated the repository settings, which resulted in admins no longer being able to approve and merge their own PRs. Due to the lack of maintainers, this is unfortunately necessary. This PR reverts the changes and does not enforce the policies for admins.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration and team ownership settings to streamline project management.
  * Adjusted branch protection enforcement policies for enhanced repository stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->