### PR TITLE
docs: Explain immutable builder behavior

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,7 +72,7 @@
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2"/>
         <PackageVersion Include="Microsoft.Playwright" Version="1.55.0"/>
         <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1"/>
-        <PackageVersion Include="MongoDB.Driver" Version="3.8.0"/>
+        <PackageVersion Include="MongoDB.Driver" Version="3.8.1"/>
         <PackageVersion Include="MQTTnet" Version="5.0.1.1416"/>
         <PackageVersion Include="MyCouch" Version="7.6.0"/>
         <PackageVersion Include="MySqlConnector" Version="2.2.5"/>

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -214,6 +214,44 @@ Using `OverwriteEnumerable<string>(Array.Empty<string>())` removes all default c
 
     You can create your own `ComposableEnumerable<T>` implementation to control exactly how configuration values are composed or modified.
 
+## Reusing builder configurations
+
+Testcontainers builders are immutable. Every builder method returns a new instance that includes the updated configuration. The existing builder instance remains unchanged.
+
+This behavior is by design. It allows you to share a common configuration and derive multiple containers from it without modifying the original builder, for example for A/B testing:
+
+```csharp
+var baseBuilder = new PostgreSqlBuilder()
+  .WithUsername("Username")
+  .WithPassword("Password")
+  .WithLabel("Key", "Value");
+
+var postgres15 = baseBuilder
+  .WithImage("postgres:15")
+  .Build();
+
+var postgres14 = baseBuilder
+  .WithImage("postgres:14")
+  .Build();
+```
+
+If you configure a builder across multiple statements or conditionally, reassign the return value. Calling `WithImage(...)` without using the returned builder does not update the existing instance:
+
+```csharp
+var builder = new PostgreSqlBuilder()
+  .WithImage("postgres:15")
+  .WithUsername("Username")
+  .WithPassword("Password")
+  .WithLabel("Key", "Value");
+
+if (Debugger.IsAttached)
+{
+  builder = builder.WithImage("postgres:14");
+}
+
+var container = builder.Build();
+```
+
 ## Examples
 
 An NGINX container that binds the HTTP port to a random host port and hosts static content. The example connects to the web server and checks the HTTP status code.


### PR DESCRIPTION
## What does this PR do?

Occasionally, developers run into misunderstandings about how the fluent builder API in Testcontainers works. Testcontainers builders are immutable. Every builder method returns a new instance that includes the updated configuration, while the existing builder instance remains unchanged.

## Why is it important?

To make this behavior clearer and more explicit for developers, this PR documents it.

## Related issues

- Relates #1692

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MongoDB.Driver dependency to version 3.8.1.

* **Documentation**
  * Added new documentation section explaining builder configuration reuse, including examples of deriving multiple containers from a shared base configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/testcontainers/testcontainers-dotnet/pull/1693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->