### PR TITLE
fix: Remove KeepAlive socket option

### DIFF
--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -304,7 +304,8 @@ namespace DotNet.Testcontainers.Containers
 
         using (var tcpClient = new TcpClient())
         {
-          tcpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+          // On some plateform the connection fail with PlatformNotSupportedException: Sockets on this platform are invalid for use after a failed connection attempt.
+          // tcpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
           tcpClient.LingerState = DiscardAllPendingData;
 
           try


### PR DESCRIPTION
## What does this PR do?

On some platform the TCPClient fail to connect because of KeepAlive settings.

## Why is it important?

If the client fail to connect, TestContainer does not work at all.

## Related issues

Relates https://github.com/dotnet/runtime/issues/24917
Closes https://github.com/testcontainers/testcontainers-dotnet/issues/1670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of resource connection stability on certain platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->