### PR TITLE
fix: Run OpenSSF Scorecard only on default branch

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -2,7 +2,7 @@ name: OpenSSF Scorecard
 
 on:
   push:
-    branches: [ develop, main ]
+    branches: [ develop ]
     paths-ignore: [ 'docs/**', 'examples/**' ]
 
 concurrency:


### PR DESCRIPTION
## What does this PR do?

OpenSSF Scorecard failed on the `main` branch. This PR removes the on `main` push event.

    Only the default branch develop is supported.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified continuous integration workflow configuration to adjust when automated analysis is triggered on development branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->