### PR TITLE
chore(deps): Revert Dependabot NuGet jobs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,8 @@
 version: 2
+# No NuGet ecosystem here on purpose: versions are managed centrally in the root
+# Directory.Packages.props, so Dependabot cannot split updates by directory, and
+# grouping ~100 dependencies by pattern is not worth it. We bump them manually with
+# `dotnet list package --outdated|--vulnerable`. Security updates are unaffected.
 updates:
   - package-ecosystem: github-actions
     directory: /
@@ -12,87 +16,3 @@ updates:
       actions:
         patterns:
           - '*'
-  - package-ecosystem: nuget
-    directory: /build
-    open-pull-requests-limit: 3
-    schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
-    labels:
-      - dependencies
-    ignore:
-      - dependency-name: Cake.*
-        update-types:
-          - version-update:semver-major
-      - dependency-name: Microsoft.Bcl.*
-        update-types:
-          - version-update:semver-major
-      - dependency-name: Microsoft.Extensions.*
-        update-types:
-          - version-update:semver-major
-      - dependency-name: xunit*
-        update-types:
-          - version-update:semver-major
-    groups:
-      nuget-patch-minor:
-        update-types:
-          - minor
-          - patch
-      nuget-major:
-        update-types:
-          - major
-  - package-ecosystem: nuget
-    directory: /src
-    open-pull-requests-limit: 3
-    schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
-    labels:
-      - dependencies
-    ignore:
-      - dependency-name: Microsoft.Bcl.*
-        update-types:
-          - version-update:semver-major
-      - dependency-name: Microsoft.Extensions.*
-        update-types:
-          - version-update:semver-major
-      - dependency-name: xunit*
-        update-types:
-          - version-update:semver-major
-    groups:
-      nuget-patch-minor:
-        update-types:
-          - minor
-          - patch
-      nuget-major:
-        update-types:
-          - major
-  - package-ecosystem: nuget
-    directory: /tests
-    open-pull-requests-limit: 3
-    schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
-    labels:
-      - dependencies
-    ignore:
-      - dependency-name: Microsoft.Bcl.*
-        update-types:
-          - version-update:semver-major
-      - dependency-name: Microsoft.Extensions.*
-        update-types:
-          - version-update:semver-major
-      - dependency-name: xunit*
-        update-types:
-          - version-update:semver-major
-    groups:
-      nuget-patch-minor:
-        update-types:
-          - minor
-          - patch
-      nuget-major:
-        update-types:
-          - major


### PR DESCRIPTION
## What does this PR do?

Running Dependabot's NuGet ecosystem across the whole repo (directory: `/`) doesn't work here. Discovery starts from the root solution and follows `ProjectReference` transitively: every test project reaches into src, directly or through `Testcontainers.Commons`, so any entry point expands to all 66 src projects across five target frameworks each. That resolve exceeds Dependabot's time limit, so the job never produces useful updates.

Scoping to src/tests doesn't help either. Neither directory holds a project file itself, so discovery finds no entry point there, and pointing at the projects beneath them just reintroduces the same transitive blow-up. And because all versions are managed centrally in the single root `Directory.Packages.props`, there's no per-directory version file to split the updates across anyway.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates  https://github.com/dependabot/dependabot-core/issues/12082

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management to focus on GitHub Actions.
  * Centralized NuGet package version updates and vulnerability checks through the repository’s shared package configuration and .NET tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->