### PR TITLE
chore: Enable Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7      
     labels:
       - dependencies
     groups:
@@ -17,6 +19,8 @@ updates:
     open-pull-requests-limit: 3
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 7      
     labels:
       - dependencies
     ignore:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update schedules to add a 7-day cooldown after monthly checks for GitHub Actions and NuGet updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->