### PR TITLE
chore(deps): Bump Docker.DotNet from 4.0.2 to 4.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="4.0.2"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced" Version="4.0.2"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="4.1.0"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced" Version="4.1.0"/>
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
         <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1"/>
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying dependencies to the latest versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->