### PR TITLE
fix: Trim tar record padding to avoid broken-pipe failure on Podman

### DIFF
--- a/Testcontainers.slnx
+++ b/Testcontainers.slnx
@@ -66,7 +66,7 @@
         <Project Path="src/Testcontainers.Seq/Testcontainers.Seq.csproj"/>
         <Project Path="src/Testcontainers.ServiceBus/Testcontainers.ServiceBus.csproj"/>
         <Project Path="src/Testcontainers.Sftp/Testcontainers.Sftp.csproj"/>
-        <Project Path="src/Testcontainers.Temporalio/Testcontainers.Temporalio.csproj"/>
+        <Project Path="src/Testcontainers.Temporal/Testcontainers.Temporal.csproj"/>
         <Project Path="src/Testcontainers.Toxiproxy/Testcontainers.Toxiproxy.csproj"/>
         <Project Path="src/Testcontainers.Typesense/Testcontainers.Typesense.csproj"/>
         <Project Path="src/Testcontainers.Weaviate/Testcontainers.Weaviate.csproj"/>
@@ -139,7 +139,7 @@
         <Project Path="tests/Testcontainers.Seq.Tests/Testcontainers.Seq.Tests.csproj"/>
         <Project Path="tests/Testcontainers.ServiceBus.Tests/Testcontainers.ServiceBus.Tests.csproj"/>
         <Project Path="tests/Testcontainers.Sftp.Tests/Testcontainers.Sftp.Tests.csproj"/>
-        <Project Path="tests/Testcontainers.Temporalio.Tests/Testcontainers.Temporalio.Tests.csproj"/>
+        <Project Path="tests/Testcontainers.Temporal.Tests/Testcontainers.Temporal.Tests.csproj"/>
         <Project Path="tests/Testcontainers.Tests/Testcontainers.Tests.csproj"/>
         <Project Path="tests/Testcontainers.Toxiproxy.Tests/Testcontainers.Toxiproxy.Tests.csproj"/>
         <Project Path="tests/Testcontainers.Typesense.Tests/Testcontainers.Typesense.Tests.csproj"/>

--- a/src/Testcontainers/Containers/TarOutputMemoryStream.cs
+++ b/src/Testcontainers/Containers/TarOutputMemoryStream.cs
@@ -36,7 +36,13 @@ namespace DotNet.Testcontainers.Containers
     /// </summary>
     /// <param name="logger">The logger.</param>
     public TarOutputMemoryStream(ILogger logger)
-      : base(new MemoryStream(), Encoding.Default)
+      // blockFactor:1 keeps record size == block size (512 B), so SharpZipLib writes no
+      // trailing zero-padding beyond the two standard EOF blocks. The default factor of 20
+      // produces ~8 KB of post-EOF zeros that trigger a race in Podman's archive handler:
+      // the tar subprocess exits after the EOF blocks while the HTTP sender is still
+      // flushing the padding, causing EPIPE (HTTP 500 "broken pipe").
+      // See: https://github.com/testcontainers/testcontainers-dotnet/issues/1683
+      : base(new MemoryStream(), blockFactor: 1, Encoding.Default)
     {
       _logger = logger;
       IsStreamOwner = false;

--- a/src/Testcontainers/Containers/TarOutputMemoryStream.cs
+++ b/src/Testcontainers/Containers/TarOutputMemoryStream.cs
@@ -14,6 +14,8 @@ namespace DotNet.Testcontainers.Containers
   /// </summary>
   public sealed class TarOutputMemoryStream : TarOutputStream
   {
+    public const int TarBlockFactor = 1;
+
     private readonly string _targetDirectoryPath;
 
     private readonly ILogger _logger;
@@ -36,13 +38,14 @@ namespace DotNet.Testcontainers.Containers
     /// </summary>
     /// <param name="logger">The logger.</param>
     public TarOutputMemoryStream(ILogger logger)
-      // blockFactor:1 keeps record size == block size (512 B), so SharpZipLib writes no
-      // trailing zero-padding beyond the two standard EOF blocks. The default factor of 20
-      // produces ~8 KB of post-EOF zeros that trigger a race in Podman's archive handler:
-      // the tar subprocess exits after the EOF blocks while the HTTP sender is still
-      // flushing the padding, causing EPIPE (HTTP 500 "broken pipe").
-      // See: https://github.com/testcontainers/testcontainers-dotnet/issues/1683
-      : base(new MemoryStream(), blockFactor: 1, Encoding.Default)
+      // TarBlockFactor keeps the record size equal to the block size (512 B),
+      // so SharpZipLib does not write extra zero padding beyond the two standard
+      // EOF blocks. The default factor of 20 produces ~8 KB of zeros after EOF,
+      // which can trigger a race in Podman's archive handler: the tar subprocess
+      // exits after the EOF blocks while the HTTP sender is still flushing the
+      // padding, causing EPIPE (HTTP 500 "broken pipe").
+      // See: https://github.com/testcontainers/testcontainers-dotnet/issues/1683.
+      : base(new MemoryStream(), TarBlockFactor, Encoding.Default)
     {
       _logger = logger;
       IsStreamOwner = false;

--- a/src/Testcontainers/Containers/TarOutputMemoryStream.cs
+++ b/src/Testcontainers/Containers/TarOutputMemoryStream.cs
@@ -14,8 +14,6 @@ namespace DotNet.Testcontainers.Containers
   /// </summary>
   public sealed class TarOutputMemoryStream : TarOutputStream
   {
-    public const int TarBlockFactor = 1;
-
     private readonly string _targetDirectoryPath;
 
     private readonly ILogger _logger;
@@ -38,14 +36,7 @@ namespace DotNet.Testcontainers.Containers
     /// </summary>
     /// <param name="logger">The logger.</param>
     public TarOutputMemoryStream(ILogger logger)
-      // TarBlockFactor keeps the record size equal to the block size (512 B),
-      // so SharpZipLib does not write extra zero padding beyond the two standard
-      // EOF blocks. The default factor of 20 produces ~8 KB of zeros after EOF,
-      // which can trigger a race in Podman's archive handler: the tar subprocess
-      // exits after the EOF blocks while the HTTP sender is still flushing the
-      // padding, causing EPIPE (HTTP 500 "broken pipe").
-      // See: https://github.com/testcontainers/testcontainers-dotnet/issues/1683.
-      : base(new MemoryStream(), TarBlockFactor, Encoding.Default)
+      : base(new MemoryStream(), TarArchiveDefaults.TarBlockFactor, Encoding.Default)
     {
       _logger = logger;
       IsStreamOwner = false;

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -192,7 +192,9 @@ namespace DotNet.Testcontainers.Images
 
       using (var tarOutputFileStream = new FileStream(dockerfileArchiveFilePath, FileMode.Create, FileAccess.Write))
       {
-        using (var tarOutputStream = new TarOutputStream(tarOutputFileStream, Encoding.Default))
+        // Keep the record size equal to the block size (512 B) so SharpZipLib does
+        // not append extra zero padding after the two EOF blocks.
+        using (var tarOutputStream = new TarOutputStream(tarOutputFileStream, TarOutputMemoryStream.TarBlockFactor, Encoding.Default))
         {
           tarOutputStream.IsStreamOwner = false;
 

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -9,7 +9,6 @@ namespace DotNet.Testcontainers.Images
   using System.Threading;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
-  using DotNet.Testcontainers.Containers;
   using ICSharpCode.SharpZipLib.Tar;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
@@ -193,9 +192,7 @@ namespace DotNet.Testcontainers.Images
 
       using (var tarOutputFileStream = new FileStream(dockerfileArchiveFilePath, FileMode.Create, FileAccess.Write))
       {
-        // Keep the record size equal to the block size (512 B) so SharpZipLib does
-        // not append extra zero padding after the two EOF blocks.
-        using (var tarOutputStream = new TarOutputStream(tarOutputFileStream, TarOutputMemoryStream.TarBlockFactor, Encoding.Default))
+        using (var tarOutputStream = new TarOutputStream(tarOutputFileStream, TarArchiveDefaults.TarBlockFactor, Encoding.Default))
         {
           tarOutputStream.IsStreamOwner = false;
 

--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -9,9 +9,10 @@ namespace DotNet.Testcontainers.Images
   using System.Threading;
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Containers;
   using ICSharpCode.SharpZipLib.Tar;
-  using Microsoft.Extensions.Logging;
   using JetBrains.Annotations;
+  using Microsoft.Extensions.Logging;
 
   /// <summary>
   /// Generates a tar archive with Docker configuration files. The tar archive can be used to build a Docker image.

--- a/src/Testcontainers/TarArchiveDefaults.cs
+++ b/src/Testcontainers/TarArchiveDefaults.cs
@@ -1,0 +1,14 @@
+namespace DotNet.Testcontainers
+{
+  internal static class TarArchiveDefaults
+  {
+    // Keep the record size equal to the block size (512 B) so SharpZipLib does
+    // not write extra zero padding beyond the two standard EOF blocks. The
+    // default factor of 20 produces ~8 KB of zeros after EOF, which can trigger
+    // a race in Podman's archive handler. The tar subprocess exits after the EOF
+    // blocks while the HTTP sender is still flushing the padding, causing EPIPE
+    // (HTTP 500 "broken pipe"). See:
+    // https://github.com/testcontainers/testcontainers-dotnet/issues/1683.
+    internal const int TarBlockFactor = 1;
+  }
+}


### PR DESCRIPTION
## Problem

When running MongoDb replica-set tests (or any container that uses `WithResourceMapping`) against a **Podman** daemon, the container start intermittently fails with:

```
Docker.DotNet.DockerApiException : Docker API responded with status code='InternalServerError',
response='{"cause":"broken pipe","message":"passing bulk input to subprocess: write |1: broken pipe","response":500}'
```

The failure is flaky: it's rare on an idle host, but becomes near-certain when other containers using the same image are already running. In the MongoDb test suite specifically, the four replica-set test classes fail while the twelve non-replica-set tests pass, because the replica-set code path is the only one that calls `WithResourceMapping` (to upload a keyfile init script).

## Fix

Set `blockFactor: 1` in `TarOutputMemoryStream`'s base constructor call (`src/Testcontainers/Containers/TarOutputMemoryStream.cs`).

With `blockFactor = 1` the record size equals the block size (512 bytes). Each block is flushed to the underlying `MemoryStream` immediately, and `WriteFinalRecord` finds no partial record to pad. The emitted archive is exactly:

```
[header block 512 B][data block(s) padded to 512 B] × N  +  [EOF block 1 512 B][EOF block 2 512 B]
```

— no trailing padding. After the subprocess reads the second EOF block and exits, the HTTP sender has nothing more to write. The race window is closed.

The on-the-wire format is unchanged in every other respect. The tar specification does not mandate any particular record size for archive consumers; all conformant readers (GNU tar, BSD tar, Go `archive/tar`, Docker's in-process reader, Podman's reader) accept a block factor of 1 archive. This is a strictly smaller byte stream, not a malformed one, so it is safe on Docker as well.

## Impact

- **One file changed, one argument added.** No public API change.
- **All `WithResourceMapping` callers benefit,** not just MongoDb — any module that uploads bytes or files into a container on Podman was susceptible to the same race.
- **Docker behaviour is unchanged** — the padding was always inert for Docker, which reads the tar in-process.
- **Works on Podman versions without the upstream Buildah fix** — which is every shipping Podman release as of this writing.

## Related issues

- Closes #1683

## References

- [containers/buildah#6573] — upstream bug report with exact error string
- [containers/buildah#6678] — upstream fix (not yet released)
- [testcontainers/testcontainers-java#6640] — same symptom in the Java library

[containers/buildah#6573]: https://github.com/containers/buildah/issues/6573
[containers/buildah#6678]: https://github.com/containers/buildah/pull/6678
[testcontainers/testcontainers-java#6640]: https://github.com/testcontainers/testcontainers-java/issues/6640

## Root cause

This is a confirmed race condition in Podman's `containers/buildah` copier package — see **[containers/buildah#6573]**.

Podman's `PUT /containers/{id}/archive` handler pipes the HTTP request body into a tar subprocess via `io.Copy`. The subprocess reads the body through `tar.Reader`; as soon as `Next()` returns `io.EOF` (after the two 512-byte end-of-archive zero blocks), the subprocess exits and closes the read end of the pipe. If the HTTP sender is still writing bytes at that moment, it gets EPIPE → the 500 above.

Our archive producer (`TarOutputMemoryStream`, backed by SharpZipLib's `TarOutputStream`) uses a **block factor of 20** by default, which causes SharpZipLib to pad the finished archive up to the next 10 240-byte record boundary *after* the two EOF zero blocks. For a small file (like the ~100-byte keyfile init script) that produces roughly 8 KB of trailing zero padding that serves no purpose but gives Podman's race condition something to EPIPE on.

The race is timing-dependent: on a busy host the write is slower relative to the read, so the subprocess wins the race more often and the error appears. The upstream Buildah fix (**[containers/buildah#6678]**, merged 2026-02-11) drains the full body before exiting the subprocess, but as of this writing it is not yet included in any tagged Buildah or Podman release.

The same failure has been observed in the testcontainers-java ecosystem: **[testcontainers/testcontainers-java#6640]** (closed as "not planned"; workaround was test-level retry).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced extra padding in generated tar archives to avoid broken-pipe errors and improve compatibility with container runtimes (Podman/Docker).

* **Chores**
  * Updated solution to reference renamed Temporal-related projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->