### PR TITLE
feat: Enable Dependabot for NuGet (repo)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     labels:
       - dependencies
     groups:
@@ -11,16 +11,25 @@ updates:
         patterns:
           - '*'
   - package-ecosystem: nuget
-    directory: /src
+    directory: /
+    exclude-paths:
+      - examples/**
+    open-pull-requests-limit: 3
     schedule:
-      interval: weekly
+      interval: monthly
     labels:
       - dependencies
     ignore:
+      - dependency-name: Cake.*
+        update-types:
+          - version-update:semver-major
       - dependency-name: Microsoft.Bcl.*
         update-types:
           - version-update:semver-major
       - dependency-name: Microsoft.Extensions.*
+        update-types:
+          - version-update:semver-major
+      - dependency-name: xunit*
         update-types:
           - version-update:semver-major
     groups:


### PR DESCRIPTION
## What does this PR do?

The previously used Dependabot configuration was too narrow for NuGet and did not run properly. This configuration enables Dependabot for the entire repository, excluding the examples. It also prevents Dependabot from bumping major versions for Cake and xUnit. For these packages, I want to ensure that we use versions that are compatible with each other. For xUnit, we cannot simply bump version 2 because we need to keep it explicitly for our xUnit v2 module.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration schedules from weekly to monthly intervals.
  * Adjusted dependency update rules and limits for improved release stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->