### PR TITLE
chore: bump testcontainers/sshd from 1.3.0 to 1.4.0

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -88,9 +88,13 @@ labels:
     color: '#b5f7d9'
     description: An official Testcontainers module
 
-  - name: podman
+  - name: container runtime
     color: '#b52710'
-    description: An issue related to Podman
+    description: An issue related to container runtimes such as Docker, Podman, Rancher or Colima
+
+  - name: buildkit
+    color: '#5319e7'
+    description: An issue related to BuildKit
 
   - name: breaking change
     color: '#c91873'
@@ -115,6 +119,10 @@ labels:
   - name: test flakiness
     color: '#602a4f'
     description: A flaky test
+
+  - name: stale
+    color: '#ededed'
+    description: Inactive issue or pull request pending cleanup
 
   - name: won't fix
     color: '#ffffff'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
 
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
 
@@ -80,7 +80,7 @@ jobs:
           path: ~/.nuget/packages
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
 
       - name: Restore NuGet Packages
         run: ./build.sh --target=Restore-NuGet-Packages
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
           fetch-depth: 0
@@ -159,7 +159,7 @@ jobs:
           java-version: 21
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
 
       - name: Restore NuGet Packages
         run: ./build.sh --target=Restore-NuGet-Packages
@@ -189,7 +189,7 @@ jobs:
 
       # Cake sets the semVer environment variable.
       - name: Draft Release
-        uses: release-drafter/release-drafter@563bf132657a13ded0b01fcb723c5a58cdd824e2 # v7.2.1
+        uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
         with:
           version: ${{ env.semVer }}
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,17 +29,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/autobuild@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1

--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
           persist-credentials: false
@@ -42,6 +42,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF Result to CodeQL Code Scanning
-        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -22,7 +22,7 @@ jobs:
       # https://github.com/dorny/test-reporter/issues/131#issuecomment-2093880211.
       # https://github.com/dorny/test-reporter/issues/234#issuecomment-1462911162.
       - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           lfs: true
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <PackageId>$(AssemblyName)</PackageId>
-    <Version>4.12.0</Version>
+    <Version>4.13.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
     <Product>Testcontainers</Product>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,7 +72,7 @@
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2"/>
         <PackageVersion Include="Microsoft.Playwright" Version="1.55.0"/>
         <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1"/>
-        <PackageVersion Include="MongoDB.Driver" Version="3.8.0"/>
+        <PackageVersion Include="MongoDB.Driver" Version="3.8.1"/>
         <PackageVersion Include="MQTTnet" Version="5.0.1.1416"/>
         <PackageVersion Include="MyCouch" Version="7.6.0"/>
         <PackageVersion Include="MySqlConnector" Version="2.2.5"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,10 +17,10 @@
         <PackageVersion Include="Cake.Frosting" Version="5.1.0"/>
         <PackageVersion Include="Cake.Sonar" Version="5.0.0"/>
         <!-- Unit and integration test dependencies: -->
-        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
         <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0"/>
         <PackageVersion Include="coverlet.collector" Version="6.0.4"/>
-        <PackageVersion Include="Dapper" Version="2.1.66"/>
+        <PackageVersion Include="Dapper" Version="2.1.79"/>
         <PackageVersion Include="Moq" Version="4.20.72"/>
         <PackageVersion Include="ReflectionMagic" Version="5.0.1"/>
         <PackageVersion Include="xunit.analyzers" Version="1.27.0"/>
@@ -72,7 +72,7 @@
         <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2"/>
         <PackageVersion Include="Microsoft.Playwright" Version="1.55.0"/>
         <PackageVersion Include="Milvus.Client" Version="2.3.0-preview.1"/>
-        <PackageVersion Include="MongoDB.Driver" Version="3.8.1"/>
+        <PackageVersion Include="MongoDB.Driver" Version="3.9.0"/>
         <PackageVersion Include="MQTTnet" Version="5.0.1.1416"/>
         <PackageVersion Include="MyCouch" Version="7.6.0"/>
         <PackageVersion Include="MySqlConnector" Version="2.2.5"/>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <OutputType>Exe</OutputType>
         <SignAssembly>false</SignAssembly>
         <RunWorkingDirectory>$(MSBuildProjectDirectory)/..</RunWorkingDirectory>

--- a/build/Program.cs
+++ b/build/Program.cs
@@ -5,7 +5,7 @@ public static class Program
     public static int Main(string[] args)
     {
         return new CakeHost()
-            .InstallTool(new Uri("nuget:?package=dotnet-sonarscanner&version=10.1.2"))
+            .InstallTool(new Uri("nuget:?package=dotnet-sonarscanner&version=11.2.1"))
             .UseContext<BuildContext>()
             .UseLifetime<BuildLifetime>()
             .Run(args);

--- a/docs/api/create_docker_container.md
+++ b/docs/api/create_docker_container.md
@@ -214,6 +214,44 @@ Using `OverwriteEnumerable<string>(Array.Empty<string>())` removes all default c
 
     You can create your own `ComposableEnumerable<T>` implementation to control exactly how configuration values are composed or modified.
 
+## Reusing builder configurations
+
+Testcontainers builders are immutable. Every builder method returns a new instance that includes the updated configuration. The existing builder instance remains unchanged.
+
+This behavior is by design. It allows you to share a common configuration and derive multiple containers from it without modifying the original builder, for example for A/B testing:
+
+```csharp
+var baseBuilder = new PostgreSqlBuilder()
+  .WithUsername("Username")
+  .WithPassword("Password")
+  .WithLabel("Key", "Value");
+
+var postgres15 = baseBuilder
+  .WithImage("postgres:15")
+  .Build();
+
+var postgres14 = baseBuilder
+  .WithImage("postgres:14")
+  .Build();
+```
+
+If you configure a builder across multiple statements or conditionally, reassign the return value. Calling `WithImage(...)` without using the returned builder does not update the existing instance:
+
+```csharp
+var builder = new PostgreSqlBuilder()
+  .WithImage("postgres:15")
+  .WithUsername("Username")
+  .WithPassword("Password")
+  .WithLabel("Key", "Value");
+
+if (Debugger.IsAttached)
+{
+  builder = builder.WithImage("postgres:14");
+}
+
+var container = builder.Build();
+```
+
 ## Examples
 
 An NGINX container that binds the HTTP port to a random host port and hosts static content. The example connects to the web server and checks the HTTP status code.

--- a/docs/api/create_docker_image.md
+++ b/docs/api/create_docker_image.md
@@ -2,6 +2,10 @@
 
 Testcontainers for .NET uses the builder design pattern to configure, create and delete Docker resources. It prepares and initializes your test environment and disposes of everything after your tests are finished — whether the tests are successful or not. To create a container image from a Dockerfile use `ImageFromDockerfileBuilder`.
 
+!!! warning
+
+    BuildKit features are not supported through the Docker Engine API. As a result, Dockerfile instructions and options that depend on BuildKit cannot be used with Testcontainers' image builder API. For more details, see this [discussion](https://github.com/testcontainers/testcontainers-dotnet/discussions/1193#discussioncomment-10315903).
+
 ## Examples
 
 Builds and tags a new container image. The Dockerfile is located inside the solution (`.sln`) directory.

--- a/src/Testcontainers/Clients/DockerApiClient.cs
+++ b/src/Testcontainers/Clients/DockerApiClient.cs
@@ -9,6 +9,7 @@ namespace DotNet.Testcontainers.Clients
   using System.Threading;
   using System.Threading.Tasks;
   using Docker.DotNet;
+  using DotNet.Testcontainers;
   using DotNet.Testcontainers.Configurations;
   using JetBrains.Annotations;
   using Microsoft.Extensions.Logging;
@@ -118,7 +119,7 @@ namespace DotNet.Testcontainers.Clients
           runtimeInfo.Append(string.Join(Environment.NewLine, labels.Select(label => "    " + label)));
         }
 
-        Logger.LogInformation("{RuntimeInfo}", runtimeInfo);
+        Logger.DockerRuntimeInfo(runtimeInfo.ToString());
       }
       catch (Exception e)
       {

--- a/src/Testcontainers/Clients/DockerImageOperations.cs
+++ b/src/Testcontainers/Clients/DockerImageOperations.cs
@@ -14,12 +14,9 @@ namespace DotNet.Testcontainers.Clients
 
   internal sealed class DockerImageOperations : DockerApiClient, IDockerImageOperations
   {
-    private readonly TraceProgress _traceProgress;
-
     public DockerImageOperations(Guid sessionId, IDockerEndpointAuthenticationConfiguration dockerEndpointAuthConfig, ILogger logger)
       : base(sessionId, dockerEndpointAuthConfig, logger)
     {
-      _traceProgress = new TraceProgress(logger);
     }
 
     public async Task<IEnumerable<ImagesListResponse>> GetAllAsync(CancellationToken ct = default)
@@ -57,6 +54,8 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task CreateAsync(IImage image, IDockerRegistryAuthenticationConfiguration dockerRegistryAuthConfig, CancellationToken ct = default)
     {
+      var traceProgress = new TraceProgress(Logger);
+
       var createParameters = new ImagesCreateParameters
       {
         FromImage = image.FullName,
@@ -71,7 +70,7 @@ namespace DotNet.Testcontainers.Clients
         IdentityToken = dockerRegistryAuthConfig.IdentityToken,
       };
 
-      await DockerClient.Images.CreateImageAsync(createParameters, authConfig, _traceProgress, ct)
+      await DockerClient.Images.CreateImageAsync(createParameters, authConfig, traceProgress, ct)
         .ConfigureAwait(false);
 
       Logger.DockerImageCreated(image);
@@ -85,6 +84,8 @@ namespace DotNet.Testcontainers.Clients
 
     public async Task<string> BuildAsync(IImageFromDockerfileConfiguration configuration, ITarArchive dockerfileArchive, CancellationToken ct = default)
     {
+      var traceProgress = new TraceProgress(Logger);
+
       var image = configuration.Image;
 
       var imageExists = await ExistsWithIdAsync(image.FullName, ct)
@@ -120,7 +121,7 @@ namespace DotNet.Testcontainers.Clients
       {
         using (var dockerfileArchiveStream = new FileStream(dockerfileArchiveFilePath, FileMode.Open, FileAccess.Read))
         {
-          await DockerClient.Images.BuildImageFromDockerfileAsync(buildParameters, dockerfileArchiveStream, Array.Empty<AuthConfig>(), new Dictionary<string, string>(), _traceProgress, ct)
+          await DockerClient.Images.BuildImageFromDockerfileAsync(buildParameters, dockerfileArchiveStream, Array.Empty<AuthConfig>(), new Dictionary<string, string>(), traceProgress, ct)
             .ConfigureAwait(false);
 
           var imageHasBeenCreated = await ExistsWithIdAsync(image.FullName, ct)
@@ -128,7 +129,7 @@ namespace DotNet.Testcontainers.Clients
 
           if (!imageHasBeenCreated)
           {
-            throw new InvalidOperationException($"Docker image {image.FullName} has not been created.");
+            throw new ImageBuildFailedException(image, traceProgress.Errors);
           }
         }
       }

--- a/src/Testcontainers/Clients/TraceProgress.cs
+++ b/src/Testcontainers/Clients/TraceProgress.cs
@@ -1,12 +1,16 @@
 namespace DotNet.Testcontainers.Clients
 {
   using System;
+  using System.Collections.Concurrent;
+  using System.Collections.Generic;
   using System.Text.Json;
   using Docker.DotNet.Models;
   using Microsoft.Extensions.Logging;
 
   internal sealed class TraceProgress : IProgress<JSONMessage>
   {
+    private readonly ConcurrentQueue<JSONError> _errors = new ConcurrentQueue<JSONError>();
+
     private readonly ILogger _logger;
 
     public TraceProgress(ILogger logger)
@@ -14,8 +18,15 @@ namespace DotNet.Testcontainers.Clients
       _logger = logger;
     }
 
+    public IEnumerable<JSONError> Errors => _errors;
+
     public void Report(JSONMessage value)
     {
+      if (value.Error != null)
+      {
+        _errors.Enqueue(value.Error);
+      }
+
       if (!_logger.IsEnabled(LogLevel.Error))
       {
         return;
@@ -38,7 +49,7 @@ namespace DotNet.Testcontainers.Clients
         return;
       }
 
-      if (value.Progress != null && value.Progress.Total > 0)
+      if (value.Progress != null && value.Progress.Current.HasValue && value.Progress.Total > 0)
       {
         var percentage = (double)value.Progress.Current / value.Progress.Total * 100;
         _logger.LogDebug("ID={ID}: {Status} {Percentage,6:F2}% ({Current}/{Total})", value.ID, value.Status, percentage, value.Progress.Current, value.Progress.Total);

--- a/src/Testcontainers/Containers/PortForwarding.cs
+++ b/src/Testcontainers/Containers/PortForwarding.cs
@@ -61,7 +61,7 @@ namespace DotNet.Testcontainers.Containers
     [PublicAPI]
     private sealed class PortForwardingBuilder : ContainerBuilder<PortForwardingBuilder, PortForwardingContainer, PortForwardingConfiguration>
     {
-      public const string SshdImage = "testcontainers/sshd:1.3.0@sha256:c50c0f59554dcdb2d9e5e705112144428ae9d04ac0af6322b365a18e24213a6a";
+      public const string SshdImage = "testcontainers/sshd:1.4.0@sha256:bdae17f702908bee93c877ab3e97eddd782e2fb5bdd23a9f29869b9a87b30acd";
 
       public const ushort SshdPort = 22;
 

--- a/src/Testcontainers/Containers/TarOutputMemoryStream.cs
+++ b/src/Testcontainers/Containers/TarOutputMemoryStream.cs
@@ -5,6 +5,7 @@ namespace DotNet.Testcontainers.Containers
   using System.Text;
   using System.Threading;
   using System.Threading.Tasks;
+  using DotNet.Testcontainers;
   using DotNet.Testcontainers.Configurations;
   using ICSharpCode.SharpZipLib.Tar;
   using Microsoft.Extensions.Logging;
@@ -73,9 +74,7 @@ namespace DotNet.Testcontainers.Containers
 
       var fileModeOctal = Convert.ToString(tarEntry.TarHeader.Mode, 8).PadLeft(4, '0');
 
-      _logger.LogInformation(
-        "Add file to tar archive: Content length: {Length} byte(s), Target file: \"{Target}\", UID: {Uid}, GID: {Gid}, Mode: {Mode}",
-        tarEntry.Size, targetFilePath, tarEntry.TarHeader.UserId, tarEntry.TarHeader.GroupId, fileModeOctal);
+      _logger.AddFileToTarArchive(tarEntry.Size, targetFilePath, tarEntry.TarHeader.UserId, tarEntry.TarHeader.GroupId, fileModeOctal);
 
       await PutNextEntryAsync(tarEntry, ct)
         .ConfigureAwait(false);
@@ -153,9 +152,7 @@ namespace DotNet.Testcontainers.Containers
 
         var fileModeOctal = Convert.ToString(tarEntry.TarHeader.Mode, 8).PadLeft(4, '0');
 
-        _logger.LogInformation(
-          "Add file to tar archive: Source file: \"{Source}\", Target file: \"{Target}\", UID: {Uid}, GID: {Gid}, Mode: {Mode}",
-          tarEntry.Size, targetFilePath, tarEntry.TarHeader.UserId, tarEntry.TarHeader.GroupId, fileModeOctal);
+        _logger.AddFileToTarArchive(file.FullName, targetFilePath, tarEntry.TarHeader.UserId, tarEntry.TarHeader.GroupId, fileModeOctal);
 
         await PutNextEntryAsync(tarEntry, ct)
           .ConfigureAwait(false);

--- a/src/Testcontainers/Images/ImageBuildFailedException.cs
+++ b/src/Testcontainers/Images/ImageBuildFailedException.cs
@@ -1,0 +1,45 @@
+﻿namespace DotNet.Testcontainers.Images
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+  using System.Text;
+  using Docker.DotNet.Models;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Represents an exception that is thrown when a Docker image build has failed.
+  /// </summary>
+  [PublicAPI]
+  public sealed class ImageBuildFailedException : Exception
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ImageBuildFailedException" /> class.
+    /// </summary>
+    /// <param name="image">The Docker image.</param>
+    /// <param name="errors">The image build errors.</param>
+    public ImageBuildFailedException(IImage image, IEnumerable<JSONError> errors)
+      : base(CreateMessage(image, errors.ToArray()))
+    {
+    }
+
+    private static string CreateMessage(IImage image, IReadOnlyCollection<JSONError> errors)
+    {
+      var exceptionInfo = new StringBuilder(256);
+      exceptionInfo.Append($"Docker image {image.FullName} has not been created.");
+
+      if (errors.Count > 0)
+      {
+        var formattedErrors = errors
+          .Where(error => error != null)
+          .Select(error => "    " + error.Message);
+
+        exceptionInfo.AppendLine();
+        exceptionInfo.AppendLine("  Error: ");
+        exceptionInfo.Append(string.Join(Environment.NewLine, formattedErrors));
+      }
+
+      return exceptionInfo.ToString();
+    }
+  }
+}

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -205,12 +205,8 @@ namespace DotNet.Testcontainers
 
     public static void ExecuteCommandInDockerContainer(this ILogger logger, string id, IEnumerable<string> command)
     {
-      if (!logger.IsEnabled(LogLevel.Information))
-      {
-        return;
-      }
-
-      ExecuteCommandInDockerContainerCore(logger, string.Join(" ", command), new TruncatedId(id));
+      var commandLine = string.Join(" ", command);
+      ExecuteCommandInDockerContainerCore(logger, commandLine, new TruncatedId(id));
     }
 
     public static void DockerImageCreated(this ILogger logger, IImage image)

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -205,6 +205,11 @@ namespace DotNet.Testcontainers
 
     public static void ExecuteCommandInDockerContainer(this ILogger logger, string id, IEnumerable<string> command)
     {
+      if (!logger.IsEnabled(LogLevel.Information))
+      {
+        return;
+      }
+
       ExecuteCommandInDockerContainerCore(logger, string.Join(" ", command), new TruncatedId(id));
     }
 

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -7,292 +7,312 @@ namespace DotNet.Testcontainers
   using DotNet.Testcontainers.Images;
   using Microsoft.Extensions.Logging;
 
-  internal static class Logging
+  internal static partial class Logging
   {
-#pragma warning disable InconsistentNaming, SA1309
+    [LoggerMessage(Level = LogLevel.Information, Message = "Pattern {IgnorePattern} added to the regex cache")]
+    private static partial void IgnorePatternAddedCore(ILogger logger, Regex ignorePattern);
 
-    private static readonly Action<ILogger, Regex, Exception> _IgnorePatternAdded
-      = LoggerMessage.Define<Regex>(LogLevel.Information, default, "Pattern {IgnorePattern} added to the regex cache");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Docker container {Id} created")]
+    private static partial void DockerContainerCreatedCore(ILogger logger, string id);
 
-    private static readonly Action<ILogger, string, Exception> _DockerContainerCreated
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker container {Id} created");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Start Docker container {Id}")]
+    private static partial void StartDockerContainerCore(ILogger logger, string id);
 
-    private static readonly Action<ILogger, string, Exception> _StartDockerContainer
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Start Docker container {Id}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Stop Docker container {Id}")]
+    private static partial void StopDockerContainerCore(ILogger logger, string id);
 
-    private static readonly Action<ILogger, string, Exception> _StopDockerContainer
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Stop Docker container {Id}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Pause Docker container {Id}")]
+    private static partial void PauseDockerContainerCore(ILogger logger, string id);
 
-    private static readonly Action<ILogger, string, Exception> _PauseDockerContainer
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Pause Docker container {Id}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Unpause Docker container {Id}")]
+    private static partial void UnpauseDockerContainerCore(ILogger logger, string id);
 
-    private static readonly Action<ILogger, string, Exception> _UnpauseDockerContainer
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Unpause Docker container {Id}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Delete Docker container {Id}")]
+    private static partial void DeleteDockerContainerCore(ILogger logger, string id);
 
-    private static readonly Action<ILogger, string, Exception> _DeleteDockerContainer
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Delete Docker container {Id}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Wait for Docker container {Id} to complete readiness checks")]
+    private static partial void StartReadinessCheckCore(ILogger logger, string id);
 
-    private static readonly Action<ILogger, string, Exception> _StartReadinessCheck
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Wait for Docker container {Id} to complete readiness checks");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Docker container {Id} ready")]
+    private static partial void CompleteReadinessCheckCore(ILogger logger, string id);
 
-    private static readonly Action<ILogger, string, Exception> _CompleteReadinessCheck
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker container {Id} ready");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Copy tar archive to container: Content length: {Length} byte(s), Docker container: {Id}")]
+    private static partial void CopyArchiveToDockerContainerCore(ILogger logger, long length, string id);
 
-    private static readonly Action<ILogger, long, string, Exception> _CopyArchiveToDockerContainer
-      = LoggerMessage.Define<long, string>(LogLevel.Information, default, "Copy tar archive to container: Content length: {Length} byte(s), Docker container: {Id}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Read \"{Path}\" from Docker container {Id}")]
+    private static partial void ReadArchiveFromDockerContainerCore(ILogger logger, string path, string id);
 
-    private static readonly Action<ILogger, string, string, Exception> _ReadArchiveFromDockerContainer
-      = LoggerMessage.Define<string, string>(LogLevel.Information, default, "Read \"{Path}\" from Docker container {Id}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Attach {OutputConsumer} at Docker container {Id}")]
+    private static partial void AttachToDockerContainerCore(ILogger logger, Type outputConsumer, string id);
 
-    private static readonly Action<ILogger, Type, string, Exception> _AttachToDockerContainer
-      = LoggerMessage.Define<Type, string>(LogLevel.Information, default, "Attach {OutputConsumer} at Docker container {Id}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Connect Docker container {ContainerId} to Docker network {NetworkId}")]
+    private static partial void ConnectToDockerNetworkCore(ILogger logger, string containerId, string networkId);
 
-    private static readonly Action<ILogger, string, string, Exception> _ConnectToDockerNetwork
-      = LoggerMessage.Define<string, string>(LogLevel.Information, default, "Connect Docker container {ContainerId} to Docker network {NetworkId}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Execute \"{Command}\" at Docker container {Id}")]
+    private static partial void ExecuteCommandInDockerContainerCore(ILogger logger, string command, string id);
 
-    private static readonly Action<ILogger, string, string, Exception> _ExecuteCommandInDockerContainer
-      = LoggerMessage.Define<string, string>(LogLevel.Information, default, "Execute \"{Command}\" at Docker container {Id}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Docker image {FullName} created")]
+    private static partial void DockerImageCreatedCore(ILogger logger, string fullName);
 
-    private static readonly Action<ILogger, string, Exception> _DockerImageCreated
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker image {FullName} created");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Docker image {FullName} built")]
+    private static partial void DockerImageBuiltCore(ILogger logger, string fullName);
 
-    private static readonly Action<ILogger, string, Exception> _DockerImageBuilt
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker image {FullName} built");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Delete Docker image {FullName}")]
+    private static partial void DeleteDockerImageCore(ILogger logger, string fullName);
 
-    private static readonly Action<ILogger, string, Exception> _DeleteDockerImage
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Delete Docker image {FullName}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Docker network {Id} created")]
+    private static partial void DockerNetworkCreatedCore(ILogger logger, string id);
 
-    private static readonly Action<ILogger, string, Exception> _DockerNetworkCreated
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker network {Id} created");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Delete Docker network {Id}")]
+    private static partial void DeleteDockerNetworkCore(ILogger logger, string id);
 
-    private static readonly Action<ILogger, string, Exception> _DeleteDockerNetwork
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Delete Docker network {Id}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Docker volume {Name} created")]
+    private static partial void DockerVolumeCreatedCore(ILogger logger, string name);
 
-    private static readonly Action<ILogger, string, Exception> _DockerVolumeCreated
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker volume {Name} created");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Delete Docker volume {Name}")]
+    private static partial void DeleteDockerVolumeCore(ILogger logger, string name);
 
-    private static readonly Action<ILogger, string, Exception> _DeleteDockerVolume
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Delete Docker volume {Name}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "{RuntimeInfo}")]
+    private static partial void DockerRuntimeInfoCore(ILogger logger, string runtimeInfo);
 
-    private static readonly Action<ILogger, Guid, Exception> _CanNotGetResourceReaperEndpoint
-      = LoggerMessage.Define<Guid>(LogLevel.Debug, default, "Cannot get resource reaper {Id} endpoint");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Add file to tar archive: Content length: {Length} byte(s), Target file: \"{Target}\", UID: {Uid}, GID: {Gid}, Mode: {Mode}")]
+    private static partial void AddFileToTarArchiveCore(ILogger logger, long length, string target, int uid, int gid, string mode);
 
-    private static readonly Action<ILogger, Guid, string, Exception> _CanNotConnectToResourceReaper
-      = LoggerMessage.Define<Guid, string>(LogLevel.Debug, default, "Cannot connect to resource reaper {Id} at {Endpoint}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Add file to tar archive: Source file: \"{Source}\", Target file: \"{Target}\", UID: {Uid}, GID: {Gid}, Mode: {Mode}")]
+    private static partial void AddFileToTarArchiveCore(ILogger logger, string source, string target, int uid, int gid, string mode);
 
-    private static readonly Action<ILogger, Guid, string, Exception> _LostConnectionToResourceReaper
-      = LoggerMessage.Define<Guid, string>(LogLevel.Debug, default, "Lost connection to resource reaper {Id} at {Endpoint}");
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Cannot get resource reaper {Id} endpoint")]
+    private static partial void CanNotGetResourceReaperEndpointCore(ILogger logger, Guid id, Exception exception);
 
-    private static readonly Action<ILogger, string, Exception> _DockerConfigFileNotFound
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker config \"{DockerConfigFilePath}\" not found");
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Cannot connect to resource reaper {Id} at {Endpoint}")]
+    private static partial void CanNotConnectToResourceReaperCore(ILogger logger, Guid id, string endpoint, Exception exception);
 
-    private static readonly Action<ILogger, string, Exception> _SearchingDockerRegistryCredential
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Searching Docker registry credential in {CredentialStore}");
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Lost connection to resource reaper {Id} at {Endpoint}")]
+    private static partial void LostConnectionToResourceReaperCore(ILogger logger, Guid id, string endpoint, Exception exception);
 
-    private static readonly Action<ILogger, string, JsonValueKind, Exception> _DockerRegistryAuthPropertyValueKindInvalid
-      = LoggerMessage.Define<string, JsonValueKind>(LogLevel.Warning, default, "The \"auth\" property value kind for {DockerRegistry} is invalid: {ValueKind}");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Docker config \"{DockerConfigFilePath}\" not found")]
+    private static partial void DockerConfigFileNotFoundCore(ILogger logger, string dockerConfigFilePath);
 
-    private static readonly Action<ILogger, string, Exception> _DockerRegistryAuthPropertyValueNotFound
-      = LoggerMessage.Define<string>(LogLevel.Warning, default, "The \"auth\" property value for {DockerRegistry} not found");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Searching Docker registry credential in {CredentialStore}")]
+    private static partial void SearchingDockerRegistryCredentialCore(ILogger logger, string credentialStore);
 
-    private static readonly Action<ILogger, string, Exception> _DockerRegistryAuthPropertyValueInvalidBase64
-      = LoggerMessage.Define<string>(LogLevel.Warning, default, "The \"auth\" property value for {DockerRegistry} is not a valid Base64 string");
+    [LoggerMessage(Level = LogLevel.Warning, Message = "The \"auth\" property value kind for {DockerRegistry} is invalid: {ValueKind}")]
+    private static partial void DockerRegistryAuthPropertyValueKindInvalidCore(ILogger logger, string dockerRegistry, JsonValueKind valueKind);
 
-    private static readonly Action<ILogger, string, Exception> _DockerRegistryAuthPropertyValueInvalidBasicAuthenticationFormat
-      = LoggerMessage.Define<string>(LogLevel.Warning, default, "The \"auth\" property value for {DockerRegistry} should contain one colon separating the username and the password (basic authentication)");
+    [LoggerMessage(Level = LogLevel.Warning, Message = "The \"auth\" property value for {DockerRegistry} not found")]
+    private static partial void DockerRegistryAuthPropertyValueNotFoundCore(ILogger logger, string dockerRegistry);
 
-    private static readonly Action<ILogger, string, Exception> _DockerRegistryCredentialNotFound
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker registry credential {DockerRegistry} not found");
+    [LoggerMessage(Level = LogLevel.Warning, Message = "The \"auth\" property value for {DockerRegistry} is not a valid Base64 string")]
+    private static partial void DockerRegistryAuthPropertyValueInvalidBase64Core(ILogger logger, string dockerRegistry, Exception exception);
 
-    private static readonly Action<ILogger, string, Exception> _DockerRegistryCredentialFound
-      = LoggerMessage.Define<string>(LogLevel.Information, default, "Docker registry credential {DockerRegistry} found");
+    [LoggerMessage(Level = LogLevel.Warning, Message = "The \"auth\" property value for {DockerRegistry} should contain one colon separating the username and the password (basic authentication)")]
+    private static partial void DockerRegistryAuthPropertyValueInvalidBasicAuthenticationFormatCore(ILogger logger, string dockerRegistry);
 
-    private static readonly Action<ILogger, Exception> _ReusableExperimentalFeature
-      = LoggerMessage.Define(LogLevel.Warning, default, "Reuse is an experimental feature. For more information, visit: https://dotnet.testcontainers.org/api/resource_reuse/");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Docker registry credential {DockerRegistry} not found")]
+    private static partial void DockerRegistryCredentialNotFoundCore(ILogger logger, string dockerRegistry);
 
-    private static readonly Action<ILogger, Exception> _ReusableResourceFound
-      = LoggerMessage.Define(LogLevel.Information, default, "Reusable resource found");
+    [LoggerMessage(Level = LogLevel.Information, Message = "Docker registry credential {DockerRegistry} found")]
+    private static partial void DockerRegistryCredentialFoundCore(ILogger logger, string dockerRegistry);
 
-    private static readonly Action<ILogger, Exception> _ReusableResourceNotFound
-      = LoggerMessage.Define(LogLevel.Information, default, "Reusable resource not found, create resource");
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Reuse is an experimental feature. For more information, visit: https://dotnet.testcontainers.org/api/resource_reuse/")]
+    private static partial void ReusableExperimentalFeatureCore(ILogger logger);
 
-#pragma warning restore InconsistentNaming, SA1309
+    [LoggerMessage(Level = LogLevel.Information, Message = "Reusable resource found")]
+    private static partial void ReusableResourceFoundCore(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Reusable resource not found, create resource")]
+    private static partial void ReusableResourceNotFoundCore(ILogger logger);
 
     public static void IgnorePatternAdded(this ILogger logger, Regex ignorePattern)
     {
-      _IgnorePatternAdded(logger, ignorePattern, null);
+      IgnorePatternAddedCore(logger, ignorePattern);
     }
 
     public static void DockerContainerCreated(this ILogger logger, string id)
     {
-      _DockerContainerCreated(logger, TruncId(id), null);
+      DockerContainerCreatedCore(logger, TruncId(id));
     }
 
     public static void StartDockerContainer(this ILogger logger, string id)
     {
-      _StartDockerContainer(logger, TruncId(id), null);
+      StartDockerContainerCore(logger, TruncId(id));
     }
 
     public static void StopDockerContainer(this ILogger logger, string id)
     {
-      _StopDockerContainer(logger, TruncId(id), null);
+      StopDockerContainerCore(logger, TruncId(id));
     }
 
     public static void PauseDockerContainer(this ILogger logger, string id)
     {
-      _PauseDockerContainer(logger, TruncId(id), null);
+      PauseDockerContainerCore(logger, TruncId(id));
     }
 
     public static void UnpauseDockerContainer(this ILogger logger, string id)
     {
-      _UnpauseDockerContainer(logger, TruncId(id), null);
+      UnpauseDockerContainerCore(logger, TruncId(id));
     }
 
     public static void DeleteDockerContainer(this ILogger logger, string id)
     {
-      _DeleteDockerContainer(logger, TruncId(id), null);
+      DeleteDockerContainerCore(logger, TruncId(id));
     }
 
     public static void StartReadinessCheck(this ILogger logger, string id)
     {
-      _StartReadinessCheck(logger, TruncId(id), null);
+      StartReadinessCheckCore(logger, TruncId(id));
     }
 
     public static void CompleteReadinessCheck(this ILogger logger, string id)
     {
-      _CompleteReadinessCheck(logger, TruncId(id), null);
+      CompleteReadinessCheckCore(logger, TruncId(id));
     }
 
     public static void CopyArchiveToDockerContainer(this ILogger logger, string id, long length)
     {
-      _CopyArchiveToDockerContainer(logger, length, TruncId(id), null);
+      CopyArchiveToDockerContainerCore(logger, length, TruncId(id));
     }
 
     public static void ReadArchiveFromDockerContainer(this ILogger logger, string id, string path)
     {
-      _ReadArchiveFromDockerContainer(logger, path, TruncId(id), null);
+      ReadArchiveFromDockerContainerCore(logger, path, TruncId(id));
     }
 
     public static void AttachToDockerContainer(this ILogger logger, string id, Type type)
     {
-      _AttachToDockerContainer(logger, type, TruncId(id), null);
+      AttachToDockerContainerCore(logger, type, TruncId(id));
     }
 
     public static void ConnectToDockerNetwork(this ILogger logger, string networkId, string containerId)
     {
-      _ConnectToDockerNetwork(logger, TruncId(containerId), TruncId(networkId), null);
+      ConnectToDockerNetworkCore(logger, TruncId(containerId), TruncId(networkId));
     }
 
     public static void ExecuteCommandInDockerContainer(this ILogger logger, string id, IEnumerable<string> command)
     {
-      _ExecuteCommandInDockerContainer(logger, string.Join(" ", command), TruncId(id), null);
+      ExecuteCommandInDockerContainerCore(logger, string.Join(" ", command), TruncId(id));
     }
 
     public static void DockerImageCreated(this ILogger logger, IImage image)
     {
-      _DockerImageCreated(logger, image.FullName, null);
+      DockerImageCreatedCore(logger, image.FullName);
     }
 
     public static void DockerImageBuilt(this ILogger logger, IImage image)
     {
-      _DockerImageBuilt(logger, image.FullName, null);
+      DockerImageBuiltCore(logger, image.FullName);
     }
 
     public static void DeleteDockerImage(this ILogger logger, IImage image)
     {
-      _DeleteDockerImage(logger, image.FullName, null);
+      DeleteDockerImageCore(logger, image.FullName);
     }
 
     public static void DockerNetworkCreated(this ILogger logger, string id)
     {
-      _DockerNetworkCreated(logger, TruncId(id), null);
+      DockerNetworkCreatedCore(logger, TruncId(id));
     }
 
     public static void DeleteDockerNetwork(this ILogger logger, string id)
     {
-      _DeleteDockerNetwork(logger, TruncId(id), null);
+      DeleteDockerNetworkCore(logger, TruncId(id));
     }
 
     public static void DockerVolumeCreated(this ILogger logger, string name)
     {
-      _DockerVolumeCreated(logger, name, null);
+      DockerVolumeCreatedCore(logger, name);
     }
 
     public static void DeleteDockerVolume(this ILogger logger, string name)
     {
-      _DeleteDockerVolume(logger, name, null);
+      DeleteDockerVolumeCore(logger, name);
+    }
+
+    public static void DockerRuntimeInfo(this ILogger logger, string runtimeInfo)
+    {
+      DockerRuntimeInfoCore(logger, runtimeInfo);
+    }
+
+    public static void AddFileToTarArchive(this ILogger logger, long length, string target, int uid, int gid, string mode)
+    {
+      AddFileToTarArchiveCore(logger, length, target, uid, gid, mode);
+    }
+
+    public static void AddFileToTarArchive(this ILogger logger, string source, string target, int uid, int gid, string mode)
+    {
+      AddFileToTarArchiveCore(logger, source, target, uid, gid, mode);
     }
 
     public static void CanNotGetResourceReaperEndpoint(this ILogger logger, Guid id, Exception e)
     {
-      _CanNotGetResourceReaperEndpoint(logger, id, logger.IsEnabled(LogLevel.Debug) ? e : null);
+      CanNotGetResourceReaperEndpointCore(logger, id, logger.IsEnabled(LogLevel.Debug) ? e : null);
     }
 
     public static void CanNotConnectToResourceReaper(this ILogger logger, Guid id, string host, ushort port, Exception e)
     {
       var endpoint = $"{host}:{port}";
-      _CanNotConnectToResourceReaper(logger, id, endpoint, e);
+      CanNotConnectToResourceReaperCore(logger, id, endpoint, e);
     }
 
     public static void LostConnectionToResourceReaper(this ILogger logger, Guid id, string host, ushort port, Exception e)
     {
       var endpoint = $"{host}:{port}";
-      _LostConnectionToResourceReaper(logger, id, endpoint, e);
+      LostConnectionToResourceReaperCore(logger, id, endpoint, e);
     }
 
     public static void DockerConfigFileNotFound(this ILogger logger, string dockerConfigFilePath)
     {
-      _DockerConfigFileNotFound(logger, dockerConfigFilePath, null);
+      DockerConfigFileNotFoundCore(logger, dockerConfigFilePath);
     }
 
     public static void SearchingDockerRegistryCredential(this ILogger logger, string credentialStore)
     {
-      _SearchingDockerRegistryCredential(logger, credentialStore, null);
+      SearchingDockerRegistryCredentialCore(logger, credentialStore);
     }
 
     public static void DockerRegistryAuthPropertyValueKindInvalid(this ILogger logger, string dockerRegistry, JsonValueKind valueKind)
     {
-      _DockerRegistryAuthPropertyValueKindInvalid(logger, dockerRegistry, valueKind, null);
+      DockerRegistryAuthPropertyValueKindInvalidCore(logger, dockerRegistry, valueKind);
     }
 
     public static void DockerRegistryAuthPropertyValueNotFound(this ILogger logger, string dockerRegistry)
     {
-      _DockerRegistryAuthPropertyValueNotFound(logger, dockerRegistry, null);
+      DockerRegistryAuthPropertyValueNotFoundCore(logger, dockerRegistry);
     }
 
     public static void DockerRegistryAuthPropertyValueInvalidBase64(this ILogger logger, string dockerRegistry, Exception e)
     {
-      _DockerRegistryAuthPropertyValueInvalidBase64(logger, dockerRegistry, e);
+      DockerRegistryAuthPropertyValueInvalidBase64Core(logger, dockerRegistry, e);
     }
 
     public static void DockerRegistryAuthPropertyValueInvalidBasicAuthenticationFormat(this ILogger logger, string dockerRegistry)
     {
-      _DockerRegistryAuthPropertyValueInvalidBasicAuthenticationFormat(logger, dockerRegistry, null);
+      DockerRegistryAuthPropertyValueInvalidBasicAuthenticationFormatCore(logger, dockerRegistry);
     }
 
     public static void DockerRegistryCredentialNotFound(this ILogger logger, string dockerRegistry)
     {
-      _DockerRegistryCredentialNotFound(logger, dockerRegistry, null);
+      DockerRegistryCredentialNotFoundCore(logger, dockerRegistry);
     }
 
     public static void DockerRegistryCredentialFound(this ILogger logger, string dockerRegistry)
     {
-      _DockerRegistryCredentialFound(logger, dockerRegistry, null);
+      DockerRegistryCredentialFoundCore(logger, dockerRegistry);
     }
 
     public static void ReusableExperimentalFeature(this ILogger logger)
     {
-      _ReusableExperimentalFeature(logger, null);
+      ReusableExperimentalFeatureCore(logger);
     }
 
     public static void ReusableResourceFound(this ILogger logger)
     {
-      _ReusableResourceFound(logger, null);
+      ReusableResourceFoundCore(logger);
     }
 
     public static void ReusableResourceNotFound(this ILogger logger)
     {
-      _ReusableResourceNotFound(logger, null);
+      ReusableResourceNotFoundCore(logger);
     }
 
     private static string TruncId(string id)

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -7,49 +7,64 @@ namespace DotNet.Testcontainers
   using DotNet.Testcontainers.Images;
   using Microsoft.Extensions.Logging;
 
+  internal readonly struct TruncatedId
+  {
+    private readonly string _id;
+
+    public TruncatedId(string id)
+    {
+      _id = id;
+    }
+
+    public override string ToString()
+    {
+      return _id.Substring(0, Math.Min(12, _id.Length));
+    }
+  }
+
   internal static partial class Logging
   {
     [LoggerMessage(Level = LogLevel.Information, Message = "Pattern {IgnorePattern} added to the regex cache")]
     private static partial void IgnorePatternAddedCore(ILogger logger, Regex ignorePattern);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Docker container {Id} created")]
-    private static partial void DockerContainerCreatedCore(ILogger logger, string id);
+    private static partial void DockerContainerCreatedCore(ILogger logger, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Start Docker container {Id}")]
-    private static partial void StartDockerContainerCore(ILogger logger, string id);
+    private static partial void StartDockerContainerCore(ILogger logger, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Stop Docker container {Id}")]
-    private static partial void StopDockerContainerCore(ILogger logger, string id);
+    private static partial void StopDockerContainerCore(ILogger logger, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Pause Docker container {Id}")]
-    private static partial void PauseDockerContainerCore(ILogger logger, string id);
+    private static partial void PauseDockerContainerCore(ILogger logger, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Unpause Docker container {Id}")]
-    private static partial void UnpauseDockerContainerCore(ILogger logger, string id);
+    private static partial void UnpauseDockerContainerCore(ILogger logger, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Delete Docker container {Id}")]
-    private static partial void DeleteDockerContainerCore(ILogger logger, string id);
+    private static partial void DeleteDockerContainerCore(ILogger logger, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Wait for Docker container {Id} to complete readiness checks")]
-    private static partial void StartReadinessCheckCore(ILogger logger, string id);
+    private static partial void StartReadinessCheckCore(ILogger logger, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Docker container {Id} ready")]
-    private static partial void CompleteReadinessCheckCore(ILogger logger, string id);
+    private static partial void CompleteReadinessCheckCore(ILogger logger, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Copy tar archive to container: Content length: {Length} byte(s), Docker container: {Id}")]
-    private static partial void CopyArchiveToDockerContainerCore(ILogger logger, long length, string id);
+    private static partial void CopyArchiveToDockerContainerCore(ILogger logger, long length, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Read \"{Path}\" from Docker container {Id}")]
-    private static partial void ReadArchiveFromDockerContainerCore(ILogger logger, string path, string id);
+    private static partial void ReadArchiveFromDockerContainerCore(ILogger logger, string path, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Attach {OutputConsumer} at Docker container {Id}")]
-    private static partial void AttachToDockerContainerCore(ILogger logger, Type outputConsumer, string id);
+    private static partial void AttachToDockerContainerCore(ILogger logger, Type outputConsumer, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Connect Docker container {ContainerId} to Docker network {NetworkId}")]
-    private static partial void ConnectToDockerNetworkCore(ILogger logger, string containerId, string networkId);
+    private static partial void ConnectToDockerNetworkCore(ILogger logger, TruncatedId containerId, TruncatedId networkId);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Execute \"{Command}\" at Docker container {Id}")]
-    private static partial void ExecuteCommandInDockerContainerCore(ILogger logger, string command, string id);
+    private static partial void ExecuteCommandInDockerContainerCore(ILogger logger, string command, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Docker image {FullName} created")]
     private static partial void DockerImageCreatedCore(ILogger logger, string fullName);
@@ -61,10 +76,10 @@ namespace DotNet.Testcontainers
     private static partial void DeleteDockerImageCore(ILogger logger, string fullName);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Docker network {Id} created")]
-    private static partial void DockerNetworkCreatedCore(ILogger logger, string id);
+    private static partial void DockerNetworkCreatedCore(ILogger logger, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Delete Docker network {Id}")]
-    private static partial void DeleteDockerNetworkCore(ILogger logger, string id);
+    private static partial void DeleteDockerNetworkCore(ILogger logger, TruncatedId id);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Docker volume {Name} created")]
     private static partial void DockerVolumeCreatedCore(ILogger logger, string name);
@@ -130,67 +145,67 @@ namespace DotNet.Testcontainers
 
     public static void DockerContainerCreated(this ILogger logger, string id)
     {
-      DockerContainerCreatedCore(logger, TruncId(id));
+      DockerContainerCreatedCore(logger, new TruncatedId(id));
     }
 
     public static void StartDockerContainer(this ILogger logger, string id)
     {
-      StartDockerContainerCore(logger, TruncId(id));
+      StartDockerContainerCore(logger, new TruncatedId(id));
     }
 
     public static void StopDockerContainer(this ILogger logger, string id)
     {
-      StopDockerContainerCore(logger, TruncId(id));
+      StopDockerContainerCore(logger, new TruncatedId(id));
     }
 
     public static void PauseDockerContainer(this ILogger logger, string id)
     {
-      PauseDockerContainerCore(logger, TruncId(id));
+      PauseDockerContainerCore(logger, new TruncatedId(id));
     }
 
     public static void UnpauseDockerContainer(this ILogger logger, string id)
     {
-      UnpauseDockerContainerCore(logger, TruncId(id));
+      UnpauseDockerContainerCore(logger, new TruncatedId(id));
     }
 
     public static void DeleteDockerContainer(this ILogger logger, string id)
     {
-      DeleteDockerContainerCore(logger, TruncId(id));
+      DeleteDockerContainerCore(logger, new TruncatedId(id));
     }
 
     public static void StartReadinessCheck(this ILogger logger, string id)
     {
-      StartReadinessCheckCore(logger, TruncId(id));
+      StartReadinessCheckCore(logger, new TruncatedId(id));
     }
 
     public static void CompleteReadinessCheck(this ILogger logger, string id)
     {
-      CompleteReadinessCheckCore(logger, TruncId(id));
+      CompleteReadinessCheckCore(logger, new TruncatedId(id));
     }
 
     public static void CopyArchiveToDockerContainer(this ILogger logger, string id, long length)
     {
-      CopyArchiveToDockerContainerCore(logger, length, TruncId(id));
+      CopyArchiveToDockerContainerCore(logger, length, new TruncatedId(id));
     }
 
     public static void ReadArchiveFromDockerContainer(this ILogger logger, string id, string path)
     {
-      ReadArchiveFromDockerContainerCore(logger, path, TruncId(id));
+      ReadArchiveFromDockerContainerCore(logger, path, new TruncatedId(id));
     }
 
     public static void AttachToDockerContainer(this ILogger logger, string id, Type type)
     {
-      AttachToDockerContainerCore(logger, type, TruncId(id));
+      AttachToDockerContainerCore(logger, type, new TruncatedId(id));
     }
 
     public static void ConnectToDockerNetwork(this ILogger logger, string networkId, string containerId)
     {
-      ConnectToDockerNetworkCore(logger, TruncId(containerId), TruncId(networkId));
+      ConnectToDockerNetworkCore(logger, new TruncatedId(containerId), new TruncatedId(networkId));
     }
 
     public static void ExecuteCommandInDockerContainer(this ILogger logger, string id, IEnumerable<string> command)
     {
-      ExecuteCommandInDockerContainerCore(logger, string.Join(" ", command), TruncId(id));
+      ExecuteCommandInDockerContainerCore(logger, string.Join(" ", command), new TruncatedId(id));
     }
 
     public static void DockerImageCreated(this ILogger logger, IImage image)
@@ -210,12 +225,12 @@ namespace DotNet.Testcontainers
 
     public static void DockerNetworkCreated(this ILogger logger, string id)
     {
-      DockerNetworkCreatedCore(logger, TruncId(id));
+      DockerNetworkCreatedCore(logger, new TruncatedId(id));
     }
 
     public static void DeleteDockerNetwork(this ILogger logger, string id)
     {
-      DeleteDockerNetworkCore(logger, TruncId(id));
+      DeleteDockerNetworkCore(logger, new TruncatedId(id));
     }
 
     public static void DockerVolumeCreated(this ILogger logger, string name)
@@ -313,11 +328,6 @@ namespace DotNet.Testcontainers
     public static void ReusableResourceNotFound(this ILogger logger)
     {
       ReusableResourceNotFoundCore(logger);
-    }
-
-    private static string TruncId(string id)
-    {
-      return id.Substring(0, Math.Min(12, id.Length));
     }
   }
 }

--- a/tests/Testcontainers.Tests/Assets/.dockerignore
+++ b/tests/Testcontainers.Tests/Assets/.dockerignore
@@ -1,6 +1,7 @@
 Dockerfile
 credHelpers
 credsStore
+buildFailure
 context
 healthWaitStrategy
 pullBaseImages

--- a/tests/Testcontainers.Tests/Assets/buildFailure/Dockerfile
+++ b/tests/Testcontainers.Tests/Assets/buildFailure/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.20.0@sha256:77726ef6b57ddf65bb551896826ec38bc3e53f75cdde31354fbffb4f25238ebd
+RUN command-that-does-not-exist

--- a/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Images/ImageFromDockerfileTest.cs
@@ -228,6 +228,24 @@ namespace DotNet.Testcontainers.Tests.Unit
       Assert.DoesNotContain(logger.Logs, line => line.Contains("FROM build AS final"));
     }
 
+    [Fact]
+    public async Task BuildFailureIncludesDetailedErrorMessage()
+    {
+      // Given
+      var imageFromDockerfileBuilder = new ImageFromDockerfileBuilder()
+        .WithDockerfileDirectory("Assets/buildFailure/")
+        .Build();
+
+      // When
+      var exception = await Assert.ThrowsAsync<ImageBuildFailedException>(() => imageFromDockerfileBuilder.CreateAsync(TestContext.Current.CancellationToken))
+        .ConfigureAwait(true);
+
+      // Then
+      Assert.StartsWith("Docker image ", exception.Message);
+      Assert.Contains(" has not been created.", exception.Message);
+      Assert.EndsWith("The command '/bin/sh -c command-that-does-not-exist' returned a non-zero code: 127", exception.Message);
+    }
+
     private sealed class TestLogger : ILogger
     {
       public IList<string> Logs { get; }


### PR DESCRIPTION
Bumps the `testcontainers/sshd` image used by `PortForwardingContainer` from 1.3.0 to 1.4.0 and updates the pinned SHA256 digest.

**Changes:**
- Tag: `1.3.0` → `1.4.0`
- Digest: `sha256:c50c0f59554dcdb2d9e5e705112144428ae9d04ac0af6322b365a18e24213a6a` → `sha256:bdae17f702908bee93c877ab3e97eddd782e2fb5bdd23a9f29869b9a87b30acd`

**Why:** 1.4.0 upgrades the base to Alpine 3.23 and adds `AddressFamily=any` to the sshd config, enabling IPv6 alongside IPv4.

**Tests:** Both `PortForwardingTest` variants (`PortForwardingDefaultConfiguration` and `PortForwardingNetworkConfiguration`) were run locally against the new image — both passed.