### PR TITLE
feat: Improve image build failure messages

### DIFF
--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -14,12 +14,9 @@ namespace DotNet.Testcontainers.Clients
 
   internal sealed class DockerImageOperations : DockerApiClient, IDockerImageOperations
   {
-    private readonly TraceProgress _traceProgress;
-
     public DockerImageOperations(Guid sessionId, IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig, ILogger logger)
       : base(sessionId, dockerEndpointAuthConfig, logger)
     {
-      _traceProgress = new TraceProgress(logger);
     }
 
     public async Task<IEnumerable<ImagesListResponse>> GetAllAsync(CancellationToken ct = default)
@@ -57,6 +54,8 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task CreateAsync(IImage image, IDockerRegistryAuthenticationConfiguration dockerRegistryAuthConfig, CancellationToken ct = default)
     {
+      var traceProgress = new TraceProgress(Logger);
+
       var createParameters = new ImagesCreateParameters
       {
         FromImage = image.FullName,
@@ -71,7 +70,7 @@ namespace DotNet.Testcontainers.Clients
         IdentityToken = dockerRegistryAuthConfig.IdentityToken,
       };
 
-      await DockerClient.Images.CreateImageAsync(createParameters, authConfig, _traceProgress, ct)
+      await DockerClient.Images.CreateImageAsync(createParameters, authConfig, traceProgress, ct)
         .ConfigureAwait(false);
 
       Logger.DockerImageCreated(image);
@@ -85,6 +84,8 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<string> BuildAsync(IImageFromDockerfileConfiguration configuration, ITarArchive dockerfileArchive, CancellationToken ct = default)
     {
+      var traceProgress = new TraceProgress(Logger);
+
       var image = configuration.Image;
 
       var imageExists = await ExistsWithIdAsync(image.FullName, ct)
@@ -120,7 +121,7 @@ namespace DotNet.Testcontainers.Clients
       {
         using (var dockerfileArchiveStream = new FileStream(dockerfileArchiveFilePath, FileMode.Open, FileAccess.Read))
         {
-          await DockerClient.Images.BuildImageFromDockerfileAsync(buildParameters, dockerfileArchiveStream, Array.Empty<AuthConfig>(), new Dictionary<string, string>(), _traceProgress, ct)
+          await DockerClient.Images.BuildImageFromDockerfileAsync(buildParameters, dockerfileArchiveStream, Array.Empty<AuthConfig>(), new Dictionary<string, string>(), traceProgress, ct)
             .ConfigureAwait(false);
 
           var imageHasBeenCreated = await ExistsWithIdAsync(image.FullName, ct)
@@ -128,7 +129,7 @@ namespace DotNet.Testcontainers.Clients
 
           if (!imageHasBeenCreated)
           {
-            throw new InvalidOperationException($"Docker image {image.FullName} has not been created.");
+            throw new ImageBuildFailedException(image, traceProgress.Errors);
           }
         }
       }

--- a/src/Testcontainers/Clients/TraceProgress.cs
+++ b/src/Testcontainers/Clients/TraceProgress.cs
@@ -1,12 +1,16 @@
 namespace DotNet.Testcontainers.Clients
 {
   using System;
+  using System.Collections.Concurrent;
+  using System.Collections.Generic;
   using System.Text.Json;
   using Docker.DotNet.Models;
   using Microsoft.Extensions.Logging;
 
   internal sealed class TraceProgress : IProgress<JSONMessage>
   {
+    private readonly ConcurrentQueue<JSONError> _errors = new ConcurrentQueue<JSONError>();
+
     private readonly ILogger _logger;
 
     public TraceProgress(ILogger logger)
@@ -14,8 +18,15 @@ namespace DotNet.Testcontainers.Clients
       _logger = logger;
     }
 
+    public IEnumerable<JSONError> Errors => _errors;
+
     public void Report(JSONMessage value)
     {
+      if (value.Error != null)
+      {
+        _errors.Enqueue(value.Error);
+      }
+
       if (!_logger.IsEnabled(LogLevel.Error))
       {
         return;
@@ -38,7 +49,7 @@ namespace DotNet.Testcontainers.Clients
         return;
       }
 
-      if (value.Progress != null && value.Progress.Total > 0)
+      if (value.Progress != null && value.Progress.Current.HasValue && value.Progress.Total > 0)
       {
         var percentage = (double)value.Progress.Current / value.Progress.Total * 100;
         _logger.LogDebug("ID={ID}: {Status} {Percentage,6:F2}% ({Current}/{Total})", value.ID, value.Status, percentage, value.Progress.Current, value.Progress.Total);

--- a/src/Testcontainers/Images/ImageBuildFailedException.cs
+++ b/src/Testcontainers/Images/ImageBuildFailedException.cs
@@ -1,0 +1,45 @@
+﻿namespace DotNet.Testcontainers.Images
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+  using System.Text;
+  using Docker.DotNet.Models;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Represents an exception that is thrown when a Docker image build has failed.
+  /// </summary>
+  [PublicAPI]
+  public sealed class ImageBuildFailedException : Exception
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageBuildFailedException" /> class.
+    /// </summary>
+    /// <param name="image">The Docker image.</param>
+    /// <param name="errors">The image build errors.</param>
+    public ImageBuildFailedException(IImage image, IEnumerable<JSONError> errors)
+      : base(CreateMessage(image, errors.ToArray()))
+    {
+    }
+
+    private static string CreateMessage(IImage image, IReadOnlyCollection<JSONError> errors)
+    {
+      var exceptionInfo = new StringBuilder(256);
+      exceptionInfo.Append($"Docker image {image.FullName} has not been created.");
+
+      if (errors.Count > 0)
+      {
+        var formattedErrors = errors
+          .Where(error => error != null)
+          .Select(error => "    " + error.Message);
+
+        exceptionInfo.AppendLine();
+        exceptionInfo.AppendLine("  Error: ");
+        exceptionInfo.Append(string.Join(Environment.NewLine, formattedErrors));
+      }
+
+      return exceptionInfo.ToString();
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Assets/.dockerignore
+++ b/tests/Testcontainers.Tests/Assets/.dockerignore
@@ -1,6 +1,7 @@
 Dockerfile
 credHelpers
 credsStore
+buildFailure
 context
 healthWaitStrategy
 pullBaseImages

--- a/tests/Testcontainers.Tests/Assets/buildFailure/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/buildFailure/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd
+RUN command-that-does-not-exist

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -228,6 +228,24 @@ namespace DotNet.Testcontainers.Tests.Unit
       Assert.DoesNotContain(logger.Logs, line => line.Contains("FROM build AS final"));
     }
 
+    [Fact]
+    public async Task BuildFailureIncludesDetailedErrorMessage()
+    {
+      // Given
+      var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
+        .WithDockerfileDirectory("Assets/buildFailure/")
+        .Build();
+
+      // When
+      var exception = await Assert.ThrowsAsync<ImageBuildFailedException>(() => imageFromDockerfileBuilder.CreateAsync(TestContext.Current.CancellationToken))
+        .ConfigureAwait(true);
+
+      // Then
+      Assert.StartsWith("Docker image ", exception.Message);
+      Assert.Contains(" has not been created.", exception.Message);
+      Assert.EndsWith("The command '/bin/sh -c command-that-does-not-exist' returned a non-zero code: 127", exception.Message);
+    }
+
     private sealed class TestLogger : ILogger
     {
       public IList<string> Logs { get; }


### PR DESCRIPTION
## What does this PR do?

This PR adds additional error details when an image build fails.

Previously, the error message was very generic and did not provide any information about the underlying cause of the failure. To diagnose image build issues, developers had to inspect the console output, which is not always obvious. In addition, .NET console messages can be difficult to locate, especially for a library that is primarily executed in test environments.

With this change, the image build error details are included directly in the exception. A failed image build will now throw an `ImageBuildFailedException` containing the relevant error information, making failures easier to diagnose and troubleshoot.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1695

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Docker image build failures now surface detailed diagnostic errors (captured during build) instead of generic messages.

* **New Features**
  * Build error details are collected and included in the reported failure to aid troubleshooting.

* **Tests**
  * Added a unit test that verifies detailed error reporting on image build failure.

* **Chores**
  * Test assets updated to include a failing build scenario and adjusted ignore patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->