### PR TITLE
chore(deps): Bump Docker.DotNet from 4.1.0 to 4.2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,8 +5,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="4.1.0"/>
-        <PackageVersion Include="Docker.DotNet.Enhanced" Version="4.1.0"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="4.2.0"/>
+        <PackageVersion Include="Docker.DotNet.Enhanced" Version="4.2.0"/>
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
         <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1"/>
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3"/>

--- a/src/Testcontainers.Milvus/MilvusBuilder.cs
+++ b/src/Testcontainers.Milvus/MilvusBuilder.cs
@@ -135,11 +135,10 @@ public sealed class MilvusBuilder : ContainerBuilder<MilvusBuilder, MilvusContai
     {
         private Healthcheck()
         {
-            const long ninetySeconds = 90 * 1_000_000_000L;
             Test = ["CMD-SHELL", $"curl -f http://localhost:{MilvusManagementPort}/healthz"];
             Interval = TimeSpan.FromSeconds(30);
             Timeout = TimeSpan.FromSeconds(20);
-            StartPeriod = ninetySeconds;
+            StartPeriod = TimeSpan.FromSeconds(90);
             Retries = 3;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker client library dependencies to the latest versions.
  * Simplified internal healthcheck configuration initialization for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->