### PR TITLE
fix(MongoDb): Wait for post-init startup readiness before replica set initiation

### DIFF
--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -198,6 +198,8 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
             return;
         }
 
+        var readiness = new WaitIndicateReadiness(configuration);
+
         // This is a simple workaround to use the default options, which can be configured
         // with custom configurations as needed.
         var options = new WaitStrategy();
@@ -211,6 +213,14 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
 
             return 0L.Equals(execResult.ExitCode);
         };
+
+        // The official MongoDB image starts mongod twice during the first-time
+        // initialization (bootstrap + final process). Waiting here prevents the
+        // replica set from being initiated while this handover is in progress,
+        // which could otherwise cause the container start to fail:
+        // https://github.com/testcontainers/testcontainers-dotnet/issues/1636.
+        await WaitStrategy.WaitUntilAsync(() => readiness.UntilAsync(container), options.Interval, options.Timeout, options.Retries, ct)
+            .ConfigureAwait(false);
 
         await WaitStrategy.WaitUntilAsync(initiate, options.Interval, options.Timeout, options.Retries, ct)
             .ConfigureAwait(false);


### PR DESCRIPTION
## What does this PR do?

The PR changes how the MongoDB replica set is initiated. Instead of initiating it immediately, it now waits until the final process is running.

The official MongoDB image starts `mongod` twice during the first-time initialization (bootstrap + final process). Waiting prevents the replica set from being initiated while this handover is in progress, which could otherwise cause the container startup to fail (container exits).

## Why is it important?

We occasionally saw MongoDB tests fail because the container exited during startup with:

    {"msg":"Error setting up listener","attr":{"error":{"code":9001,"codeName":"SocketException","errmsg":"Address already in use"}}}

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1636

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MongoDB replica set initialization reliability by adding a readiness check before starting the replica set setup, preventing potential startup conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->