### PR TITLE
chore: Rename runtime label and add buildkit and stale labels

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -88,9 +88,13 @@ labels:
     color: '#b5f7d9'
     description: An official Testcontainers module
 
-  - name: podman
+  - name: container runtime
     color: '#b52710'
-    description: An issue related to Podman
+    description: An issue related to container runtimes such as Docker, Podman, Rancher or Colima
+
+  - name: buildkit
+    color: '#5319e7'
+    description: An issue related to BuildKit
 
   - name: breaking change
     color: '#c91873'
@@ -115,6 +119,10 @@ labels:
   - name: test flakiness
     color: '#602a4f'
     description: A flaky test
+
+  - name: stale
+    color: '#ededed'
+    description: Inactive issue or pull request pending cleanup
 
   - name: won't fix
     color: '#ffffff'

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -205,12 +205,8 @@ namespace DotNet.Testcontainers
 
     public static void ExecuteCommandInDockerContainer(this ILogger logger, string id, IEnumerable<string> command)
     {
-      if (!logger.IsEnabled(LogLevel.Information))
-      {
-        return;
-      }
-
-      ExecuteCommandInDockerContainerCore(logger, string.Join(" ", command), new TruncatedId(id));
+      var commandLine = string.Join(" ", command);
+      ExecuteCommandInDockerContainerCore(logger, commandLine, new TruncatedId(id));
     }
 
     public static void DockerImageCreated(this ILogger logger, IImage image)


### PR DESCRIPTION
## What does this PR do?

\-

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository labels: added “container runtime”, “buildkit”, and a “stale” label; removed “podman”.
* **Bug Fixes**
  * Made command execution logging consistent so command output is logged reliably across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->