### PR TITLE
docs: Extend WithCommand(params string[]) documentation

### DIFF
--- a/src/Testcontainers/Builders/IContainerBuilder`2.cs
+++ b/src/Testcontainers/Builders/IContainerBuilder`2.cs
@@ -136,18 +136,34 @@ namespace DotNet.Testcontainers.Builders
     TBuilderEntity WithEntrypoint(params string[] entrypoint);
 
     /// <summary>
-    /// Overrides the container's command arguments.
+    /// Appends command arguments to the container configuration.
     /// </summary>
+    /// <remarks>
+    /// For modules, the specified command arguments are appended to the already pre-configured command.
+    ///
+    /// To overwrite or replace an already pre-configured command, use <see cref="WithCommand(ComposableEnumerable{string})" />
+    /// with <see cref="OverwriteEnumerable{T}" />.
+    ///
+    /// For more information and examples, see
+    /// <seealso href="https://dotnet.testcontainers.org/api/create_docker_container/#composing-command-arguments">Composing command arguments</seealso>.
+    /// </remarks>
     /// <param name="command">A list of commands, "executable", "param1", "param2" or "param1", "param2".</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>
     [PublicAPI]
     TBuilderEntity WithCommand(params string[] command);
 
     /// <summary>
-    /// Overrides the container's command arguments.
+    /// Appends command arguments to the container configuration.
     /// </summary>
     /// <remarks>
-    /// The <see cref="ComposableEnumerable{T}" /> allows to choose how existing builder configurations are composed.
+    /// The <see cref="ComposableEnumerable{T}" /> parameter controls how the specified command arguments are composed
+    /// with the existing container configuration.
+    ///
+    /// Use <see cref="AppendEnumerable{T}" /> to append command arguments, or <see cref="OverwriteEnumerable{T}" /> to
+    /// overwrite or replace an already pre-configured command.
+    ///
+    /// For more information and examples, see
+    /// <seealso href="https://dotnet.testcontainers.org/api/create_docker_container/#composing-command-arguments">Composing command arguments</seealso>.
     /// </remarks>
     /// <param name="command">A list of commands, "executable", "param1", "param2" or "param1", "param2".</param>
     /// <returns>A configured instance of <typeparamref name="TBuilderEntity" />.</returns>


### PR DESCRIPTION
## What does this PR do?

Extends the `WithCommand(params string[])` documentation.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1682

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how command arguments are handled in container configuration, including details on appending versus overwriting behavior.
  * Added guidance on composing command arguments with existing configurations.
  * Updated documentation with reference to external composing command arguments guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->