### PR TITLE
chore: Set Cake build solution file path to Testcontainers.slnx

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
         <PackageVersion Include="SSH.NET" Version="2025.1.0"/>
         <!-- Cake build: -->
         <PackageVersion Include="Cake.Frosting.Git" Version="5.0.1"/>
-        <PackageVersion Include="Cake.Frosting" Version="5.1.0"/>
+        <PackageVersion Include="Cake.Frosting" Version="6.2.0"/>
         <PackageVersion Include="Cake.Sonar" Version="5.0.0"/>
         <!-- Unit and integration test dependencies: -->
         <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>

--- a/Testcontainers.slnx
+++ b/Testcontainers.slnx
@@ -12,6 +12,9 @@
         <File Path=".github/workflows/scorecard-analysis.yml"/>
         <File Path=".github/workflows/test-report.yml"/>
     </Folder>
+    <Folder Name="/build/">
+        <Project Path="build/Build.csproj" />
+    </Folder>
     <Folder Name="/src/">
         <Project Path="src/Testcontainers.ActiveMq/Testcontainers.ActiveMq.csproj"/>
         <Project Path="src/Testcontainers.ArangoDb/Testcontainers.ArangoDb.csproj"/>

--- a/build/Parameters.cs
+++ b/build/Parameters.cs
@@ -31,7 +31,7 @@ internal sealed class BuildParameters
     public static BuildParameters Instance(ICakeContext context)
     {
         const string propertiesFilePath = "Directory.Build.props";
-        const string solutionFilePath = "Testcontainers.sln";
+        const string solutionFilePath = "Testcontainers.slnx";
 
         var buildInformation = BuildInformation.Instance(context, propertiesFilePath);
 


### PR DESCRIPTION
## What does this PR do?

Update Testcontainers.sln to Testcontainers.slnx in the cake build parameters.

Also update Cake.Frosting to latest version (6.2.0) and add the Build project to the solution.

## Why is it important?

#1725 broke the CI build. 😕

## Related issues

- Relates #1725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build tooling package to a newer version.
  * Added the build project to the solution structure.
  * Updated build configuration to use the current solution file for project discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->