### PR TITLE
docs(CosmosDb): Replace unsupported tag 'latest' with 'vnext-preview'

### DIFF
--- a/src/Testcontainers.CosmosDb/CosmosDbBuilder.cs
+++ b/src/Testcontainers.CosmosDb/CosmosDbBuilder.cs
@@ -26,7 +26,7 @@ public sealed class CosmosDbBuilder : ContainerBuilder<CosmosDbBuilder, CosmosDb
     /// </summary>
     /// <param name="image">
     /// The full Docker image name, including the image repository and tag
-    /// (e.g., <c>mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest</c>).
+    /// (e.g., <c>mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:vnext-preview</c>).
     /// </param>
     /// <remarks>
     /// Docker image tags available at <see href="https://hub.docker.com/r/microsoft/azure-cosmosdb-emulator" />.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sample image tag references in CosmosDB builder documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->