### PR TITLE
chore(AspireDashboard): Cover connection string provider

### DIFF
--- a/src/Testcontainers.AspireDashboard/AspireDashboardConnectionStringProvider.cs
+++ b/src/Testcontainers.AspireDashboard/AspireDashboardConnectionStringProvider.cs
@@ -8,6 +8,6 @@ internal sealed class AspireDashboardConnectionStringProvider : ContainerConnect
     /// <inheritdoc />
     protected override string GetHostConnectionString()
     {
-        return Container.GetConnectionString();
+        return Container.GetDashboardAddress();
     }
 }

--- a/tests/Testcontainers.AspireDashboard.Tests/AspireDashboardContainerTest.cs
+++ b/tests/Testcontainers.AspireDashboard.Tests/AspireDashboardContainerTest.cs
@@ -29,11 +29,12 @@ public sealed class AspireDashboardContainerTest : IAsyncLifetime
         httpClient.BaseAddress = new Uri(_aspireDashboardContainer.GetDashboardAddress());
 
         // When
-        using var response = await httpClient.GetAsync("/", TestContext.Current.CancellationToken)
+        using var httpResponse = await httpClient.GetAsync("/", TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+        Assert.Equal(_aspireDashboardContainer.GetDashboardAddress(), _aspireDashboardContainer.GetConnectionString());
     }
 
     [Fact]


### PR DESCRIPTION
## What does this PR do?

This PR adds an assertion to test the Aspire dashboard connection string provider implementation and fixes an issue where the provider resolved the wrong method, causing it to enter an infinite loop.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard connection handling so the application now uses the correct dashboard address when building the host connection string.
  * Added verification that the dashboard endpoint remains reachable and returns a successful response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->