### PR TITLE
fix(Nats): Use healthz API for readiness probe

### DIFF
--- a/src/Testcontainers.Nats/NatsBuilder.cs
+++ b/src/Testcontainers.Nats/NatsBuilder.cs
@@ -110,7 +110,7 @@ public sealed class NatsBuilder : ContainerBuilder<NatsBuilder, NatsContainer, N
             .WithCommand("--debug")
             .WithCommand("--trace")
             .WithConnectionStringProvider(new NatsConnectionStringProvider())
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Server is ready"));
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request.ForPort(8222).ForPath("/healthz")));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Nats/NatsBuilder.cs
+++ b/src/Testcontainers.Nats/NatsBuilder.cs
@@ -110,7 +110,8 @@ public sealed class NatsBuilder : ContainerBuilder<NatsBuilder, NatsContainer, N
             .WithCommand("--debug")
             .WithCommand("--trace")
             .WithConnectionStringProvider(new NatsConnectionStringProvider())
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request.ForPort(NatsHttpManagementPort).ForPath("/healthz")));
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
+                request.ForPath("/healthz").ForPort(NatsHttpManagementPort)));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers.Nats/NatsBuilder.cs
+++ b/src/Testcontainers.Nats/NatsBuilder.cs
@@ -110,7 +110,7 @@ public sealed class NatsBuilder : ContainerBuilder<NatsBuilder, NatsContainer, N
             .WithCommand("--debug")
             .WithCommand("--trace")
             .WithConnectionStringProvider(new NatsConnectionStringProvider())
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request.ForPort(8222).ForPath("/healthz")));
+            .WithWaitStrategy(Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request => request.ForPort(NatsHttpManagementPort).ForPath("/healthz")));
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## What does this PR do?

This PR changes the wait strategy to await a 200 OK for the /healthz endpoint, rather than simply checking the logs on the container.

## Why is it important?

When using the Nats Testcontainer, the `StartAsync()` returns before the container is ready to accept connections, resulting in `NATS.Client.Core.NatsException: can not connect uris: nats://127.0.0.1:<<port>>`. This is a problem on OSX with Rancher Desktop, not sure if it's a problem with Docker Desktop. Talking to NATS Server (see issue below) they recommend waiting differently.

## Related issues

- Relates [Issue in NATS.IO](https://github.com/nats-io/nats-server/issues/8033#issuecomment-4250766353)

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NATS container startup detection: confirms readiness via HTTP health check (GET /healthz on management port 8222) instead of relying on container log output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->