### PR TITLE
fix(MongoDb): Treat an already initiated replica set as success

### DIFF
--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -204,7 +204,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
         // with custom configurations as needed.
         var options = new WaitStrategy();
 
-        // The startup callback runs on every start, so a container that is restarted or reused
+        // The startup callback runs on every start, a container that is restarted or reused
         // already holds an initiated replica set. Initiating it again throws instead of returning
         // a result, which would otherwise be retried until the wait strategy times out:
         // https://github.com/testcontainers/testcontainers-dotnet/issues/1722.

--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -204,7 +204,11 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
         // with custom configurations as needed.
         var options = new WaitStrategy();
 
-        var scriptContent = $"var r=rs.initiate({{_id:\"{configuration.ReplicaSetName}\",members:[{{_id:0,host:\"127.0.0.1:27017\"}}]}});quit(r.ok===1?0:1);";
+        // The startup callback runs on every start, so a container that is restarted or reused
+        // already holds an initiated replica set. Initiating it again throws instead of returning
+        // a result, which would otherwise be retried until the wait strategy times out:
+        // https://github.com/testcontainers/testcontainers-dotnet/issues/1722.
+        var scriptContent = $"try{{var r=rs.initiate({{_id:\"{configuration.ReplicaSetName}\",members:[{{_id:0,host:\"127.0.0.1:27017\"}}]}});quit(r.ok===1?0:1);}}catch(e){{quit(e.codeName===\"AlreadyInitialized\"?0:1);}}";
 
         var initiate = async () =>
         {

--- a/tests/Testcontainers.MongoDb.Tests/MongoDbReplicaSetReuseTest.cs
+++ b/tests/Testcontainers.MongoDb.Tests/MongoDbReplicaSetReuseTest.cs
@@ -1,9 +1,5 @@
 namespace Testcontainers.MongoDb;
 
-/// <summary>
-/// Reusing a container runs the startup callback again against a replica set that is already
-/// initiated (https://github.com/testcontainers/testcontainers-dotnet/issues/1722).
-/// </summary>
 public sealed class MongoDbReplicaSetReuseTest : IAsyncLifetime
 {
     private readonly string _labelKey = Guid.NewGuid().ToString("D");
@@ -12,61 +8,53 @@ public sealed class MongoDbReplicaSetReuseTest : IAsyncLifetime
 
     private readonly IList<MongoDbContainer> _containers = new List<MongoDbContainer>();
 
-    public ValueTask InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return ValueTask.CompletedTask;
+        for (var _ = 0; _ < 3; _++)
+        {
+            var container = new MongoDbBuilder(TestSession.GetImageFromDockerfile())
+                .WithReplicaSet()
+                .WithLabel(_labelKey, _labelValue)
+                .WithReuse(true)
+                .Build();
+
+            await container.StartAsync()
+                .ConfigureAwait(false);
+
+            _containers.Add(container);
+        }
     }
 
     public async ValueTask DisposeAsync()
     {
-        foreach (var container in _containers.Distinct())
-        {
-            await container.DisposeAsync()
-                .ConfigureAwait(false);
-        }
-
-        GC.SuppressFinalize(this);
+        await Task.WhenAll(_containers
+            .Take(1)
+            .Select(container =>
+            {
+                // We do not want to leak resources, but `WithCleanUp(true)` cannot be used
+                // alongside `WithReuse(true)`. As a workaround, we set the `SessionId` using
+                // reflection afterward to delete the container.
+                container.AsDynamic()._configuration.SessionId = ResourceReaper.DefaultSessionId;
+                return container.DisposeAsync().AsTask();
+            }));
     }
 
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
-    public async Task ReusedContainerStartsAgain()
+    public async Task ReusesSameContainerAcrossMultipleStarts()
     {
         // Given
-        // The default wait strategy timeout is one hour, so bound the wait to keep a regression
-        // from hanging the test run instead of failing it.
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        const string scriptContent = "rs.status().ok;";
 
-        var container = CreateContainer();
-        _containers.Add(container);
-
-        await container.StartAsync(cts.Token)
-            .ConfigureAwait(true);
+        var mongoDbContainer = _containers[^1];
 
         // When
-        var reusedContainer = CreateContainer();
-        _containers.Add(reusedContainer);
-
-        await reusedContainer.StartAsync(cts.Token)
+        var execResult = await mongoDbContainer.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
-        Assert.Equal(container.Id, reusedContainer.Id);
-
-        const string scriptContent = "rs.status().ok;";
-
-        var execResult = await reusedContainer.ExecScriptAsync(scriptContent, cts.Token)
-            .ConfigureAwait(true);
-
         Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
-    }
-
-    private MongoDbContainer CreateContainer()
-    {
-        return new MongoDbBuilder(TestSession.GetImageFromDockerfile())
-            .WithReplicaSet()
-            .WithLabel(_labelKey, _labelValue)
-            .WithReuse(true)
-            .Build();
+        Assert.Empty(execResult.Stderr);
+        Assert.Single(_containers.Select(container => container.Id).Distinct());
     }
 }

--- a/tests/Testcontainers.MongoDb.Tests/MongoDbReplicaSetReuseTest.cs
+++ b/tests/Testcontainers.MongoDb.Tests/MongoDbReplicaSetReuseTest.cs
@@ -1,0 +1,72 @@
+namespace Testcontainers.MongoDb;
+
+/// <summary>
+/// Reusing a container runs the startup callback again against a replica set that is already
+/// initiated (https://github.com/testcontainers/testcontainers-dotnet/issues/1722).
+/// </summary>
+public sealed class MongoDbReplicaSetReuseTest : IAsyncLifetime
+{
+    private readonly string _labelKey = Guid.NewGuid().ToString("D");
+
+    private readonly string _labelValue = Guid.NewGuid().ToString("D");
+
+    private readonly IList<MongoDbContainer> _containers = new List<MongoDbContainer>();
+
+    public ValueTask InitializeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var container in _containers.Distinct())
+        {
+            await container.DisposeAsync()
+                .ConfigureAwait(false);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+    public async Task ReusedContainerStartsAgain()
+    {
+        // Given
+        // The default wait strategy timeout is one hour, so bound the wait to keep a regression
+        // from hanging the test run instead of failing it.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+
+        var container = CreateContainer();
+        _containers.Add(container);
+
+        await container.StartAsync(cts.Token)
+            .ConfigureAwait(true);
+
+        // When
+        var reusedContainer = CreateContainer();
+        _containers.Add(reusedContainer);
+
+        await reusedContainer.StartAsync(cts.Token)
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Equal(container.Id, reusedContainer.Id);
+
+        const string scriptContent = "rs.status().ok;";
+
+        var execResult = await reusedContainer.ExecScriptAsync(scriptContent, cts.Token)
+            .ConfigureAwait(true);
+
+        Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
+    }
+
+    private MongoDbContainer CreateContainer()
+    {
+        return new MongoDbBuilder(TestSession.GetImageFromDockerfile())
+            .WithReplicaSet()
+            .WithLabel(_labelKey, _labelValue)
+            .WithReuse(true)
+            .Build();
+    }
+}

--- a/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
+++ b/tests/Testcontainers.MongoDb.Tests/Testcontainers.MongoDb.Tests.csproj
@@ -9,6 +9,7 @@
         <!-- -8<- [start:PackageReferences] -->
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="ReflectionMagic"/>
         <PackageReference Include="xunit.runner.visualstudio"/>
         <PackageReference Include="xunit.v3"/>
         <PackageReference Include="MongoDB.Driver"/>

--- a/tests/Testcontainers.MongoDb.Tests/Usings.cs
+++ b/tests/Testcontainers.MongoDb.Tests/Usings.cs
@@ -1,10 +1,11 @@
 global using System;
 global using System.Collections.Generic;
 global using System.Linq;
-global using System.Threading;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
 global using DotNet.Testcontainers.Configurations;
+global using DotNet.Testcontainers.Containers;
 global using JetBrains.Annotations;
 global using MongoDB.Driver;
+global using ReflectionMagic;
 global using Xunit;

--- a/tests/Testcontainers.MongoDb.Tests/Usings.cs
+++ b/tests/Testcontainers.MongoDb.Tests/Usings.cs
@@ -1,4 +1,7 @@
 global using System;
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Threading;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
 global using DotNet.Testcontainers.Configurations;


### PR DESCRIPTION
Fixes #1722

## The problem

`UnsafeStartAsync` invokes the startup callback on every start, so a reused container runs `InitiateReplicaSetAsync` against a replica set that is already initiated.

The script it runs is not idempotent:

```js
var r = rs.initiate({_id:"rs0", members:[{_id:0, host:"127.0.0.1:27017"}]});
quit(r.ok === 1 ? 0 : 1);
```

On a set that already exists, `rs.initiate` **throws** rather than returning a result, so `var r` is never assigned and mongosh exits non-zero:

```
MongoServerError: already initialized
  code: 23
  codeName: 'AlreadyInitialized'
```

`WaitStrategy.WaitUntilAsync` then retries the script on its interval. The default wait strategy timeout is one hour, which is why the reporter saw the same `mongosh` exec repeat "without ever resolving".

## The fix

Catch the error and treat `AlreadyInitialized` as success, so the startup callback is idempotent:

```js
try { var r = rs.initiate({...}); quit(r.ok === 1 ? 0 : 1); }
catch (e) { quit(e.codeName === "AlreadyInitialized" ? 0 : 1); }
```

Any other server error still exits non-zero and is still retried, so a genuinely failing initiation behaves as before.

## Testing

`MongoDbReplicaSetReuseTest.ReusedContainerStartsAgain` starts the same replica set container twice with `WithReuse(true)`, asserts the second start reused the first container, and asserts the replica set is healthy afterwards.

- Before the change: times out (bounded to 3 minutes in the test so a regression fails rather than hangs).
- After the change: passes in about 7 seconds.
- Full `Testcontainers.MongoDb.Tests` suite: 19 passed, 0 failed.

The test bounds its own wait because the default wait strategy timeout is one hour; without a bound a regression would stall a CI run rather than fail it.

## A related defect, not addressed here

While testing this I first wrote the regression test as a stop/start restart rather than reuse, and hit a different problem in `WaitIndicateReadiness`:

```csharp
var (stdout, stderr) = await container.GetLogsAsync(since: container.StoppedTime, timestampsEnabled: false);
return _count.Equals(... .Count(line => line.Contains("Waiting for connections")));
```

It asserts the count is **exactly** 1 or 2 over logs taken since `StoppedTime`, which is not restart-safe in either direction:

- After a restart the window spans the previous and the new boot, so the count exceeds `_count` and the equality can never hold. The container start hangs.
- A single stale "Waiting for connections" line from the previous run can satisfy the check before the new `mongod` is listening, so the start returns early and the next command fails with `MongoNetworkError: connect ECONNREFUSED 127.0.0.1:27017`.

I have kept that out of this pull request since it is a separate defect with its own design question, and raised it separately. Happy to pick it up if you would like it fixed the same way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MongoDB replica-set startup when reusing or restarting containers.
  - Recognizes an already-initialized replica set as successful, allowing startup callbacks to run safely.
  - Other initialization failures continue to be reported.

- **Tests**
  - Added coverage verifying reusable MongoDB replica-set containers can start again successfully and retain replica-set status.
  - Confirmed multiple starts resolve to the same container instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->