### PR TITLE
feat(CosmosDb): Add get method AccountEndpoint

### DIFF
--- a/src/Testcontainers.Azurite/AzuriteContainer.cs
+++ b/src/Testcontainers.Azurite/AzuriteContainer.cs
@@ -30,27 +30,27 @@ public sealed class AzuriteContainer : DockerContainer
     }
 
     /// <summary>
-    /// Gets the blob endpoint
+    /// Gets the blob endpoint.
     /// </summary>
-    /// <returns>The Azurite blob endpoint</returns>
+    /// <returns>The Azurite blob endpoint.</returns>
     public string GetBlobEndpoint()
     {
         return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.BlobPort), AzuriteBuilder.AccountName).ToString();
     }
 
     /// <summary>
-    /// Gets the queue endpoint
+    /// Gets the queue endpoint.
     /// </summary>
-    /// <returns>The Azurite queue endpoint</returns>
+    /// <returns>The Azurite queue endpoint.</returns>
     public string GetQueueEndpoint()
     {
         return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.QueuePort), AzuriteBuilder.AccountName).ToString();
     }
 
     /// <summary>
-    /// Gets the table endpoint
+    /// Gets the table endpoint.
     /// </summary>
-    /// <returns>The Azurite table endpoint</returns>
+    /// <returns>The Azurite table endpoint.</returns>
     public string GetTableEndpoint()
     {
         return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(AzuriteBuilder.TablePort), AzuriteBuilder.AccountName).ToString();

--- a/src/Testcontainers.CosmosDb/CosmosDbContainer.cs
+++ b/src/Testcontainers.CosmosDb/CosmosDbContainer.cs
@@ -21,7 +21,7 @@ public sealed class CosmosDbContainer : DockerContainer
     {
         var properties = new Dictionary<string, string>();
         properties.Add("AccountEndpoint", GetAccountEndpoint());
-        properties.Add("AccountKey", GetAccountKey());
+        properties.Add("AccountKey", CosmosDbBuilder.DefaultAccountKey);
         return string.Join(";", properties.Select(property => string.Join("=", property.Key, property.Value)));
     }
 
@@ -42,15 +42,6 @@ public sealed class CosmosDbContainer : DockerContainer
     public string GetAccountEndpoint()
     {
         return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(CosmosDbBuilder.CosmosDbPort)).ToString();
-    }
-    
-    /// <summary>
-    /// Gets the CosmosDb account key
-    /// </summary>
-    /// <returns>The CosmosDb account key</returns>
-    public string GetAccountKey()
-    {
-        return CosmosDbBuilder.DefaultAccountKey;
     }
 
     /// <summary>

--- a/src/Testcontainers.CosmosDb/CosmosDbContainer.cs
+++ b/src/Testcontainers.CosmosDb/CosmosDbContainer.cs
@@ -16,6 +16,11 @@ public sealed class CosmosDbContainer : DockerContainer
     /// <summary>
     /// Gets the CosmosDb connection string.
     /// </summary>
+    /// <remarks>
+    /// The connection string includes the emulator account endpoint and
+    /// the default account key permitted by the emulator, which is also
+    /// available through <see cref="CosmosDbBuilder.DefaultAccountKey" />.
+    /// </remarks>
     /// <returns>The CosmosDb connection string.</returns>
     public string GetConnectionString()
     {
@@ -23,6 +28,23 @@ public sealed class CosmosDbContainer : DockerContainer
         properties.Add("AccountEndpoint", GetAccountEndpoint());
         properties.Add("AccountKey", CosmosDbBuilder.DefaultAccountKey);
         return string.Join(";", properties.Select(property => string.Join("=", property.Key, property.Value)));
+    }
+
+    /// <summary>
+    /// Gets the CosmosDb account endpoint.
+    /// </summary>
+    /// <remarks>
+    /// This returns only the account endpoint. Use
+    /// <see cref="GetConnectionString" /> when you also need the default
+    /// account key permitted by the emulator. For more information, see
+    /// <see href="https://learn.microsoft.com/en-us/azure/cosmos-db/emulator">
+    /// Azure Cosmos DB emulator documentation
+    /// </see>.
+    /// </remarks>
+    /// <returns>The CosmosDb account endpoint.</returns>
+    public string GetAccountEndpoint()
+    {
+        return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(CosmosDbBuilder.CosmosDbPort)).ToString();
     }
 
     /// <summary>
@@ -34,15 +56,6 @@ public sealed class CosmosDbContainer : DockerContainer
     /// Gets a configured HTTP client that automatically trusts the CosmosDb Emulator's certificate.
     /// </summary>
     public HttpClient HttpClient => new HttpClient(HttpMessageHandler);
-    
-    /// <summary>
-    /// Gets the CosmosDb account endpoint
-    /// </summary>
-    /// <returns>The CosmosDb account endpoint</returns>
-    public string GetAccountEndpoint()
-    {
-        return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(CosmosDbBuilder.CosmosDbPort)).ToString();
-    }
 
     /// <summary>
     /// Rewrites the HTTP requests to target the running CosmosDb Emulator instance.

--- a/src/Testcontainers.CosmosDb/CosmosDbContainer.cs
+++ b/src/Testcontainers.CosmosDb/CosmosDbContainer.cs
@@ -20,8 +20,8 @@ public sealed class CosmosDbContainer : DockerContainer
     public string GetConnectionString()
     {
         var properties = new Dictionary<string, string>();
-        properties.Add("AccountEndpoint", new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(CosmosDbBuilder.CosmosDbPort)).ToString());
-        properties.Add("AccountKey", CosmosDbBuilder.DefaultAccountKey);
+        properties.Add("AccountEndpoint", GetAccountEndpoint());
+        properties.Add("AccountKey", GetAccountKey());
         return string.Join(";", properties.Select(property => string.Join("=", property.Key, property.Value)));
     }
 
@@ -34,6 +34,24 @@ public sealed class CosmosDbContainer : DockerContainer
     /// Gets a configured HTTP client that automatically trusts the CosmosDb Emulator's certificate.
     /// </summary>
     public HttpClient HttpClient => new HttpClient(HttpMessageHandler);
+    
+    /// <summary>
+    /// Gets the CosmosDb account endpoint
+    /// </summary>
+    /// <returns>The CosmosDb account endpoint</returns>
+    public string GetAccountEndpoint()
+    {
+        return new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(CosmosDbBuilder.CosmosDbPort)).ToString();
+    }
+    
+    /// <summary>
+    /// Gets the CosmosDb account key
+    /// </summary>
+    /// <returns>The CosmosDb account key</returns>
+    public string GetAccountKey()
+    {
+        return CosmosDbBuilder.DefaultAccountKey;
+    }
 
     /// <summary>
     /// Rewrites the HTTP requests to target the running CosmosDb Emulator instance.


### PR DESCRIPTION
## What does this PR do?
Add getters for Cosmos DB AccountEndpoint and AccountKey

## Why is it important?

Add a convenient way to access these properties

## Related issues

- Closes #1704 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public helper to retrieve the Cosmos DB emulator account endpoint URI.

* **Refactor**
  * Updated Cosmos DB connection string generation to populate the account endpoint using the new helper, rather than building it inline.

* **Documentation**
  * Refreshed XML documentation for Azurite endpoint helper methods (no behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->