### PR TITLE
chore(deps): Bump SSH.NET to 2026.0.0 and BouncyCastle.Cryptography to 2.7.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,14 +4,14 @@
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     </PropertyGroup>
     <ItemGroup>
-        <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2"/>
+        <PackageVersion Include="BouncyCastle.Cryptography" Version="2.7.0"/>
         <PackageVersion Include="Docker.DotNet.Enhanced.X509" Version="4.3.3"/>
         <PackageVersion Include="Docker.DotNet.Enhanced" Version="4.3.3"/>
         <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"/>
         <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.1"/>
         <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3"/>
         <PackageVersion Include="SharpZipLib" Version="1.4.2"/>
-        <PackageVersion Include="SSH.NET" Version="2025.1.0"/>
+        <PackageVersion Include="SSH.NET" Version="2026.0.0"/>
         <!-- Cake build: -->
         <PackageVersion Include="Cake.Frosting.Git" Version="5.0.1"/>
         <PackageVersion Include="Cake.Frosting" Version="6.2.0"/>


### PR DESCRIPTION
Closes #1738.

### What

Two version bumps in `Directory.Packages.props`:

```diff
-        <PackageVersion Include="BouncyCastle.Cryptography" Version="2.6.2"/>
+        <PackageVersion Include="BouncyCastle.Cryptography" Version="2.7.0"/>
-        <PackageVersion Include="SSH.NET" Version="2025.1.0"/>
+        <PackageVersion Include="SSH.NET" Version="2026.0.0"/>
```

### Why

`SSH.NET 2025.1.0` is covered by [GHSA-q939-rpr3-3284](https://github.com/advisories/GHSA-q939-rpr3-3284) — path traversal in `ScpClient`'s recursive download, CVSS 7.1, patched in 2026.0.0 (published 2026-08-09). NuGet audit raises `NU1903`, and because this repository builds with `TreatWarningsAsErrors`, that is an error rather than a warning.

**`develop` does not currently build.** On a clean clone of `f9ed3fb`, `dotnet build Testcontainers.slnx -c Release` fails with **280 `NU1903` errors** across the modules and tests. `main` (`1717807`) carries the same two versions, so it is in the same position. CI has not caught it because the last run was 2026-07-02, five weeks before the patched SSH.NET existed — the next push should go red.

BouncyCastle moves in the same commit because it has to: SSH.NET 2026.0.0 requires `BouncyCastle.Cryptography >= 2.7.0`, so bumping SSH.NET alone fails restore with `NU1605` against the pinned 2.6.2. 2.7.0 is the current stable release.

### Verification

Both runs on `develop` (`f9ed3fb`), which is this PR's base:

| | Before | After |
|---|---|---|
| `dotnet build Testcontainers.slnx -c Release` | exit 1, **280 errors** (all `NU1903`) | **exit 0, 0 warnings, 0 errors** |

I have not run the container test suites — they need a Docker environment I would rather not have decide this for you — so CI is the real check. The dependency surface is small either way: the only SSH.NET types the core references are `SshClient` and `ForwardedPortRemote`, with no reference to `ScpClient`, so the advisory does not describe a path this project can reach. The bump is about unblocking builds, not closing an exploitable hole.

Also checked so it does not surprise you: `examples/WeatherForecast` has its own `Directory.Packages.props` and consumes `Testcontainers.PostgreSql 4.10.0` from NuGet, so its three `packages.lock.json` files are decoupled from these versions and need no regeneration.

### Context

Found while pinning SSH.NET forward in a downstream repository, where nine test projects stopped restoring. Consumers can work around it — the declared range is open-ended, so `<PackageVersion Include="SSH.NET" Version="2026.0.0" />` with transitive pinning resolves cleanly, and our ClickHouse, PostgreSQL and Redis suites pass against real containers on that combination. But that only works for consumers who do not pin BouncyCastle themselves, and it leaves every other consumer to rediscover it.