### PR TITLE
fix: Restore tar archive write performance regressed by padding trim

### DIFF
--- a/src/Testcontainers/Images/DockerfileArchive.cs
+++ b/src/Testcontainers/Images/DockerfileArchive.cs
@@ -192,7 +192,7 @@ namespace DotNet.Testcontainers.Images
 
       using (var tarOutputFileStream = new FileStream(dockerfileArchiveFilePath, FileMode.Create, FileAccess.Write))
       {
-        using (var tarOutputStream = new TarOutputStream(tarOutputFileStream, TarArchiveDefaults.TarBlockFactor, Encoding.Default))
+        using (var tarOutputStream = new TarOutputStream(tarOutputFileStream, Encoding.Default))
         {
           tarOutputStream.IsStreamOwner = false;
 

--- a/src/Testcontainers/TarArchiveDefaults.cs
+++ b/src/Testcontainers/TarArchiveDefaults.cs
@@ -4,18 +4,18 @@ namespace DotNet.Testcontainers
   {
     // A block factor of 1 keeps the record size equal to the block size (512 B),
     // so SharpZipLib writes no extra zero padding beyond the two standard EOF
-    // blocks. The default factor of 20 produces ~8 KB of trailing zeros, which
-    // can trigger a race in Podman's archive handler. The tar subprocess exits
-    // after the EOF blocks while the HTTP sender is still flushing the padding,
-    // resulting in an EPIPE (HTTP 500 "broken pipe"). See:
-    // https://github.com/testcontainers/testcontainers-dotnet/issues/1683.
+    // blocks. The default factor of 20 produces up to 9 KiB of trailing zero
+    // padding, which can trigger a race in Podman's archive handler. The tar
+    // subprocess exits after the EOF blocks while the HTTP sender is still
+    // flushing the padding, resulting in an EPIPE (HTTP 500 "broken pipe").
+    // See: https://github.com/testcontainers/testcontainers-dotnet/issues/1683.
     //
     // The race only affects PUT /containers/{id}/archive (resource mappings via
     // a MemoryStream). Buildah's copierHandlerPut returned immediately after
     // tar.Reader reached io.EOF without draining the pipe. POST /build is immune
     // because containers/storage's chrootarchive.Untar always drains stdin after
-    // extraction. The server-side fix landed in buildah. See:
-    // https://github.com/podman-container-tools/buildah/pull/6678.
+    // extraction. The server-side fix landed in buildah.
+    // See: https://github.com/podman-container-tools/buildah/pull/6678.
     // Keeping the block factor at 1 stays correct for older Podman versions.
     //
     // Do NOT use this for the Dockerfile build context, which is written to a

--- a/src/Testcontainers/TarArchiveDefaults.cs
+++ b/src/Testcontainers/TarArchiveDefaults.cs
@@ -2,20 +2,26 @@ namespace DotNet.Testcontainers
 {
   internal static class TarArchiveDefaults
   {
-    // Keep the record size equal to the block size (512 B) so SharpZipLib does
-    // not write extra zero padding beyond the two standard EOF blocks. The
-    // default factor of 20 produces ~8 KB of zeros after EOF, which can trigger
-    // a race in Podman's archive handler. The tar subprocess exits after the EOF
-    // blocks while the HTTP sender is still flushing the padding, causing EPIPE
-    // (HTTP 500 "broken pipe"). See:
+    // A block factor of 1 keeps the record size equal to the block size (512 B),
+    // so SharpZipLib writes no extra zero padding beyond the two standard EOF
+    // blocks. The default factor of 20 produces ~8 KB of trailing zeros, which
+    // can trigger a race in Podman's archive handler. The tar subprocess exits
+    // after the EOF blocks while the HTTP sender is still flushing the padding,
+    // resulting in an EPIPE (HTTP 500 "broken pipe"). See:
     // https://github.com/testcontainers/testcontainers-dotnet/issues/1683.
     //
-    // This only applies to archives we stream to the daemon over a pipe (resource
-    // mappings via a MemoryStream), where the surplus padding is both unnecessary
-    // and harmful. Do NOT reuse it for the Dockerfile build context, which is
-    // written to a FileStream on disk: a 512 B record forces a write and flush per
-    // block and regresses image builds. That path keeps SharpZipLib's default block
-    // factor on purpose.
+    // The race only affects PUT /containers/{id}/archive (resource mappings via
+    // a MemoryStream). Buildah's copierHandlerPut returned immediately after
+    // tar.Reader reached io.EOF without draining the pipe. POST /build is immune
+    // because containers/storage's chrootarchive.Untar always drains stdin after
+    // extraction. The server-side fix landed in buildah. See:
+    // https://github.com/podman-container-tools/buildah/pull/6678.
+    // Keeping the block factor at 1 stays correct for older Podman versions.
+    //
+    // Do NOT use this for the Dockerfile build context, which is written to a
+    // FileStream on disk: at 512 B per record, SharpZipLib flushes on every
+    // block, which regresses image build performance. That path intentionally
+    // keeps SharpZipLib's default block factor.
     internal const int TarBlockFactor = 1;
   }
 }

--- a/src/Testcontainers/TarArchiveDefaults.cs
+++ b/src/Testcontainers/TarArchiveDefaults.cs
@@ -9,6 +9,13 @@ namespace DotNet.Testcontainers
     // blocks while the HTTP sender is still flushing the padding, causing EPIPE
     // (HTTP 500 "broken pipe"). See:
     // https://github.com/testcontainers/testcontainers-dotnet/issues/1683.
+    //
+    // This only applies to archives we stream to the daemon over a pipe (resource
+    // mappings via a MemoryStream), where the surplus padding is both unnecessary
+    // and harmful. Do NOT reuse it for the Dockerfile build context, which is
+    // written to a FileStream on disk: a 512 B record forces a write and flush per
+    // block and regresses image builds. That path keeps SharpZipLib's default block
+    // factor on purpose.
     internal const int TarBlockFactor = 1;
   }
 }


### PR DESCRIPTION
## What does this PR do?

The block factor of 1 introduced to fix the Podman EPIPE race (https://github.com/podman-container-tools/buildah/pull/6678) was inadvertently applied to the Dockerfile build context path (`DockerfileArchive`), which writes to a FileStream on disk. At a block factor of 1, SharpZipLib flushes on every 512-byte block, significantly degrading image build performance.

/cc @Rob-Hague @artiomchi

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates https://github.com/testcontainers/testcontainers-dotnet/pull/1684#issuecomment-4825305495

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tar archive creation to reduce intermittent failures when generating or uploading tar-based build contexts in container environments.

* **Documentation**
  * Expanded guidance on tar block factor usage, including why a value of `1` is recommended to avoid padding-related issues that can surface as broken-pipe errors, and cautioned against using the setting for Dockerfile build context due to performance impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->