### PR TITLE
feat(MongoDb): Resolve the MongoDb shell file path once

### DIFF
--- a/src/Testcontainers.Keycloak/KeycloakConfiguration.cs
+++ b/src/Testcontainers.Keycloak/KeycloakConfiguration.cs
@@ -60,10 +60,10 @@ public sealed class KeycloakConfiguration : ContainerConfiguration
     /// <summary>
     /// Gets the admin username.
     /// </summary>
-    public string Username { get; } = null!;
+    public string Username { get; }
 
     /// <summary>
     /// Gets the admin password.
     /// </summary>
-    public string Password { get; } = null!;
+    public string Password { get; }
 }

--- a/src/Testcontainers.MongoDb/MongoDbContainer.cs
+++ b/src/Testcontainers.MongoDb/MongoDbContainer.cs
@@ -4,6 +4,10 @@ namespace Testcontainers.MongoDb;
 [PublicAPI]
 public sealed class MongoDbContainer : DockerContainer
 {
+    private static readonly string[] FindMongoDbShellFilePath = { "/bin/sh", "-c", "command -v mongosh || command -v mongo" };
+
+    private readonly Lazy<Task<string>> _lazyMongoDbShellFilePath;
+
     private readonly MongoDbConfiguration _configuration;
 
     /// <summary>
@@ -13,6 +17,7 @@ public sealed class MongoDbContainer : DockerContainer
     public MongoDbContainer(MongoDbConfiguration configuration)
         : base(configuration)
     {
+        _lazyMongoDbShellFilePath = new Lazy<Task<string>>(FindMongoDbShellFilePathAsync);
         _configuration = configuration;
     }
 
@@ -31,6 +36,21 @@ public sealed class MongoDbContainer : DockerContainer
     }
 
     /// <summary>
+    /// Gets the MongoDb shell file path.
+    /// </summary>
+    /// <remarks>
+    /// The file path represents the path from the container, not from the Docker or test host.
+    /// Resolves <c>mongosh</c>, falling back to the legacy <c>mongo</c> shell that ships in
+    /// images prior to MongoDB 6.0. The result is resolved once and reused.
+    /// </remarks>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the MongoDb shell file path has been found.</returns>
+    public Task<string> GetMongoDbShellFilePathAsync(CancellationToken ct = default)
+    {
+        return _lazyMongoDbShellFilePath.Value;
+    }
+
+    /// <summary>
     /// Executes the JavaScript script in the MongoDb container.
     /// </summary>
     /// <param name="scriptContent">The content of the JavaScript script to execute.</param>
@@ -40,15 +60,15 @@ public sealed class MongoDbContainer : DockerContainer
     {
         var scriptFilePath = string.Join("/", string.Empty, "tmp", Guid.NewGuid().ToString("D"), Path.GetRandomFileName());
 
-        await CopyAsync(Encoding.Default.GetBytes(scriptContent), scriptFilePath, fileMode: Unix.FileMode644, ct: ct)
+        var mongoDbShellFilePath = await GetMongoDbShellFilePathAsync(ct)
             .ConfigureAwait(false);
 
-        var whichMongoDbShell = await ExecAsync(new[] { "which", "mongosh" }, ct)
+        await CopyAsync(Encoding.Default.GetBytes(scriptContent), scriptFilePath, fileMode: Unix.FileMode644, ct: ct)
             .ConfigureAwait(false);
 
         var command = new[]
         {
-            whichMongoDbShell.ExitCode == 0 ? "mongosh" : "mongo",
+            mongoDbShellFilePath,
             "--username", _configuration.Username,
             "--password", _configuration.Password,
             "--quiet",
@@ -58,5 +78,18 @@ public sealed class MongoDbContainer : DockerContainer
 
         return await ExecAsync(command, ct)
             .ConfigureAwait(false);
+    }
+
+    private async Task<string> FindMongoDbShellFilePathAsync()
+    {
+        var findMongoDbShellFilePathExecResult = await ExecAsync(FindMongoDbShellFilePath)
+            .ConfigureAwait(false);
+
+        if (findMongoDbShellFilePathExecResult.ExitCode == 0)
+        {
+            return findMongoDbShellFilePathExecResult.Stdout.Trim();
+        }
+
+        throw new NotSupportedException("The mongosh or mongo binary could not be found.");
     }
 }

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -304,8 +304,9 @@ namespace DotNet.Testcontainers.Containers
 
         using (var tcpClient = new TcpClient())
         {
-          // On some plateform the connection fail with PlatformNotSupportedException: Sockets on this platform are invalid for use after a failed connection attempt.
-          // tcpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+          // Do not configure socket-level KeepAlive here. This was previously done with
+          // SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true),
+          // but caused PlatformNotSupportedException on some platforms.
           tcpClient.LingerState = DiscardAllPendingData;
 
           try


### PR DESCRIPTION
## What does this PR do?

Resolve `mongosh` or the legacy mongo shell to its absolute file path on first use and reuse the result, instead of running `which mongosh` on every `ExecScriptAsync(...)` call. Follows the MsSql module's `sqlcmd` lookup.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MongoDB containers now expose the resolved shell executable path for inspection.
  - MongoDB script execution supports both `mongosh` and the legacy `mongo` shell, selecting the available option automatically.

- **Bug Fixes**
  - MongoDB shell detection is performed once, improving repeated script execution.
  - Improved resource reaper compatibility on platforms that do not support TCP keep-alive configuration.
  - Simplified Keycloak configuration property initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->