### PR TITLE
feat: Add image name substitution hook

### DIFF
--- a/docs/custom_configuration/index.md
+++ b/docs/custom_configuration/index.md
@@ -61,6 +61,28 @@ Setting the context to `tcc` in this example will use the Docker host running at
     docker.context=tcc
     ```
 
+## Substitute image names
+
+Testcontainers supports substituting an image name with an alternative on the fly, for example to pull from a private registry mirror instead of Docker Hub. This is useful if you have complex rules that a simple prefix cannot express, such as a non-deterministic name mapping, rules depending on the developer or environment, or auditing and restricting the images used in a build.
+
+Set `TestcontainersSettings.ImageNameSubstitution` to a function that receives the original `IImage` and returns the image to use instead. Return the original image (or `null`) to leave it unchanged.
+
+Configure the substitution once before any test resources are created. A static class with a [`[ModuleInitializer]`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.moduleinitializerattribute) method runs automatically before the first type in the test assembly is used:
+
+```csharp
+internal static class TestcontainersConfiguration
+{
+  [ModuleInitializer]
+  public static void Initialize()
+  {
+    TestcontainersSettings.ImageNameSubstitution = image
+      => new DockerImage(image.Repository, "registry.mycompany.com", image.Tag, image.Digest, image.Platform);
+  }
+}
+```
+
+The substitution runs first, then the Docker Hub image name prefix (`TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX`) is applied to the substituted image. As with any image, the prefix is only added when the image does not already specify a registry, so a substitution that sets a registry (such as the examples above) takes precedence over the prefix.
+
 ## Automatically modify Docker Hub image names
 
 Testcontainers can automatically add a registry prefix to Docker Hub image names used in your tests. This is handy if you use a private registry that mirrors Docker Hub images with predictable naming.

--- a/src/Testcontainers/Builders/ContainerBuilder`3.cs
+++ b/src/Testcontainers/Builders/ContainerBuilder`3.cs
@@ -92,7 +92,7 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc />
     public TBuilderEntity WithImage(IImage image)
     {
-      return Clone(new ContainerConfiguration(image: image.ApplyHubImageNamePrefix()));
+      return Clone(new ContainerConfiguration(image: image.ApplyImageNameSubstitution()));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
+++ b/src/Testcontainers/Builders/ImageFromDockerfileBuilder.cs
@@ -60,7 +60,7 @@ namespace DotNet.Testcontainers.Builders
     /// <inheritdoc />
     public ImageFromDockerfileBuilder WithName(IImage image)
     {
-      return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(image: image.ApplyHubImageNamePrefix()));
+      return Merge(DockerResourceConfiguration, new ImageFromDockerfileConfiguration(image: image.ApplyImageNameSubstitution()));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -142,9 +142,11 @@ namespace DotNet.Testcontainers.Configurations
     /// </summary>
     /// <remarks>
     /// This allows replacing an image name with an alternative on the fly, for example to pull
-    /// from a private registry mirror instead of Docker Hub. The substitution runs before the
-    /// Docker Hub image name prefix is applied (see <see cref="HubImageNamePrefix" />).
-    /// Return the original image to leave it unchanged.
+    /// from a private registry mirror instead of Docker Hub. The substitution runs first; the
+    /// Docker Hub image name prefix (see <see cref="HubImageNamePrefix" />) is then applied to
+    /// the substituted image, but only if that image does not already specify a registry.
+    /// A substitution that sets a registry therefore takes precedence over the prefix.
+    /// Return the original image (or <see langword="null" />) to leave it unchanged.
     /// </remarks>
     [CanBeNull]
     public static Func<IImage, IImage> ImageNameSubstitution { get; set; }

--- a/src/Testcontainers/Configurations/TestcontainersSettings.cs
+++ b/src/Testcontainers/Configurations/TestcontainersSettings.cs
@@ -138,6 +138,18 @@ namespace DotNet.Testcontainers.Configurations
       = EnvironmentConfiguration.Instance.GetWaitStrategyTimeout() ?? PropertiesFileConfiguration.Instance.GetWaitStrategyTimeout();
 
     /// <summary>
+    /// Gets or sets a function that substitutes the image name before an image is pulled.
+    /// </summary>
+    /// <remarks>
+    /// This allows replacing an image name with an alternative on the fly, for example to pull
+    /// from a private registry mirror instead of Docker Hub. The substitution runs before the
+    /// Docker Hub image name prefix is applied (see <see cref="HubImageNamePrefix" />).
+    /// Return the original image to leave it unchanged.
+    /// </remarks>
+    [CanBeNull]
+    public static Func<IImage, IImage> ImageNameSubstitution { get; set; }
+
+    /// <summary>
     /// Gets or sets the host operating system.
     /// </summary>
     [NotNull]

--- a/src/Testcontainers/Images/IImageExtensions.cs
+++ b/src/Testcontainers/Images/IImageExtensions.cs
@@ -8,12 +8,27 @@ namespace DotNet.Testcontainers.Images
   internal static class IImageExtensions
   {
     /// <summary>
-    /// Applies the Docker Hub image name prefix if it is configured.
+    /// Applies the configured image name substitution and then the Docker Hub image name prefix.
     /// </summary>
     /// <param name="image">The original <see cref="IImage" /> instance.</param>
     /// <returns>
-    /// A new <see cref="IImage" /> instance with the Docker Hub image name prefix
-    /// applied, or the original instance if no prefix is set.
+    /// A new <see cref="IImage" /> instance with the configured substitution and Docker Hub image
+    /// name prefix applied, or the original instance if neither is configured.
+    /// </returns>
+    public static IImage ApplyImageNameSubstitution(this IImage image)
+    {
+      var substitution = TestcontainersSettings.ImageNameSubstitution;
+      var substitute = substitution == null ? image : substitution(image) ?? image;
+      return substitute.ApplyHubImageNamePrefix();
+    }
+
+    /// <summary>
+    /// Applies the configured Docker Hub image name prefix.
+    /// </summary>
+    /// <param name="image">The original <see cref="IImage" /> instance.</param>
+    /// <returns>
+    /// A new <see cref="IImage" /> instance with the configured Docker Hub image name prefix
+    /// applied, or the original instance if no prefix is configured.
     /// </returns>
     public static IImage ApplyHubImageNamePrefix(this IImage image)
     {

--- a/tests/Testcontainers.Tests/Unit/Configurations/DockerImageNameSubstitutionTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Configurations/DockerImageNameSubstitutionTest.cs
@@ -10,8 +10,108 @@ namespace DotNet.Testcontainers.Tests.Unit
   [CollectionDefinition(nameof(DockerImageNameSubstitutionTest), DisableParallelization = true)]
   public static class DockerImageNameSubstitutionTest
   {
+    public abstract class ImageNameSubstitutionTest : IDisposable
+    {
+      private bool _disposed;
+
+      protected ImageNameSubstitutionTest()
+      {
+        Reset();
+      }
+
+      public void Dispose()
+      {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+      }
+
+      protected virtual void Dispose(bool disposing)
+      {
+        if (_disposed)
+        {
+          return;
+        }
+
+        if (disposing)
+        {
+          Reset();
+        }
+
+        _disposed = true;
+      }
+
+      private static void Reset()
+      {
+        TestcontainersSettings.HubImageNamePrefix = string.Empty;
+        TestcontainersSettings.ImageNameSubstitution = null;
+      }
+    }
+
     [Collection(nameof(DockerImageNameSubstitutionTest))]
-    public sealed class HubImageNamePrefixIsSet : IDisposable
+    public sealed class ImageNameSubstitutionIsSet : ImageNameSubstitutionTest
+    {
+      [Fact]
+      public void SubstitutesImageNameForStringConfiguration()
+      {
+        // Given
+        TestcontainersSettings.ImageNameSubstitution = image => new DockerImage("my.proxy.com/mirror/" + image.FullName);
+
+        // When
+        IContainer container = new ContainerBuilder("bar:1.0.0")
+          .Build();
+
+        // Then
+        Assert.Equal("my.proxy.com/mirror/bar:1.0.0", container.Image.FullName);
+      }
+
+      [Fact]
+      public void SubstitutesImageNameForObjectConfiguration()
+      {
+        // Given
+        TestcontainersSettings.ImageNameSubstitution = image => new DockerImage("my.proxy.com/mirror/" + image.FullName);
+
+        IImage image = new DockerImage("bar:1.0.0");
+
+        // When
+        IContainer container = new ContainerBuilder(image)
+          .Build();
+
+        // Then
+        Assert.Equal("my.proxy.com/mirror/bar:1.0.0", container.Image.FullName);
+      }
+
+      [Fact]
+      public void SubstitutesImageNameBeforeHubImageNamePrefix()
+      {
+        // Given
+        TestcontainersSettings.HubImageNamePrefix = "my.proxy.com";
+        TestcontainersSettings.ImageNameSubstitution = image => new DockerImage("registry.azurecr.io/" + image.FullName);
+
+        // When
+        IContainer container = new ContainerBuilder("bar:1.0.0")
+          .Build();
+
+        // Then
+        Assert.Equal("registry.azurecr.io/bar:1.0.0", container.Image.FullName);
+      }
+
+      [Fact]
+      public void KeepsOriginalImageWhenSubstitutionReturnsNull()
+      {
+        // Given
+        TestcontainersSettings.ImageNameSubstitution = _ => null;
+
+        // When
+        IContainer container = new ContainerBuilder("bar:1.0.0")
+          .Build();
+
+        // Then
+        Assert.Equal("bar:1.0.0", container.Image.FullName);
+      }
+    }
+
+    [Collection(nameof(DockerImageNameSubstitutionTest))]
+    public sealed class HubImageNamePrefixIsSet : ImageNameSubstitutionTest
     {
       public static TheoryData<string, string, string> Substitutions { get; }
         = new TheoryData<string, string, string>
@@ -60,21 +160,11 @@ namespace DotNet.Testcontainers.Tests.Unit
         // Then
         Assert.Equal(expectedFullName, container.Image.FullName);
       }
-
-      public void Dispose()
-      {
-        TestcontainersSettings.HubImageNamePrefix = string.Empty;
-      }
     }
 
     [Collection(nameof(DockerImageNameSubstitutionTest))]
-    public sealed class HubImageNamePrefixIsNotSet
+    public sealed class HubImageNamePrefixIsNotSet : ImageNameSubstitutionTest
     {
-      public HubImageNamePrefixIsNotSet()
-      {
-        TestcontainersSettings.HubImageNamePrefix = string.Empty;
-      }
-
       [Fact]
       public void DoNotPrependForStringConfiguration()
       {


### PR DESCRIPTION
## What does this PR do?

Adds `TestcontainersSettings.ImageNameSubstitution`, a `Func<IImage, IImage>` hook that lets users replace any image name before it is pulled. This is the .NET equivalent of Java's `ImageNameSubstitutor`.

The substitution runs before the existing `HubImageNamePrefix` is applied, so both mechanisms can be combined. Returning `null` from the function falls back to the original image name.

```csharp
TestcontainersSettings.ImageNameSubstitution = image => new DockerImage("registry.mycompany.com/mirror/" + image.FullName);
```

/cc @scrocquesel-ml150

## Why is it important?

This helps users to redirect image pulls to a private registry mirror (e.g., to avoid Docker Hub rate limits), apply custom routing rules that go beyond simple prefix matching, and audit or restrict which container images can be used in a build.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1705

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom image name substitution, enabling transformation of container images before deployment.

* **Documentation**
  * Added documentation for the new image name substitution configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->