### PR TITLE
feat: Add possibility to select MSSQL database (instead of master)

### DIFF
--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -85,7 +85,11 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     public override MsSqlContainer Build()
     {
         Validate();
-        return new MsSqlContainer(DockerResourceConfiguration);
+
+        // By default, the base builder waits until the container is running. However, for MsSql, a more advanced waiting strategy is necessary that requires access to the configured database, username and password.
+        // Always append the default MsSql waiting strategy because that's where the custom database is created.
+        var msSqlBuilder = WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil(DockerResourceConfiguration)));
+        return new MsSqlContainer(msSqlBuilder.DockerResourceConfiguration);
     }
 
     /// <inheritdoc />
@@ -97,8 +101,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             .WithDatabase(DefaultDatabase)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
-            .WithConnectionStringProvider(new MsSqlConnectionStringProvider())
-            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil()));
+            .WithConnectionStringProvider(new MsSqlConnectionStringProvider());
     }
 
     /// <inheritdoc />
@@ -133,14 +136,14 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// Sets the MsSql database.
     /// </summary>
     /// <remarks>
-    /// The Docker image does not allow to configure the database.
+    /// This is useful, for example, when the database needs to be set to single-user mode.
+    /// Typically, Entity Framework Core does it through the <c>EnsureDeleted</c> method.
     /// </remarks>
     /// <param name="database">The MsSql database.</param>
     /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
-    private MsSqlBuilder WithDatabase(string database)
+    public MsSqlBuilder WithDatabase(string database)
     {
-        return Merge(DockerResourceConfiguration, new MsSqlConfiguration(database: database))
-            .WithEnvironment("SQLCMDDBNAME", database);
+        return Merge(DockerResourceConfiguration, new MsSqlConfiguration(database: database));
     }
 
     /// <summary>
@@ -162,7 +165,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// Uses the <c>sqlcmd</c> utility scripting variables to detect readiness of the MsSql container:
     /// https://learn.microsoft.com/en-us/sql/tools/sqlcmd/sqlcmd-utility?view=sql-server-linux-ver15#sqlcmd-scripting-variables.
     /// </remarks>
-    private sealed class WaitUntil : IWaitUntil
+    private sealed class WaitUntil(MsSqlConfiguration configuration) : IWaitUntil
     {
         /// <inheritdoc />
         public Task<bool> UntilAsync(IContainer container)
@@ -171,13 +174,22 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
         }
 
         /// <inheritdoc cref="IWaitUntil.UntilAsync" />
-        private static async Task<bool> UntilAsync(MsSqlContainer container)
+        private async Task<bool> UntilAsync(MsSqlContainer container)
         {
             var sqlCmdFilePath = await container.GetSqlCmdFilePathAsync()
                 .ConfigureAwait(false);
 
-            var execResult = await container.ExecAsync(new[] { sqlCmdFilePath, "-C", "-Q", "SELECT 1;" })
+            var execResult = await container.ExecAsync([sqlCmdFilePath, "-C", "-Q", "SELECT 1;"])
                 .ConfigureAwait(false);
+
+            if (execResult.ExitCode == 0 && configuration.Database != DefaultDatabase)
+            {
+                var createDbScript = $"IF DB_ID('{configuration.Database}') IS NULL " +
+                                     $"BEGIN CREATE DATABASE [{configuration.Database}] END";
+
+                var masterConfiguration = new MsSqlConfiguration(DefaultDatabase, DefaultUsername, configuration.Password);
+                await container.ExecScriptAsync(createDbScript, masterConfiguration);
+            }
 
             return 0L.Equals(execResult.ExitCode);
         }

--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -120,6 +120,10 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     {
         base.Validate();
 
+        _ = Guard.Argument(DockerResourceConfiguration.Database, nameof(DockerResourceConfiguration.Database))
+            .NotNull()
+            .NotEmpty();
+
         _ = Guard.Argument(DockerResourceConfiguration.Password, nameof(DockerResourceConfiguration.Password))
             .NotNull()
             .NotEmpty();

--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -70,6 +70,17 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     protected override MsSqlConfiguration DockerResourceConfiguration { get; }
 
     /// <summary>
+    /// Sets the MsSql database.
+    /// </summary>
+    /// <param name="database">The MsSql database.</param>
+    /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
+    public MsSqlBuilder WithDatabase(string database)
+    {
+        return Merge(DockerResourceConfiguration, new MsSqlConfiguration(database: database))
+            .WithEnvironment("SQLCMDDBNAME", database);
+    }
+
+    /// <summary>
     /// Sets the MsSql password.
     /// </summary>
     /// <param name="password">The MsSql password.</param>
@@ -87,7 +98,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
         Validate();
 
         // By default, the base builder waits until the container is running. However, for MsSql, a more advanced waiting strategy is necessary that requires access to the configured database, username and password.
-        // Always append the default MsSql waiting strategy because that's where the custom database is created.
+        // Always append the default MsSql waiting strategy, since that's where the custom database is created.
         var msSqlBuilder = WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil(DockerResourceConfiguration)));
         return new MsSqlContainer(msSqlBuilder.DockerResourceConfiguration);
     }
@@ -133,20 +144,6 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     }
 
     /// <summary>
-    /// Sets the MsSql database.
-    /// </summary>
-    /// <remarks>
-    /// This is useful, for example, when the database needs to be set to single-user mode.
-    /// Typically, Entity Framework Core does it through the <c>EnsureDeleted</c> method.
-    /// </remarks>
-    /// <param name="database">The MsSql database.</param>
-    /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
-    public MsSqlBuilder WithDatabase(string database)
-    {
-        return Merge(DockerResourceConfiguration, new MsSqlConfiguration(database: database));
-    }
-
-    /// <summary>
     /// Sets the MsSql username.
     /// </summary>
     /// <remarks>
@@ -165,8 +162,19 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// Uses the <c>sqlcmd</c> utility scripting variables to detect readiness of the MsSql container:
     /// https://learn.microsoft.com/en-us/sql/tools/sqlcmd/sqlcmd-utility?view=sql-server-linux-ver15#sqlcmd-scripting-variables.
     /// </remarks>
-    private sealed class WaitUntil(MsSqlConfiguration configuration) : IWaitUntil
+    private sealed class WaitUntil : IWaitUntil
     {
+        private readonly string _configuredDatabase;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WaitUntil" /> class.
+        /// </summary>
+        /// <param name="configuration">The container configuration.</param>
+        public WaitUntil(MsSqlConfiguration configuration)
+        {
+            _configuredDatabase = configuration.Database;
+        }
+
         /// <inheritdoc />
         public Task<bool> UntilAsync(IContainer container)
         {
@@ -179,19 +187,20 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             var sqlCmdFilePath = await container.GetSqlCmdFilePathAsync()
                 .ConfigureAwait(false);
 
-            var execResult = await container.ExecAsync([sqlCmdFilePath, "-C", "-Q", "SELECT 1;"])
+            var execResult = await container.ExecAsync(new[] { sqlCmdFilePath, "-C", "-d", DefaultDatabase, "-Q", "SELECT 1;" })
                 .ConfigureAwait(false);
 
-            if (execResult.ExitCode == 0 && configuration.Database != DefaultDatabase)
-            {
-                var createDbScript = $"IF DB_ID('{configuration.Database}') IS NULL " +
-                                     $"BEGIN CREATE DATABASE [{configuration.Database}] END";
+            var isSuccessful = 0L.Equals(execResult.ExitCode);
 
-                var masterConfiguration = new MsSqlConfiguration(DefaultDatabase, DefaultUsername, configuration.Password);
-                await container.ExecScriptAsync(createDbScript, masterConfiguration);
+            if (isSuccessful && !DefaultDatabase.Equals(_configuredDatabase, StringComparison.OrdinalIgnoreCase))
+            {
+                var sqlStatement = $"IF DB_ID('{_configuredDatabase}') IS NULL BEGIN CREATE DATABASE [{_configuredDatabase}] END";
+
+                _ = await container.ExecAsync(new[] { sqlCmdFilePath, "-C", "-d", DefaultDatabase, "-Q", sqlStatement })
+                    .ConfigureAwait(false);
             }
 
-            return 0L.Equals(execResult.ExitCode);
+            return isSuccessful;
         }
     }
 }

--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -73,9 +73,8 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// Sets the MsSql database.
     /// </summary>
     /// <remarks>
-    /// The Docker image does not create the database. It is created as part of the
-    /// readiness check, which runs before any caller-defined wait strategy. Ideally,
-    /// creating the database is moved from the readiness check into the startup.
+    /// The Docker image does not allow to configure the database. It is created
+    /// as part of the startup callback, which runs before any wait strategy.
     /// </remarks>
     /// <param name="database">The MsSql database.</param>
     /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
@@ -114,7 +113,8 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
             .WithConnectionStringProvider(new MsSqlConnectionStringProvider())
-            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil()));
+            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil()))
+            .WithStartupCallback(CreateDatabaseAsync);
     }
 
     /// <inheritdoc />
@@ -163,6 +163,47 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             .WithEnvironment("SQLCMDUSER", username);
     }
 
+    /// <summary>
+    /// Creates the configured MsSql database.
+    /// </summary>
+    /// <remarks>
+    /// The configured database is resolved by <c>sqlcmd</c> itself, substituting
+    /// the <c>SQLCMDDBNAME</c> scripting variable that <see cref="WithDatabase" />
+    /// sets. Creating the default database is skipped, since it always exists.
+    /// </remarks>
+    /// <param name="container">The container instance.</param>
+    /// <param name="configuration">The container configuration.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the database has been created.</returns>
+    private static async Task CreateDatabaseAsync(MsSqlContainer container, MsSqlConfiguration configuration, CancellationToken ct)
+    {
+        if (DefaultDatabase.Equals(configuration.Database))
+        {
+            return;
+        }
+
+        const string sqlStatement = "IF DB_ID('$(SQLCMDDBNAME)') IS NULL BEGIN CREATE DATABASE [$(SQLCMDDBNAME)] END";
+
+        var sqlCmdFilePath = await container.GetSqlCmdFilePathAsync(ct)
+            .ConfigureAwait(false);
+
+        var readiness = new WaitUntil();
+
+        // This is a simple workaround to use the default options, which can be configured
+        // with custom configurations as needed.
+        var options = new WaitStrategy();
+
+        // The startup callback runs before any wait strategy. Waiting here prevents creating the
+        // database while the MsSql instance is not accepting connections yet, which would
+        // otherwise cause the container start to fail.
+        await WaitStrategy.WaitUntilAsync(() => readiness.UntilAsync(container), options.Interval, options.Timeout, options.Retries, ct)
+            .ConfigureAwait(false);
+
+        _ = await container.ExecAsync(new[] { sqlCmdFilePath, "-C", "-b", "-r", "1", "-d", DefaultDatabase, "-Q", sqlStatement }, ct)
+            .ThrowOnFailure()
+            .ConfigureAwait(false);
+    }
+
     /// <inheritdoc cref="IWaitUntil" />
     /// <remarks>
     /// Uses the <c>sqlcmd</c> utility scripting variables to detect readiness of the MsSql container:
@@ -177,7 +218,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
         }
 
         /// <inheritdoc cref="IWaitUntil.UntilAsync" />
-        private async Task<bool> UntilAsync(MsSqlContainer container)
+        private static async Task<bool> UntilAsync(MsSqlContainer container)
         {
             var sqlCmdFilePath = await container.GetSqlCmdFilePathAsync()
                 .ConfigureAwait(false);
@@ -185,25 +226,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             var execResult = await container.ExecAsync(new[] { sqlCmdFilePath, "-C", "-b", "-r", "1", "-d", DefaultDatabase, "-Q", "SELECT 1;" })
                 .ConfigureAwait(false);
 
-            if (!0L.Equals(execResult.ExitCode))
-            {
-                return false;
-            }
-
-            // The configured database is resolved by sqlcmd itself, substituting the SQLCMDDBNAME
-            // scripting variable that WithDatabase(string) sets. Creating the default database
-            // is a noop, since it always exists.
-            const string sqlStatement = "IF DB_ID('$(SQLCMDDBNAME)') IS NULL BEGIN CREATE DATABASE [$(SQLCMDDBNAME)] END";
-
-            var createDatabaseExecResult = await container.ExecAsync(new[] { sqlCmdFilePath, "-C", "-b", "-r", "1", "-d", DefaultDatabase, "-Q", sqlStatement })
-                .ConfigureAwait(false);
-
-            if (!0L.Equals(createDatabaseExecResult.ExitCode))
-            {
-                throw new InvalidOperationException("The database could not be created: " + createDatabaseExecResult.Stderr.Trim());
-            }
-
-            return true;
+            return 0L.Equals(execResult.ExitCode);
         }
     }
 }

--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -96,11 +96,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     public override MsSqlContainer Build()
     {
         Validate();
-
-        // By default, the base builder waits until the container is running. However, for MsSql, a more advanced waiting strategy is necessary that requires access to the configured database, username and password.
-        // Always append the default MsSql waiting strategy, since that's where the custom database is created.
-        var msSqlBuilder = WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil(DockerResourceConfiguration)));
-        return new MsSqlContainer(msSqlBuilder.DockerResourceConfiguration);
+        return new MsSqlContainer(DockerResourceConfiguration);
     }
 
     /// <inheritdoc />
@@ -112,7 +108,8 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             .WithDatabase(DefaultDatabase)
             .WithUsername(DefaultUsername)
             .WithPassword(DefaultPassword)
-            .WithConnectionStringProvider(new MsSqlConnectionStringProvider());
+            .WithConnectionStringProvider(new MsSqlConnectionStringProvider())
+            .WithWaitStrategy(Wait.ForUnixContainer().AddCustomWaitStrategy(new WaitUntil()));
     }
 
     /// <inheritdoc />
@@ -168,17 +165,6 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// </remarks>
     private sealed class WaitUntil : IWaitUntil
     {
-        private readonly string _configuredDatabase;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WaitUntil" /> class.
-        /// </summary>
-        /// <param name="configuration">The container configuration.</param>
-        public WaitUntil(MsSqlConfiguration configuration)
-        {
-            _configuredDatabase = configuration.Database;
-        }
-
         /// <inheritdoc />
         public Task<bool> UntilAsync(IContainer container)
         {
@@ -191,20 +177,28 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             var sqlCmdFilePath = await container.GetSqlCmdFilePathAsync()
                 .ConfigureAwait(false);
 
-            var execResult = await container.ExecAsync(new[] { sqlCmdFilePath, "-C", "-d", DefaultDatabase, "-Q", "SELECT 1;" })
+            var execResult = await container.ExecAsync(new[] { sqlCmdFilePath, "-C", "-b", "-r", "1", "-d", DefaultDatabase, "-Q", "SELECT 1;" })
                 .ConfigureAwait(false);
 
-            var isSuccessful = 0L.Equals(execResult.ExitCode);
-
-            if (isSuccessful && !DefaultDatabase.Equals(_configuredDatabase, StringComparison.OrdinalIgnoreCase))
+            if (!0L.Equals(execResult.ExitCode))
             {
-                var sqlStatement = $"IF DB_ID('{_configuredDatabase}') IS NULL BEGIN CREATE DATABASE [{_configuredDatabase}] END";
-
-                _ = await container.ExecAsync(new[] { sqlCmdFilePath, "-C", "-d", DefaultDatabase, "-Q", sqlStatement })
-                    .ConfigureAwait(false);
+                return false;
             }
 
-            return isSuccessful;
+            // The configured database is resolved by sqlcmd itself, substituting the SQLCMDDBNAME
+            // scripting variable that WithDatabase(string) sets. Creating the default database
+            // is a noop, since it always exists.
+            const string sqlStatement = "IF DB_ID('$(SQLCMDDBNAME)') IS NULL BEGIN CREATE DATABASE [$(SQLCMDDBNAME)] END";
+
+            var createDatabaseExecResult = await container.ExecAsync(new[] { sqlCmdFilePath, "-C", "-b", "-r", "1", "-d", DefaultDatabase, "-Q", sqlStatement })
+                .ConfigureAwait(false);
+
+            if (!0L.Equals(createDatabaseExecResult.ExitCode))
+            {
+                throw new InvalidOperationException("The database could not be created: " + createDatabaseExecResult.Stderr.Trim());
+            }
+
+            return true;
         }
     }
 }

--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -180,6 +180,14 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             return;
         }
 
+        var readiness = new WaitStrategy(new WaitUntil());
+
+        // The startup callback runs before any wait strategy. Waiting here prevents creating the
+        // database while the MsSql instance is not accepting connections yet, which would
+        // otherwise cause the container start to fail.
+        await WaitStrategy.WaitUntilAsync(() => readiness.UntilAsync(container, ct), readiness.Interval, readiness.Timeout, readiness.Retries, ct)
+            .ConfigureAwait(false);
+
         // The database name cannot be passed as the SQLCMDDBNAME scripting variable that
         // WithDatabase(string) sets. The -d option below overrides it with the default
         // database, which would resolve the statement against the wrong database.
@@ -188,18 +196,6 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
         var sqlStatement = $"IF DB_ID('{database}') IS NULL BEGIN CREATE DATABASE [{database}] END";
 
         var sqlCmdFilePath = await container.GetSqlCmdFilePathAsync(ct)
-            .ConfigureAwait(false);
-
-        var readiness = new WaitUntil();
-
-        // This is a simple workaround to use the default options, which can be configured
-        // with custom configurations as needed.
-        var options = new WaitStrategy();
-
-        // The startup callback runs before any wait strategy. Waiting here prevents creating the
-        // database while the MsSql instance is not accepting connections yet, which would
-        // otherwise cause the container start to fail.
-        await WaitStrategy.WaitUntilAsync(() => readiness.UntilAsync(container), options.Interval, options.Timeout, options.Retries, ct)
             .ConfigureAwait(false);
 
         _ = await container.ExecAsync(new[] { sqlCmdFilePath, "-C", "-b", "-r", "1", "-d", DefaultDatabase, "-Q", sqlStatement }, ct)

--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -167,9 +167,7 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// Creates the configured MsSql database.
     /// </summary>
     /// <remarks>
-    /// The configured database is resolved by <c>sqlcmd</c> itself, substituting
-    /// the <c>SQLCMDDBNAME</c> scripting variable that <see cref="WithDatabase" />
-    /// sets. Creating the default database is skipped, since it always exists.
+    /// Creating the default database is skipped.
     /// </remarks>
     /// <param name="container">The container instance.</param>
     /// <param name="configuration">The container configuration.</param>
@@ -182,7 +180,12 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
             return;
         }
 
-        const string sqlStatement = "IF DB_ID('$(SQLCMDDBNAME)') IS NULL BEGIN CREATE DATABASE [$(SQLCMDDBNAME)] END";
+        // The database name cannot be passed as the SQLCMDDBNAME scripting variable that
+        // WithDatabase(string) sets. The -d option below overrides it with the default
+        // database, which would resolve the statement against the wrong database.
+        var database = configuration.Database;
+
+        var sqlStatement = $"IF DB_ID('{database}') IS NULL BEGIN CREATE DATABASE [{database}] END";
 
         var sqlCmdFilePath = await container.GetSqlCmdFilePathAsync(ct)
             .ConfigureAwait(false);

--- a/src/Testcontainers.MsSql/MsSqlBuilder.cs
+++ b/src/Testcontainers.MsSql/MsSqlBuilder.cs
@@ -72,6 +72,11 @@ public sealed class MsSqlBuilder : ContainerBuilder<MsSqlBuilder, MsSqlContainer
     /// <summary>
     /// Sets the MsSql database.
     /// </summary>
+    /// <remarks>
+    /// The Docker image does not create the database. It is created as part of the
+    /// readiness check, which runs before any caller-defined wait strategy. Ideally,
+    /// creating the database is moved from the readiness check into the startup.
+    /// </remarks>
     /// <param name="database">The MsSql database.</param>
     /// <returns>A configured instance of <see cref="MsSqlBuilder" />.</returns>
     public MsSqlBuilder WithDatabase(string database)

--- a/src/Testcontainers.MsSql/MsSqlContainer.cs
+++ b/src/Testcontainers.MsSql/MsSqlContainer.cs
@@ -57,18 +57,6 @@ public sealed class MsSqlContainer : DockerContainer, IDatabaseContainer
     /// <returns>Task that completes when the SQL script has been executed.</returns>
     public async Task<ExecResult> ExecScriptAsync(string scriptContent, CancellationToken ct = default)
     {
-        return await ExecScriptAsync(scriptContent, _configuration, ct);
-    }
-
-    /// <summary>
-    /// Executes the SQL script in the MsSql container on the specified database.
-    /// </summary>
-    /// <param name="scriptContent">The content of the SQL script to execute.</param>
-    /// <param name="configuration">The database configuration used to execute the SQL script.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the SQL script has been executed.</returns>
-    internal async Task<ExecResult> ExecScriptAsync(string scriptContent, MsSqlConfiguration configuration, CancellationToken ct = default)
-    {
         var scriptFilePath = string.Join("/", string.Empty, "tmp", Guid.NewGuid().ToString("D"), Path.GetRandomFileName());
 
         var sqlCmdFilePath = await GetSqlCmdFilePathAsync(ct)
@@ -77,7 +65,7 @@ public sealed class MsSqlContainer : DockerContainer, IDatabaseContainer
         await CopyAsync(Encoding.Default.GetBytes(scriptContent), scriptFilePath, fileMode: Unix.FileMode644, ct: ct)
             .ConfigureAwait(false);
 
-        return await ExecAsync([sqlCmdFilePath, "-C", "-b", "-r", "1", "-U", configuration.Username, "-P", configuration.Password, "-d", configuration.Database, "-i", scriptFilePath], ct)
+        return await ExecAsync(new[] { sqlCmdFilePath, "-C", "-b", "-r", "1", "-U", _configuration.Username, "-P", _configuration.Password, "-d", _configuration.Database, "-i", scriptFilePath }, ct)
             .ConfigureAwait(false);
     }
 

--- a/src/Testcontainers.MsSql/MsSqlContainer.cs
+++ b/src/Testcontainers.MsSql/MsSqlContainer.cs
@@ -57,6 +57,18 @@ public sealed class MsSqlContainer : DockerContainer, IDatabaseContainer
     /// <returns>Task that completes when the SQL script has been executed.</returns>
     public async Task<ExecResult> ExecScriptAsync(string scriptContent, CancellationToken ct = default)
     {
+        return await ExecScriptAsync(scriptContent, _configuration, ct);
+    }
+
+    /// <summary>
+    /// Executes the SQL script in the MsSql container on the specified database.
+    /// </summary>
+    /// <param name="scriptContent">The content of the SQL script to execute.</param>
+    /// <param name="configuration">The database configuration used to execute the SQL script.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the SQL script has been executed.</returns>
+    internal async Task<ExecResult> ExecScriptAsync(string scriptContent, MsSqlConfiguration configuration, CancellationToken ct = default)
+    {
         var scriptFilePath = string.Join("/", string.Empty, "tmp", Guid.NewGuid().ToString("D"), Path.GetRandomFileName());
 
         var sqlCmdFilePath = await GetSqlCmdFilePathAsync(ct)
@@ -65,7 +77,7 @@ public sealed class MsSqlContainer : DockerContainer, IDatabaseContainer
         await CopyAsync(Encoding.Default.GetBytes(scriptContent), scriptFilePath, fileMode: Unix.FileMode644, ct: ct)
             .ConfigureAwait(false);
 
-        return await ExecAsync(new[] { sqlCmdFilePath, "-C", "-b", "-r", "1", "-U", _configuration.Username, "-P", _configuration.Password, "-i", scriptFilePath }, ct)
+        return await ExecAsync([sqlCmdFilePath, "-C", "-b", "-r", "1", "-U", configuration.Username, "-P", configuration.Password, "-d", configuration.Database, "-i", scriptFilePath], ct)
             .ConfigureAwait(false);
     }
 

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -40,25 +40,28 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
     public async Task CreatesTableInConfiguredDatabase()
     {
         // Given
-        using DbConnection connection = fixture.CreateConnection();
+        const string scriptContent = "CREATE TABLE dbo.Employee (EmployeeID INT PRIMARY KEY CLUSTERED);";
+
+        using var command = fixture.CreateCommand("SELECT DB_NAME() FROM sys.Tables WHERE Name = 'Employee' AND SCHEMA_ID = SCHEMA_ID('dbo');");
 
         // When
-        await fixture.Container.ExecScriptAsync("CREATE TABLE dbo.Employee (EmployeeID INT PRIMARY KEY CLUSTERED);", TestContext.Current.CancellationToken)
+        var execResult = await fixture.Container.ExecScriptAsync(scriptContent, TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
 
-        using var command = fixture.CreateCommand();
-        command.CommandText = "SELECT DB_NAME() FROM sys.Tables WHERE Name = 'Employee' AND SCHEMA_ID = SCHEMA_ID('dbo');";
-
-        using var dataReader = command.ExecuteReader();
+        var database = await command.ExecuteScalarAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
 
         // Then
-        Assert.True(dataReader.Read());
-        Assert.Equal(connection.Database, dataReader.GetString(0));
+        Assert.True(0L.Equals(execResult.ExitCode), execResult.Stderr);
+        Assert.Equal(fixture.Database, database);
     }
 
     public class MsSqlDefaultFixture(IMessageSink messageSink)
         : DbContainerFixture<MsSqlBuilder, MsSqlContainer>(messageSink)
     {
+        public virtual string Database
+            => MsSqlBuilder.DefaultDatabase;
+
         protected override MsSqlBuilder Configure()
             => new MsSqlBuilder(TestSession.GetImageFromDockerfile());
 
@@ -78,8 +81,11 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
     public class MsSqlCustomDatabaseFixture(IMessageSink messageSink)
         : MsSqlDefaultFixture(messageSink)
     {
+        public override string Database
+            => "MyDatabase";
+
         protected override MsSqlBuilder Configure()
-            => base.Configure().WithDatabase("MyDatabase");
+            => base.Configure().WithDatabase(Database);
     }
 
     [UsedImplicitly]

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -37,17 +37,23 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
 
     [Fact]
     [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
-    public async Task CreatesTableOnTheConfiguredDatabase()
+    public async Task CreatesTableInConfiguredDatabase()
     {
         // Given
         using DbConnection connection = fixture.CreateConnection();
 
         // When
-        await fixture.Container.ExecScriptAsync("CREATE TABLE dbo.Employee (EmployeeID INT PRIMARY KEY CLUSTERED);", TestContext.Current.CancellationToken);
+        await fixture.Container.ExecScriptAsync("CREATE TABLE dbo.Employee (EmployeeID INT PRIMARY KEY CLUSTERED);", TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        using var command = fixture.CreateCommand();
+        command.CommandText = "SELECT DB_NAME() FROM sys.Tables WHERE Name = 'Employee' AND SCHEMA_ID = SCHEMA_ID('dbo');";
+
+        using var dataReader = command.ExecuteReader();
 
         // Then
-        using var command = fixture.CreateCommand("SELECT COUNT(*) FROM dbo.Employee;");
-        Assert.Equal(0, await command.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        Assert.True(dataReader.Read());
+        Assert.Equal(connection.Database, dataReader.GetString(0));
     }
 
     public class MsSqlDefaultFixture(IMessageSink messageSink)

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -59,14 +59,14 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
     public class MsSqlDefaultFixture(IMessageSink messageSink)
         : DbContainerFixture<MsSqlBuilder, MsSqlContainer>(messageSink)
     {
-        public virtual string Database
-            => MsSqlBuilder.DefaultDatabase;
-
         protected override MsSqlBuilder Configure()
             => new MsSqlBuilder(TestSession.GetImageFromDockerfile());
 
         public override DbProviderFactory DbProviderFactory
             => SqlClientFactory.Instance;
+
+        public virtual string Database
+            => MsSqlBuilder.DefaultDatabase;
     }
 
     [UsedImplicitly]
@@ -81,11 +81,22 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
     public class MsSqlCustomDatabaseFixture(IMessageSink messageSink)
         : MsSqlDefaultFixture(messageSink)
     {
-        public override string Database
-            => "MyDatabase";
-
         protected override MsSqlBuilder Configure()
             => base.Configure().WithDatabase(Database);
+
+        public override string Database
+            => "MyDatabase";
+    }
+
+    [UsedImplicitly]
+    public class MsSqlWaitForCustomDatabaseFixture(IMessageSink messageSink)
+        : MsSqlDefaultFixture(messageSink)
+    {
+        protected override MsSqlBuilder Configure()
+            => base.Configure().WithDatabase(Database).WithWaitStrategy(Wait.ForUnixContainer().UntilDatabaseIsAvailable(DbProviderFactory));
+
+        public override string Database
+            => "MyDatabase";
     }
 
     [UsedImplicitly]
@@ -99,4 +110,8 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
     [UsedImplicitly]
     public sealed class MsSqlCustomDatabaseConfiguration(MsSqlCustomDatabaseFixture fixture)
         : MsSqlContainerTest(fixture), IClassFixture<MsSqlCustomDatabaseFixture>;
+
+    [UsedImplicitly]
+    public sealed class MsSqlWaitForCustomDatabaseConfiguration(MsSqlWaitForCustomDatabaseFixture fixture)
+        : MsSqlContainerTest(fixture), IClassFixture<MsSqlWaitForCustomDatabaseFixture>;
 }

--- a/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
+++ b/tests/Testcontainers.MsSql.Tests/MsSqlContainerTest.cs
@@ -35,6 +35,21 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
     }
     // # --8<-- [end:UseMsSqlContainer]
 
+    [Fact]
+    [Trait(nameof(DockerCli.DockerPlatform), nameof(DockerCli.DockerPlatform.Linux))]
+    public async Task CreatesTableOnTheConfiguredDatabase()
+    {
+        // Given
+        using DbConnection connection = fixture.CreateConnection();
+
+        // When
+        await fixture.Container.ExecScriptAsync("CREATE TABLE dbo.Employee (EmployeeID INT PRIMARY KEY CLUSTERED);", TestContext.Current.CancellationToken);
+
+        // Then
+        using var command = fixture.CreateCommand("SELECT COUNT(*) FROM dbo.Employee;");
+        Assert.Equal(0, await command.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+    }
+
     public class MsSqlDefaultFixture(IMessageSink messageSink)
         : DbContainerFixture<MsSqlBuilder, MsSqlContainer>(messageSink)
     {
@@ -54,10 +69,22 @@ public abstract class MsSqlContainerTest(MsSqlContainerTest.MsSqlDefaultFixture 
     }
 
     [UsedImplicitly]
+    public class MsSqlCustomDatabaseFixture(IMessageSink messageSink)
+        : MsSqlDefaultFixture(messageSink)
+    {
+        protected override MsSqlBuilder Configure()
+            => base.Configure().WithDatabase("MyDatabase");
+    }
+
+    [UsedImplicitly]
     public sealed class MsSqlDefaultConfiguration(MsSqlDefaultFixture fixture)
         : MsSqlContainerTest(fixture), IClassFixture<MsSqlDefaultFixture>;
 
     [UsedImplicitly]
     public sealed class MsSqlWaitForDatabaseConfiguration(MsSqlWaitForDatabaseFixture fixture)
         : MsSqlContainerTest(fixture), IClassFixture<MsSqlWaitForDatabaseFixture>;
+
+    [UsedImplicitly]
+    public sealed class MsSqlCustomDatabaseConfiguration(MsSqlCustomDatabaseFixture fixture)
+        : MsSqlContainerTest(fixture), IClassFixture<MsSqlCustomDatabaseFixture>;
 }


### PR DESCRIPTION
# Add possibility to choose a custom database in MsSql (instead of master)

## What does this PR do?

This pull request introduces a new `WithDatabase` method on `MsSqlBuilder` (technically, it changes the existing private method to a public method). This enables using  a custom database (instead of the default `master` database).

In pretty much all database containers, this would simply require setting an environment variable, but not for SQL Server. There's an open issue https://github.com/microsoft/mssql-docker/issues/2 asking for a simple configuration to automatically create a database, but it has been ignored for almost 10 years.

The implementation simply creates the configured database once the container is ready with this SQL:

```sql
IF DB_ID('{configuration.Database}') IS NULL BEGIN CREATE DATABASE [{configuration.Database}] END
```

Note that container [reuse](https://dotnet.testcontainers.org/api/resource_reuse/) is supported.

## Why is it important?

Using the default `master` database has some limitations. For example, [single-user mode](https://learn.microsoft.com/en-us/sql/relational-databases/databases/set-a-database-to-single-user-mode) can't be set in the `master` database. Note that this is exactly what is used by EF Core [EnsureDeleted](https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.infrastructure.databasefacade.ensuredeleted) operation.

## Related issues

Fixes #986

## How to test this PR

New tests that configure a custom database have been added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a custom Microsoft SQL Server database name.
  - Configured databases are created automatically after SQL Server is ready.
  - Script execution now targets the selected database.
- **Bug Fixes**
  - Improved readiness handling to ensure database operations begin only after connectivity is available.
- **Tests**
  - Added coverage confirming tables can be created and accessed in a custom configured database.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->