### PR TITLE
fix(MongoDb): Probe the server instead of counting log messages before initiating

### DIFF
--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -198,7 +198,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
             return;
         }
 
-        var readiness = new WaitIndicateReadiness(configuration);
+        var readiness = new WaitReplicationEnabled();
 
         // This is a simple workaround to use the default options, which can be configured
         // with custom configurations as needed.
@@ -227,6 +227,32 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
     }
 
     /// <inheritdoc cref="IWaitUntil" />
+    /// <inheritdoc cref="IWaitUntil" />
+    private sealed class WaitReplicationEnabled : IWaitUntil
+    {
+        // rs.status() only answers once the final mongod is serving. The official image forks a
+        // temporary mongod during first-time initialization to create the root user, and that
+        // process is not started with --replSet, so it never reports NotYetInitialized. This
+        // preserves the handover guarantee from #1636 without counting log messages, whose
+        // number depends on log content the module does not control: #1732.
+        private const string ScriptContent = "try{rs.status();quit(0);}catch(e){quit(e.codeName===\"NotYetInitialized\"?0:1);}";
+
+        /// <inheritdoc />
+        public Task<bool> UntilAsync(IContainer container)
+        {
+            return UntilAsync(container as MongoDbContainer);
+        }
+
+        /// <inheritdoc cref="IWaitUntil.UntilAsync" />
+        private static async Task<bool> UntilAsync(MongoDbContainer container)
+        {
+            var execResult = await container.ExecScriptAsync(ScriptContent)
+                .ConfigureAwait(false);
+
+            return 0L.Equals(execResult.ExitCode);
+        }
+    }
+
     private sealed class WaitIndicateReadiness : IWaitUntil
     {
         private static readonly string[] LineEndings = { "\r\n", "\n" };

--- a/src/Testcontainers.MongoDb/MongoDbBuilder.cs
+++ b/src/Testcontainers.MongoDb/MongoDbBuilder.cs
@@ -130,7 +130,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
         }
         else
         {
-            waitUntil = new WaitInitiateReplicaSet();
+            waitUntil = new WaitReplicaSetPrimary();
         }
 
         // If the user does not provide a custom waiting strategy, append the default MongoDb waiting strategy.
@@ -198,7 +198,7 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
             return;
         }
 
-        var readiness = new WaitReplicationEnabled();
+        var readiness = new WaitReplicaSetEnabled();
 
         // This is a simple workaround to use the default options, which can be configured
         // with custom configurations as needed.
@@ -231,32 +231,6 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
     }
 
     /// <inheritdoc cref="IWaitUntil" />
-    /// <inheritdoc cref="IWaitUntil" />
-    private sealed class WaitReplicationEnabled : IWaitUntil
-    {
-        // rs.status() only answers once the final mongod is serving. The official image forks a
-        // temporary mongod during first-time initialization to create the root user, and that
-        // process is not started with --replSet, so it never reports NotYetInitialized. This
-        // preserves the handover guarantee from #1636 without counting log messages, whose
-        // number depends on log content the module does not control: #1732.
-        private const string ScriptContent = "try{rs.status();quit(0);}catch(e){quit(e.codeName===\"NotYetInitialized\"?0:1);}";
-
-        /// <inheritdoc />
-        public Task<bool> UntilAsync(IContainer container)
-        {
-            return UntilAsync(container as MongoDbContainer);
-        }
-
-        /// <inheritdoc cref="IWaitUntil.UntilAsync" />
-        private static async Task<bool> UntilAsync(MongoDbContainer container)
-        {
-            var execResult = await container.ExecScriptAsync(ScriptContent)
-                .ConfigureAwait(false);
-
-            return 0L.Equals(execResult.ExitCode);
-        }
-    }
-
     private sealed class WaitIndicateReadiness : IWaitUntil
     {
         private static readonly string[] LineEndings = { "\r\n", "\n" };
@@ -286,9 +260,9 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
     }
 
     /// <inheritdoc cref="IWaitUntil" />
-    private sealed class WaitInitiateReplicaSet : IWaitUntil
+    private abstract class WaitUntilScriptBase : IWaitUntil
     {
-        private const string ScriptContent = "var r=db.runCommand({hello:1}).isWritablePrimary;quit(r===true?0:1);";
+        protected abstract string ScriptContent { get; }
 
         /// <inheritdoc />
         public Task<bool> UntilAsync(IContainer container)
@@ -297,12 +271,28 @@ public sealed class MongoDbBuilder : ContainerBuilder<MongoDbBuilder, MongoDbCon
         }
 
         /// <inheritdoc cref="IWaitUntil.UntilAsync" />
-        private static async Task<bool> UntilAsync(MongoDbContainer container)
+        private async Task<bool> UntilAsync(MongoDbContainer container)
         {
             var execResult = await container.ExecScriptAsync(ScriptContent)
                 .ConfigureAwait(false);
 
             return 0L.Equals(execResult.ExitCode);
         }
+    }
+
+    /// <inheritdoc cref="IWaitUntil" />
+    private sealed class WaitReplicaSetEnabled : WaitUntilScriptBase
+    {
+        // rs.status() only answers once the final mongod is serving. The official image
+        // forks a temporary mongod during first-time initialization to create the root
+        // user. That process is not started with --replSet, so it never reports
+        // NotYetInitialized.
+        protected override string ScriptContent => "try{rs.status();quit(0);}catch(e){quit(e.codeName===\"NotYetInitialized\"?0:1);}";
+    }
+
+    /// <inheritdoc cref="IWaitUntil" />
+    private sealed class WaitReplicaSetPrimary : WaitUntilScriptBase
+    {
+        protected override string ScriptContent => "var r=db.runCommand({hello:1}).isWritablePrimary;quit(r===true?0:1);";
     }
 }

--- a/tests/Testcontainers.MongoDb.Tests/MongoDbReplicaSetReadinessTest.cs
+++ b/tests/Testcontainers.MongoDb.Tests/MongoDbReplicaSetReadinessTest.cs
@@ -1,59 +1,40 @@
-using System.Text;
-using System.Threading;
-using DotNet.Testcontainers.Configurations;
-
 namespace Testcontainers.MongoDb;
 
-/// <summary>
-/// The readiness check that runs before the replica set is initiated counts occurrences of a log
-/// message and compares that count for equality. Any other log line carrying the same text pushes
-/// the count past the expected value, and it can then never match
-/// (https://github.com/testcontainers/testcontainers-dotnet/issues/1732).
-/// </summary>
 public sealed class MongoDbReplicaSetReadinessTest : IAsyncLifetime
 {
-    private const string ExtraMarkerScriptFilePath = "/docker-entrypoint-initdb.d/00-extra-marker.sh";
+    private const string ReadinessMessagesScriptContent = "#!/bin/sh\necho 'Waiting for connections'\necho 'Waiting for connections'\n";
+
+    private const string ReadinessMessagesScriptFilePath = "/docker-entrypoint-initdb.d/00-readiness-messages.sh";
 
     private readonly MongoDbContainer _mongoDbContainer = new MongoDbBuilder(TestSession.GetImageFromDockerfile())
         .WithReplicaSet()
-        .WithResourceMapping(
-            Encoding.Default.GetBytes("#!/bin/bash\necho 'Waiting for connections'\necho 'Waiting for connections'\n"),
-            ExtraMarkerScriptFilePath,
-            fileMode: Unix.FileMode755)
+        .WithResourceMapping(Encoding.Default.GetBytes(ReadinessMessagesScriptContent), ReadinessMessagesScriptFilePath, fileMode: Unix.FileMode755)
         .Build();
 
-    public ValueTask InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
-        return ValueTask.CompletedTask;
+        await _mongoDbContainer.StartAsync()
+            .ConfigureAwait(false);
     }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        await _mongoDbContainer.DisposeAsync()
-            .ConfigureAwait(false);
-
-        GC.SuppressFinalize(this);
+        return _mongoDbContainer.DisposeAsync();
     }
 
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
-    public async Task StartsWhenTheLogContainsAdditionalReadinessMessages()
+    public async Task StartsWithAdditionalReadinessMessages()
     {
         // Given
-        // The default wait strategy timeout is one hour, so bound the wait to keep a regression
-        // from stalling the test run instead of failing it.
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+        const string scriptContent = "rs.status().ok;";
 
         // When
-        await _mongoDbContainer.StartAsync(cts.Token)
+        var execResult = await _mongoDbContainer.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
         // Then
-        const string scriptContent = "rs.status().ok;";
-
-        var execResult = await _mongoDbContainer.ExecScriptAsync(scriptContent, cts.Token)
-            .ConfigureAwait(true);
-
         Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
+        Assert.Empty(execResult.Stderr);
     }
 }

--- a/tests/Testcontainers.MongoDb.Tests/MongoDbReplicaSetReadinessTest.cs
+++ b/tests/Testcontainers.MongoDb.Tests/MongoDbReplicaSetReadinessTest.cs
@@ -1,0 +1,59 @@
+using System.Text;
+using System.Threading;
+using DotNet.Testcontainers.Configurations;
+
+namespace Testcontainers.MongoDb;
+
+/// <summary>
+/// The readiness check that runs before the replica set is initiated counts occurrences of a log
+/// message and compares that count for equality. Any other log line carrying the same text pushes
+/// the count past the expected value, and it can then never match
+/// (https://github.com/testcontainers/testcontainers-dotnet/issues/1732).
+/// </summary>
+public sealed class MongoDbReplicaSetReadinessTest : IAsyncLifetime
+{
+    private const string ExtraMarkerScriptFilePath = "/docker-entrypoint-initdb.d/00-extra-marker.sh";
+
+    private readonly MongoDbContainer _mongoDbContainer = new MongoDbBuilder(TestSession.GetImageFromDockerfile())
+        .WithReplicaSet()
+        .WithResourceMapping(
+            Encoding.Default.GetBytes("#!/bin/bash\necho 'Waiting for connections'\necho 'Waiting for connections'\n"),
+            ExtraMarkerScriptFilePath,
+            fileMode: Unix.FileMode755)
+        .Build();
+
+    public ValueTask InitializeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _mongoDbContainer.DisposeAsync()
+            .ConfigureAwait(false);
+
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+    public async Task StartsWhenTheLogContainsAdditionalReadinessMessages()
+    {
+        // Given
+        // The default wait strategy timeout is one hour, so bound the wait to keep a regression
+        // from stalling the test run instead of failing it.
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3));
+
+        // When
+        await _mongoDbContainer.StartAsync(cts.Token)
+            .ConfigureAwait(true);
+
+        // Then
+        const string scriptContent = "rs.status().ok;";
+
+        var execResult = await _mongoDbContainer.ExecScriptAsync(scriptContent, cts.Token)
+            .ConfigureAwait(true);
+
+        Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
+    }
+}

--- a/tests/Testcontainers.MongoDb.Tests/Usings.cs
+++ b/tests/Testcontainers.MongoDb.Tests/Usings.cs
@@ -1,6 +1,7 @@
 global using System;
 global using System.Collections.Generic;
 global using System.Linq;
+global using System.Text;
 global using System.Threading.Tasks;
 global using DotNet.Testcontainers.Commons;
 global using DotNet.Testcontainers.Configurations;


### PR DESCRIPTION
Fixes #1732

## The problem

The readiness check that runs before the replica set is initiated counts occurrences of a log message and compares that count for **equality**:

```csharp
var (stdout, stderr) = await container.GetLogsAsync(since: container.StoppedTime, timestampsEnabled: false);
return _count.Equals(... .Count(line => line.Contains("Waiting for connections")));
```

`_count` is 1 or 2. The count only grows, and the module does not control what else writes that text, so the check fails in both directions:

- **Too many occurrences and the start hangs.** The equality can never become true. The default wait strategy timeout is one hour, so the caller does not fail, it appears to hang.
- **A stale occurrence and the start returns early.** The check passes before `mongod` is serving, and the next command fails with `MongoNetworkError: connect ECONNREFUSED 127.0.0.1:27017`.

@xamir82's reproduction on the issue shows this needs no restart: extra markers written by an init script during a single run are enough, and whether it fails at all depends on when the once-per-second poll samples.

This arrived in 4.11.0. #1656 (`ec6b50f6`) put this check on the replica set path; before that the path did not use it.

## The fix

Ask the server instead of reading its logs:

```csharp
private const string ScriptContent = "try{rs.status();quit(0);}catch(e){quit(e.codeName===\"NotYetInitialized\"?0:1);}";
```

This still satisfies what #1656 needed for #1636. The official image forks a temporary `mongod` during first-time initialization to create the root user, and that process is **not** started with `--replSet`, so it never reports `NotYetInitialized`. Only the final server does.

Measured on `mongo:6.0.27` with the module's own configuration (auth plus the generated keyfile), polling twice a second from container start:

| t | authenticated ping | `rs.status()` | "Waiting for connections" |
|---|---|---|---|
| 1.0s | fails | no reply | 1 |
| 2.0s | succeeds | `NotYetInitialized` | 2 |

A plain `ping` is not sufficient on its own; against a container without the keyfile it succeeds during the bootstrap phase. `rs.status()` is what distinguishes the two processes.

It is also idempotent for an already initiated set, which returns `ok: 1` and exits zero.

## Scope

Limited to the replica set path, which is where #1656 introduced this. `Build()` still uses the log-counting strategy for non-replica-set containers, and it has the same weakness, but changing it alters long-standing behaviour for every MongoDb container and seemed better decided separately. Happy to extend this PR if you would prefer both in one go.

## Testing

`MongoDbReplicaSetReadinessTest` follows @xamir82's reproduction: a replica set container with an init script that writes the marker twice more.

- Before: times out (bounded to three minutes in the test so a regression fails rather than stalls the run).
- After: passes in about seven seconds.
- Full `Testcontainers.MongoDb.Tests`: 19 passed, 0 failed, including every replica set fixture, which is what covers the first-time initialization path from #1636.

Separate from #1731, which is about `rs.initiate` not being idempotent. The two touch the same method but neither depends on the other.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MongoDB replica-set startup detection by verifying replication status directly.
  - Containers now start reliably when readiness messages appear multiple times.
  - Replica sets in the intermediate `NotYetInitialized` state are handled correctly.

- **Tests**
  - Added regression coverage for duplicate readiness messages and successful replica-set initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->