### PR TITLE
chore: Bump sshd-docker image from 1.3.0 to 1.4.0

### DIFF
--- a/src/Testcontainers/Containers/PortForwarding.cs
+++ b/src/Testcontainers/Containers/PortForwarding.cs
@@ -61,7 +61,7 @@ namespace DotNet.Testcontainers.Containers
     [PublicAPI]
     private sealed class PortForwardingBuilder : ContainerBuilder<PortForwardingBuilder, PortForwardingContainer, PortForwardingConfiguration>
     {
-      public const string SshdImage = "testcontainers/sshd:1.3.0@sha256:c50c0f59554dcdb2d9e5e705112144428ae9d04ac0af6322b365a18e24213a6a";
+      public const string SshdImage = "testcontainers/sshd:1.4.0@sha256:bdae17f702908bee93c877ab3e97eddd782e2fb5bdd23a9f29869b9a87b30acd";
 
       public const ushort SshdPort = 22;
 


### PR DESCRIPTION
Bumps `testcontainers/sshd` from `1.3.0` to `1.4.0` in `PortForwarding.cs`, updating both the tag and the pinned SHA256 digest.

Notable changes in 1.4.0:
- Alpine bumped to 3.23
- Added `AddressFamily=any` sshd option (enables both IPv4 and IPv6)

New digest: `sha256:bdae17f702908bee93c877ab3e97eddd782e2fb5bdd23a9f29869b9a87b30acd`

**Tests:** `PortForwardingTest.EstablishesHostConnection` (both default and network configurations) — 2/2 passed locally against the new image.

Release: https://github.com/testcontainers/sshd-docker/releases/tag/1.4.0