### PR TITLE
feat: Ignore port-forwarding extra host in reuse hash

### DIFF
--- a/src/Testcontainers/Configurations/Commons/JsonIgnoreRuntimeExtraHosts.cs
+++ b/src/Testcontainers/Configurations/Commons/JsonIgnoreRuntimeExtraHosts.cs
@@ -1,0 +1,29 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+  using System.Text.Json;
+  using System.Text.Json.Serialization;
+
+  /// <summary>
+  /// Excludes the port-forwarding extra host entry (host.testcontainers.internal)
+  /// from the reuse hash, its IP changes every test session, which would otherwise
+  /// make identical configurations appear different.
+  /// </summary>
+  internal sealed class JsonIgnoreRuntimeExtraHosts : JsonConverter<IEnumerable<string>>
+  {
+    private const string PortForwardingHostEntry = "host.testcontainers.internal:";
+
+    public override IEnumerable<string> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+      return JsonSerializer.Deserialize<IEnumerable<string>>(ref reader);
+    }
+
+    public override void Write(Utf8JsonWriter writer, IEnumerable<string> value, JsonSerializerOptions options)
+    {
+      var extraHosts = value.Where(host => !host.StartsWith(PortForwardingHostEntry, StringComparison.OrdinalIgnoreCase)).OrderBy(host => host);
+      JsonSerializer.Serialize(writer, extraHosts, options);
+    }
+  }
+}

--- a/src/Testcontainers/Configurations/Commons/JsonIgnoreRuntimeResourceLabels.cs
+++ b/src/Testcontainers/Configurations/Commons/JsonIgnoreRuntimeResourceLabels.cs
@@ -6,6 +6,10 @@ namespace DotNet.Testcontainers.Configurations
   using DotNet.Testcontainers.Clients;
   using DotNet.Testcontainers.Containers;
 
+  /// <summary>
+  /// Excludes session-specific labels from the reuse hash so containers with
+  /// identical configuration are still recognized as reusable across test sessions.
+  /// </summary>
   internal sealed class JsonIgnoreRuntimeResourceLabels : JsonOrderedKeysConverter
   {
     private static readonly ISet<string> IgnoreLabels = new HashSet<string>

--- a/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ContainerConfiguration.cs
@@ -208,6 +208,7 @@ namespace DotNet.Testcontainers.Configurations
     public IEnumerable<string> NetworkAliases { get; }
 
     /// <inheritdoc />
+    [JsonConverter(typeof(JsonIgnoreRuntimeExtraHosts))]
     public IEnumerable<string> ExtraHosts { get; }
 
     /// <inheritdoc />


### PR DESCRIPTION
## What does this PR do?

The PR ignores the port-forwarding extra host value in the reuse hash. That value is set as soon as the port-forwarding container runs.

## Why is it important?

TBH, I'm not sure this change is ideal. I wouldn't expect reuse + port-forwarding to work reliably anyway, because the port-forwarding container is currently a singleton and gets recreated for every test session (process). As a result, it ends up with different IP addresses, which leads to different container configurations and therefore different reuse hashes.

I believe ignoring it for now enables more use cases. Once we can reuse the port-forwarding container itself, this likely won't be necessary anymore.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1673

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime-dependent host entries are now filtered from container extra hosts configuration during serialization.

* **Documentation**
  * Added clarification on container label handling for configuration reuse.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/testcontainers/testcontainers-dotnet/pull/1689)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->