### PR TITLE
chore(deps): Bump Docker.DotNet from 3.131.1 to 4.0.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="3.131.1"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.131.1"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="4.0.2"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced" Version="4.0.2"/>
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
         <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1"/>
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3"/>

--- a/src/Testcontainers/Builders/DockerEndpointAuthenticationProvider.cs
+++ b/src/Testcontainers/Builders/DockerEndpointAuthenticationProvider.cs
@@ -39,26 +39,23 @@ namespace DotNet.Testcontainers.Builders
 
       return TaskFactory.StartNew(async () =>
         {
-          using (var dockerClientConfiguration = authConfig.GetDockerClientConfiguration(ResourceReaper.DefaultSessionId))
+          using (var dockerClient = authConfig.GetDockerClientBuilder(ResourceReaper.DefaultSessionId).Build())
           {
-            using (var dockerClient = dockerClientConfiguration.CreateClient(authConfig.Version))
+            try
             {
-              try
-              {
-                await dockerClient.System.PingAsync()
-                  .ConfigureAwait(false);
+              await dockerClient.System.PingAsync()
+                .ConfigureAwait(false);
 
-                _cachedException = null;
+              _cachedException = null;
 
-                return true;
-              }
-              catch (Exception e)
-              {
-                var message = $"Failed to connect to Docker endpoint at '{dockerClientConfiguration.EndpointBaseUri}'.";
-                _cachedException = new DockerUnavailableException(message, e);
+              return true;
+            }
+            catch (Exception e)
+            {
+              var message = $"Failed to connect to Docker endpoint at '{dockerClient.Options.Endpoint}'.";
+              _cachedException = new DockerUnavailableException(message, e);
 
-                return false;
-              }
+              return false;
             }
           }
         })

--- a/src/Testcontainers/Builders/TlsCredentials.cs
+++ b/src/Testcontainers/Builders/TlsCredentials.cs
@@ -1,26 +1,12 @@
 namespace DotNet.Testcontainers.Builders
 {
-  using System.Net.Http;
   using Docker.DotNet.X509;
-  using Microsoft.Net.Http.Client;
 
   internal sealed class TlsCredentials : CertificateCredentials
   {
     public TlsCredentials()
       : base(null)
     {
-    }
-
-    public override bool IsTlsCredentials()
-    {
-      return true;
-    }
-
-    public override HttpMessageHandler GetHandler(HttpMessageHandler handler)
-    {
-      var managedHandler = (ManagedHandler)handler;
-      managedHandler.ServerCertificateValidationCallback = ServerCertificateValidationCallback;
-      return managedHandler;
     }
   }
 }

--- a/src/Testcontainers/Clients/DockerApiClient.cs
+++ b/src/Testcontainers/Clients/DockerApiClient.cs
@@ -93,7 +93,7 @@ namespace DotNet.Testcontainers.Clients
         runtimeInfo.AppendLine("Connected to Docker:");
 
         runtimeInfo.Append("  Host: ");
-        runtimeInfo.AppendLine(DockerClient.Configuration.EndpointBaseUri.ToString());
+        runtimeInfo.AppendLine(DockerClient.Options.Endpoint.ToString());
 
         runtimeInfo.Append("  Server Version: ");
         runtimeInfo.AppendLine(dockerInfo.ServerVersion);
@@ -133,10 +133,8 @@ namespace DotNet.Testcontainers.Clients
 
     private static IDockerClient GetDockerClient(Guid sessionId, IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig)
     {
-      using (var dockerClientConfiguration = dockerEndpointAuthConfig.GetDockerClientConfiguration(sessionId))
-      {
-        return dockerClientConfiguration.CreateClient(dockerEndpointAuthConfig.Version);
-      }
+      var dockerClientBuilder = dockerEndpointAuthConfig.GetDockerClientBuilder(sessionId);
+      return dockerClientBuilder.Build();
     }
   }
 }

--- a/src/Testcontainers/Configurations/AuthConfigs/DockerEndpointAuthenticationConfiguration.cs
+++ b/src/Testcontainers/Configurations/AuthConfigs/DockerEndpointAuthenticationConfiguration.cs
@@ -3,6 +3,8 @@ namespace DotNet.Testcontainers.Configurations
   using System;
   using System.Collections.Generic;
   using Docker.DotNet;
+  using Docker.DotNet.Handler.Abstractions;
+  using Docker.DotNet.NPipe;
   using DotNet.Testcontainers.Clients;
   using JetBrains.Annotations;
 
@@ -15,22 +17,22 @@ namespace DotNet.Testcontainers.Configurations
 
     // Since the static `TestcontainersSettings` class holds the detected container
     // runtime information from the auto-discovery mechanism, we can't add a static
-    // `NamedPipeConnectionTimeout` property to it because that would create a
+    // `NPipeConnectTimeout` property to it because that would create a
     // circular dependency during discovery. To fix this, we either need to split the
     // class or stop exposing the `TestcontainersSettings` properties publicly.
     // Instead, we could rely only on custom configurations via environment variables
     // or the properties file.
-    private static readonly TimeSpan NamedPipeConnectionTimeout = EnvironmentConfiguration.Instance.GetNamedPipeConnectionTimeout() ?? PropertiesFileConfiguration.Instance.GetNamedPipeConnectionTimeout() ?? TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan NPipeConnectTimeout = EnvironmentConfiguration.Instance.GetNamedPipeConnectionTimeout() ?? PropertiesFileConfiguration.Instance.GetNamedPipeConnectionTimeout() ?? TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerEndpointAuthenticationConfiguration" /> struct.
     /// </summary>
     /// <param name="endpoint">The Docker API endpoint.</param>
-    /// <param name="credentials">The Docker API authentication credentials.</param>
-    public DockerEndpointAuthenticationConfiguration(Uri endpoint, Credentials credentials = null)
+    /// <param name="credentials">The Docker API authentication provider.</param>
+    public DockerEndpointAuthenticationConfiguration(Uri endpoint, IAuthProvider credentials = null)
     {
       Endpoint = endpoint;
-      Credentials = credentials;
+      AuthProvider = credentials;
     }
 
     /// <inheritdoc />
@@ -40,16 +42,33 @@ namespace DotNet.Testcontainers.Configurations
     public Uri Endpoint { get; }
 
     /// <inheritdoc />
-    public Credentials Credentials { get; }
+    public IAuthProvider AuthProvider { get; }
 
     /// <inheritdoc />
-    public DockerClientConfiguration GetDockerClientConfiguration(Guid sessionId = default)
+    public DockerClientBuilder GetDockerClientBuilder(Guid sessionId = default)
     {
-      var defaultHttpRequestHeaders = new Dictionary<string, string>();
-      defaultHttpRequestHeaders.Add("User-Agent", "tc-dotnet/" + TestcontainersClient.Version);
-      defaultHttpRequestHeaders.Add("x-tc-sid", sessionId.ToString("D"));
+      var headers = new Dictionary<string, string>();
+      headers.Add("User-Agent", "tc-dotnet/" + TestcontainersClient.Version);
+      headers.Add("x-tc-sid", sessionId.ToString("D"));
 
-      return new DockerClientConfiguration(Endpoint, Credentials, namedPipeConnectTimeout: NamedPipeConnectionTimeout, defaultHttpRequestHeaders: defaultHttpRequestHeaders);
+      var dockerClientBuilder = new DockerClientBuilder()
+        .WithApiVersion(Version)
+        .WithEndpoint(Endpoint)
+        .WithAuthProvider(AuthProvider)
+        .WithHeaders(headers);
+
+      if ("npipe".Equals(Endpoint.Scheme, StringComparison.OrdinalIgnoreCase))
+      {
+        var transportOptions = new NPipeTransportOptions
+        {
+          ConnectTimeout = NPipeConnectTimeout,
+        };
+
+        dockerClientBuilder = dockerClientBuilder
+          .WithTransportOptions(transportOptions);
+      }
+
+      return dockerClientBuilder;
     }
   }
 }

--- a/src/Testcontainers/Configurations/AuthConfigs/DockerEndpointAuthenticationConfiguration.cs
+++ b/src/Testcontainers/Configurations/AuthConfigs/DockerEndpointAuthenticationConfiguration.cs
@@ -28,11 +28,11 @@ namespace DotNet.Testcontainers.Configurations
     /// Initializes a new instance of the <see cref="DockerEndpointAuthenticationConfiguration" /> struct.
     /// </summary>
     /// <param name="endpoint">The Docker API endpoint.</param>
-    /// <param name="credentials">The Docker API authentication provider.</param>
-    public DockerEndpointAuthenticationConfiguration(Uri endpoint, IAuthProvider credentials = null)
+    /// <param name="authProvider">The Docker API authentication provider.</param>
+    public DockerEndpointAuthenticationConfiguration(Uri endpoint, IAuthProvider authProvider = null)
     {
       Endpoint = endpoint;
-      AuthProvider = credentials;
+      AuthProvider = authProvider;
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Configurations/AuthConfigs/IDockerEndpointAuthenticationConfiguration.cs
+++ b/src/Testcontainers/Configurations/AuthConfigs/IDockerEndpointAuthenticationConfiguration.cs
@@ -2,6 +2,7 @@ namespace DotNet.Testcontainers.Configurations
 {
   using System;
   using Docker.DotNet;
+  using Docker.DotNet.Handler.Abstractions;
   using JetBrains.Annotations;
 
   /// <summary>
@@ -23,17 +24,17 @@ namespace DotNet.Testcontainers.Configurations
     Uri Endpoint { get; }
 
     /// <summary>
-    /// Gets the Docker API credentials.
+    /// Gets the Docker API authentication provider.
     /// </summary>
     [CanBeNull]
-    Credentials Credentials { get; }
+    IAuthProvider AuthProvider { get; }
 
     /// <summary>
-    /// Gets the Docker client configuration.
+    /// Gets the Docker client builder.
     /// </summary>
     /// <param name="sessionId">The session id.</param>
-    /// <returns>The Docker client configuration.</returns>
+    /// <returns>The Docker client builder.</returns>
     [NotNull]
-    DockerClientConfiguration GetDockerClientConfiguration(Guid sessionId = default);
+    DockerClientBuilder GetDockerClientBuilder(Guid sessionId = default);
   }
 }

--- a/tests/Testcontainers.Platform.Linux.Tests/DependsOnTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/DependsOnTest.cs
@@ -62,9 +62,7 @@ public sealed class DependsOnTest : IAsyncLifetime
     public async Task DependsOnCreatesDependentResources()
     {
         // Given
-        using var clientConfiguration = TestcontainersSettings.OS.DockerEndpointAuthConfig.GetDockerClientConfiguration(Guid.NewGuid());
-
-        using var client = clientConfiguration.CreateClient();
+        using var dockerClient = TestcontainersSettings.OS.DockerEndpointAuthConfig.GetDockerClientBuilder(Guid.NewGuid()).Build();
 
         var containersListParameters = new ContainersListParameters { All = true, Filters = _filters };
 
@@ -73,13 +71,13 @@ public sealed class DependsOnTest : IAsyncLifetime
         var volumesListParameters = new VolumesListParameters { Filters = _filters };
 
         // When
-        var containers = await client.Containers.ListContainersAsync(containersListParameters, TestContext.Current.CancellationToken)
+        var containers = await dockerClient.Containers.ListContainersAsync(containersListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var networks = await client.Networks.ListNetworksAsync(networksListParameters, TestContext.Current.CancellationToken)
+        var networks = await dockerClient.Networks.ListNetworksAsync(networksListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var response = await client.Volumes.ListAsync(volumesListParameters, TestContext.Current.CancellationToken)
+        var response = await dockerClient.Volumes.ListAsync(volumesListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then

--- a/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ReusableResourceTest.cs
@@ -73,9 +73,7 @@ public sealed class ReusableResourceTest : IAsyncLifetime
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
     public async Task ShouldReuseExistingResource()
     {
-        using var clientConfiguration = TestcontainersSettings.OS.DockerEndpointAuthConfig.GetDockerClientConfiguration(Guid.NewGuid());
-
-        using var client = clientConfiguration.CreateClient();
+        using var dockerClient = TestcontainersSettings.OS.DockerEndpointAuthConfig.GetDockerClientBuilder(Guid.NewGuid()).Build();
 
         var containersListParameters = new ContainersListParameters { All = true, Filters = _filters };
 
@@ -83,13 +81,13 @@ public sealed class ReusableResourceTest : IAsyncLifetime
 
         var volumesListParameters = new VolumesListParameters { Filters = _filters };
 
-        var containers = await client.Containers.ListContainersAsync(containersListParameters, TestContext.Current.CancellationToken)
+        var containers = await dockerClient.Containers.ListContainersAsync(containersListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var networks = await client.Networks.ListNetworksAsync(networksListParameters, TestContext.Current.CancellationToken)
+        var networks = await dockerClient.Networks.ListNetworksAsync(networksListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        var response = await client.Volumes.ListAsync(volumesListParameters, TestContext.Current.CancellationToken)
+        var response = await dockerClient.Volumes.ListAsync(volumesListParameters, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         Assert.Single(containers);

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerEndpointAuthenticationProviderTest.cs
@@ -39,11 +39,9 @@ namespace DotNet.Testcontainers.Tests.Unit
     [ClassData(typeof(AuthConfigTestData))]
     internal void AuthConfigShouldGetDockerClientEndpoint(IDockerEndpointAuthenticationConfiguration authConfig, Uri dockerClientEndpoint)
     {
-      using (var dockerClientConfiguration = authConfig.GetDockerClientConfiguration())
-      {
-        Assert.Equal(dockerClientEndpoint, authConfig.Endpoint);
-        Assert.Equal(dockerClientEndpoint, dockerClientConfiguration.EndpointBaseUri);
-      }
+      var dockerClient = authConfig.GetDockerClientBuilder().Build();
+      Assert.Equal(dockerClientEndpoint, authConfig.Endpoint);
+      Assert.Equal(dockerClientEndpoint, dockerClient.Options.Endpoint);
     }
 
     public sealed class TestcontainersHostEndpointAuthenticationProviderTest

--- a/tests/Testcontainers.Tests/Unit/Containers/Unix/ProtectDockerDaemonSocketTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Containers/Unix/ProtectDockerDaemonSocketTest.cs
@@ -4,6 +4,7 @@ namespace DotNet.Testcontainers.Tests.Unit
   using System.Linq;
   using System.Threading.Tasks;
   using Docker.DotNet;
+  using Docker.DotNet.Handler.Abstractions;
   using DotNet.Testcontainers.Builders;
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Configurations;
@@ -41,11 +42,11 @@ namespace DotNet.Testcontainers.Tests.Unit
       public Uri Endpoint
         => _authConfig.Endpoint;
 
-      public Credentials Credentials
-        => _authConfig.Credentials;
+      public IAuthProvider AuthProvider
+        => _authConfig.AuthProvider;
 
-      public DockerClientConfiguration GetDockerClientConfiguration(Guid sessionId = default)
-        => _authConfig.GetDockerClientConfiguration(sessionId);
+      public DockerClientBuilder GetDockerClientBuilder(Guid sessionId = default)
+        => _authConfig.GetDockerClientBuilder(sessionId).WithApiVersion(Version);
 
       [Fact]
       public async Task GetVersionReturnsVersion()


### PR DESCRIPTION
## What does this PR do?

This PR upgrades Docker.DotNet to the latest major version. The new release introduces a client builder API along with numerous internal improvements and fixes.

Due to changes in Docker.DotNet, the `IDockerEndpointAuthenticationConfiguration` interface has been updated to use the new types introduced by the library. This interface is publicly exposed via `WithDockerEndpoint(IDockerEndpointAuthenticationConfiguration)`, most users don't use this API.

This breaking change is unlikely to affect users or developers. In most cases, the container runtime is resolved through the auto-discovery mechanism and/or configured via environment variables or the properties file (`~/.testcontainers.properties`).

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Dependencies**
  * Upgraded Docker.DotNet.Enhanced packages to version 4.0.2, providing updated Docker API compatibility.

* **Refactor**
  * Modernized Docker client initialization pattern for improved maintainability.
  * Simplified TLS credentials handling by removing legacy custom handler customization.
  * Updated named-pipe connection timeout configuration for better reliability on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->