### PR TITLE
feat: Add Compose support

### DIFF
--- a/docs/api/compose.md
+++ b/docs/api/compose.md
@@ -1,0 +1,66 @@
+# Docker Compose
+
+`ComposeBuilder` and `ComposeContainer` run a Docker Compose project as part of your tests. Docker Compose runs inside a container (`docker compose up` / `docker compose down`), so you do not need Docker Compose installed on the test host. Testcontainers copies the Docker Compose files, and the directories they live in, into that container, and mounts the Docker socket so Docker Compose can reach the Docker daemon.
+
+```csharp
+--8<-- "tests/Testcontainers.Platform.Linux.Tests/ComposeContainerExampleTest.cs:CreateComposeContainer"
+```
+
+## Docker Compose files
+
+`WithComposeFile(params string[])` accepts one or more Docker Compose file paths. Each file keeps the path it has on the test host, which lets Docker Compose resolve relative references, such as bind mount sources or included Docker Compose files, the same way it would outside a container.
+
+By default, the entire directory of each Docker Compose file is copied into the container. If that directory also contains files you do not want copied, such as build output, restrict the copy with `WithCopyFilesInContainer(params string[])`. It copies the Docker Compose files and the listed files and directories only, resolved relative to the directory of the first Docker Compose file.
+
+## Waiting for services
+
+Use `WaitingFor(string, IWaitForContainerOS)` to wait for a service without exposing it, and `WithExposedService(string, ushort, IWaitForContainerOS)` to expose a service port and wait for it at the same time. `WithExposedService(string, ushort)` exposes a port without an additional wait strategy; the readiness check then only waits until the port accepts connections.
+
+An exposed service port does not need to be published in the Docker Compose file. An ambassador container proxies the port and makes it accessible to the test host, so wait strategies work against Docker Compose services the same way they work against any other container. Resolve the address with `GetServiceHost(string, ushort)` and `GetServicePort(string, ushort)`.
+
+```csharp
+--8<-- "tests/Testcontainers.Platform.Linux.Tests/ComposeContainerExampleTest.cs:ConnectToExposedService"
+```
+
+!!! note
+
+    `docker compose up` already starts the services. The wait strategies of a Docker Compose service run against the already running container, they do not start it.
+
+## Getting the service container
+
+`GetServiceContainer(string)` returns the `IContainer` that belongs to a Docker Compose service, for example to read its logs or run a command inside it. Docker Compose owns its lifecycle; stopping or disposing the returned container has no effect. Stop or dispose the `ComposeContainer` instead.
+
+```csharp
+--8<-- "tests/Testcontainers.Platform.Linux.Tests/ComposeContainerExampleTest.cs:GetServiceContainer"
+```
+
+## Scaled services
+
+`WithScaledService(string, ushort)` runs more than one container for a Docker Compose service. Each container is one instance, addressed by the service name and an instance number starting at `1`. Every `*Service` member has an `*ServiceInstance` counterpart that takes the instance number, for example `WithExposedServiceInstance(string, ushort, ushort)` and `GetServiceInstanceContainer(string, ushort)`. Members without an instance number always address the first instance.
+
+```csharp
+var composeContainer = new ComposeBuilder(image)
+  .WithComposeFile(composeFilePath)
+  .WithScaledService("web", 2)
+  .WithExposedServiceInstance("web", 1, 80)
+  .WithExposedServiceInstance("web", 2, 80)
+  .Build();
+```
+
+## Project name
+
+Testcontainers generates a random Docker Compose project name for every `ComposeContainer`, so concurrent test runs do not collide. Use `WithProjectNamePrefix(string)` to make the generated name easier to recognize, for example in Docker Desktop or `docker compose ls`. Testcontainers appends a random suffix to the prefix, and reads it back through `ComposeContainer.ProjectName`.
+
+```csharp
+_ = new ComposeBuilder(image)
+  .WithComposeFile(composeFilePath)
+  .WithProjectNamePrefix("checkout-service");
+```
+
+## Pulling images
+
+Testcontainers pulls the Docker Compose service images from the test host before `docker compose up` runs, so the Docker credentials and credential helpers of the test host apply; Docker Compose running inside its own container does not have access to them. This is enabled by default. A failing pull does not fail the start, Docker Compose still tries to pull the image itself. Disable it with `WithPull(false)` if your images are already present on the Docker host.
+
+!!! note
+
+    `ComposeContainer` does not support `WithReuse(true)`.

--- a/docs/api/compose.md
+++ b/docs/api/compose.md
@@ -1,6 +1,6 @@
 # Docker Compose
 
-`ComposeBuilder` and `ComposeContainer` run a Docker Compose project as part of your tests. Docker Compose runs inside a container (`docker compose up` / `docker compose down`), so you do not need Docker Compose installed on the test host. Testcontainers copies the Docker Compose files, and the directories they live in, into that container, and mounts the Docker socket so Docker Compose can reach the Docker daemon.
+`ComposeBuilder` and `ComposeContainer` run a Docker Compose project as part of your tests. Docker Compose runs inside a container (`docker compose up` / `docker compose down`), you do not need Docker Compose installed on the test host. Testcontainers copies the Docker Compose files, and the directories they live in, into that container, and mounts the Docker socket so Docker Compose can reach the Docker daemon.
 
 ```csharp
 --8<-- "tests/Testcontainers.Platform.Linux.Tests/ComposeContainerExampleTest.cs:CreateComposeContainer"
@@ -14,7 +14,7 @@ By default, the entire directory of each Docker Compose file is copied into the 
 
 ## Waiting for services
 
-Use `WaitingFor(string, IWaitForContainerOS)` to wait for a service without exposing it, and `WithExposedService(string, ushort, IWaitForContainerOS)` to expose a service port and wait for it at the same time. `WithExposedService(string, ushort)` exposes a port without an additional wait strategy; the readiness check then only waits until the port accepts connections.
+Use `WaitingFor(string, IWaitForContainerOS)` to wait for a service without exposing it, and `WithExposedService(string, ushort, IWaitForContainerOS)` to expose a service port and wait for it at the same time. `WithExposedService(string, ushort)` exposes a port without an additional wait strategy. The readiness check then only waits until the port accepts connections.
 
 An exposed service port does not need to be published in the Docker Compose file. An ambassador container proxies the port and makes it accessible to the test host, so wait strategies work against Docker Compose services the same way they work against any other container. Resolve the address with `GetServiceHost(string, ushort)` and `GetServicePort(string, ushort)`.
 
@@ -24,11 +24,11 @@ An exposed service port does not need to be published in the Docker Compose file
 
 !!! note
 
-    `docker compose up` already starts the services. The wait strategies of a Docker Compose service run against the already running container, they do not start it.
+    `docker compose up` already starts the services. The wait strategies of a Docker Compose service run against the already running container. They do not start it.
 
 ## Getting the service container
 
-`GetServiceContainer(string)` returns the `IContainer` that belongs to a Docker Compose service, for example to read its logs or run a command inside it. Docker Compose owns its lifecycle; stopping or disposing the returned container has no effect. Stop or dispose the `ComposeContainer` instead.
+`GetServiceContainer(string)` returns the `IContainer` that belongs to a Docker Compose service, for example to read its logs or run a command inside it. Docker Compose owns its lifecycle. Stopping or disposing the returned container has no effect. Stop or dispose the `ComposeContainer` instead.
 
 ```csharp
 --8<-- "tests/Testcontainers.Platform.Linux.Tests/ComposeContainerExampleTest.cs:GetServiceContainer"
@@ -59,7 +59,7 @@ _ = new ComposeBuilder(image)
 
 ## Pulling images
 
-Testcontainers pulls the Docker Compose service images from the test host before `docker compose up` runs, so the Docker credentials and credential helpers of the test host apply; Docker Compose running inside its own container does not have access to them. This is enabled by default. A failing pull does not fail the start, Docker Compose still tries to pull the image itself. Disable it with `WithPull(false)` if your images are already present on the Docker host.
+Testcontainers pulls the Docker Compose service images from the test host before `docker compose up` runs, so the Docker credentials and credential helpers of the test host apply. Docker Compose running inside its own container does not have access to them. This is enabled by default. A failing pull does not fail the start. Docker Compose still tries to pull the image itself. Disable it with `WithPull(false)` if your images are already present on the Docker host.
 
 !!! note
 

--- a/docs/dind/index.md
+++ b/docs/dind/index.md
@@ -11,6 +11,7 @@ docker run -v /var/run/docker.sock.raw:/var/run/docker.sock $IMAGE dotnet test
 ```
 
 !!! note
+
     If you are using Docker Desktop, you need to configure the `TESTCONTAINERS_HOST_OVERRIDE` environment variable to use the special DNS name
     `host.docker.internal` for accessing the host from within a container, which is provided by Docker Desktop:
     `-e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal`

--- a/docs/modules/postgres.md
+++ b/docs/modules/postgres.md
@@ -28,6 +28,7 @@ The following example utilizes the [xUnit.net](/test_frameworks/xunit_net/) modu
 Use `WithSsl` to enable TLS and map the server certificates. Configure the client connection string with `SslMode` and (for validation) the CA certificate.
 
 !!! note
+
     When SSL is enabled, Testcontainers doesn't set the SSL mode for the connection string. You'll need to choose the `SslMode` and configure it yourself.
 
 ```csharp

--- a/docs/modules/toxiproxy.md
+++ b/docs/modules/toxiproxy.md
@@ -50,6 +50,7 @@ To test network conditions with Toxiproxy, you need to configure the communicati
         ```
 
 !!! tip
+
     Toxiproxy allows you to configure the `Toxicity` property, which determines the probability (0.0 to 1.0) that a toxic will be applied to the connection. A value of 1.0 means the toxic is applied 100% of the time, while 0.5 would apply it to approximately 50% of requests.
 
 The test example uses the following NuGet dependencies:

--- a/docs/test_frameworks/xunit_net.md
+++ b/docs/test_frameworks/xunit_net.md
@@ -26,6 +26,7 @@ The example below demonstrates how to override the `Configure(TBuilderEntity)` m
     ```
 
 !!! tip
+
     Always pin the image version to avoid flakiness. This ensures consistency and prevents unexpected behavior, as the `latest` tag may pointing to a new version.
 
 The base class also receives an instance of xUnit.net's [ITestOutputHelper](https://xunit.net/docs/capturing-output) to capture and forward log messages to the running test.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
   - api/create_docker_image.md
   - api/create_docker_container.md
   - api/create_docker_network.md
+  - api/compose.md
   - api/low_level_api_access.md
   - api/resource_reaper.md
   - api/resource_reuse.md

--- a/src/Testcontainers/Builders/ComposeBuilder.cs
+++ b/src/Testcontainers/Builders/ComposeBuilder.cs
@@ -36,6 +36,18 @@ namespace DotNet.Testcontainers.Builders
     /// </summary>
     private const int ProjectNameSuffixLength = 8;
 
+    /// <summary>
+    /// The path separator characters that separate the Docker Compose file paths in
+    /// <c>COMPOSE_FILE</c>, in the order they are considered.
+    /// </summary>
+    /// <remarks>
+    /// A Unix path may contain the default path separator (colon). The path
+    /// separator that Docker Compose uses is configurable, so that a path that
+    /// contains one of them can still be passed (see
+    /// <see cref="GetPathSeparator" />).
+    /// </remarks>
+    private static readonly string[] PathSeparators = { ":", ";", "|", "," };
+
     private static readonly Regex ProjectNameRegex = new Regex("^[a-z0-9][a-z0-9_-]*$", RegexOptions.None, TimeSpan.FromSeconds(1));
 
     /// <summary>
@@ -319,7 +331,14 @@ namespace DotNet.Testcontainers.Builders
 
       var composeFiles = GetComposeFilePaths();
 
-      var composeFile = string.Join(":", composeFiles.Select(GetContainerPath));
+      var containerComposeFilePaths = composeFiles.Select(GetContainerPath).ToArray();
+
+      // Docker Compose splits COMPOSE_FILE on the path separator. Use a path
+      // separator that none of the Docker Compose file paths contains, otherwise
+      // Docker Compose reads a single path as multiple Docker Compose files.
+      var pathSeparator = GetPathSeparator(containerComposeFilePaths);
+
+      var composeFile = string.Join(pathSeparator, containerComposeFilePaths);
 
       // Docker Compose resolves relative references, such as bind mount sources,
       // against the directory of the first Docker Compose file.
@@ -337,6 +356,7 @@ namespace DotNet.Testcontainers.Builders
 
       var composeBuilder = Merge(DockerResourceConfiguration, new ComposeConfiguration(projectName: projectName))
         .WithEnvironment("COMPOSE_PROJECT_NAME", projectName)
+        .WithEnvironment("COMPOSE_PATH_SEPARATOR", pathSeparator)
         .WithEnvironment("COMPOSE_FILE", composeFile)
         .WithWorkingDirectory(projectDirectoryPath)
         .WithMount(new UnixSocketMount(DockerResourceConfiguration.DockerEndpointAuthConfig.Endpoint));
@@ -382,6 +402,10 @@ namespace DotNet.Testcontainers.Builders
       const string composeFileNotOnLocalDrive = "The Docker Compose file '{0}' is on a UNC path. The Docker Compose files must be on a local drive, the Docker daemon cannot resolve a UNC path.";
       _ = Guard.Argument(composeFiles, nameof(DockerResourceConfiguration.ComposeFiles))
         .ThrowIf(argument => argument.Value.Any(IsUncPath), argument => new ArgumentException(string.Format(composeFileNotOnLocalDrive, argument.Value.First(IsUncPath)), argument.Name));
+
+      const string composeFilePathSeparatorNotFound = "The Docker Compose file paths contain every supported path separator character ({0}). At least one of them must be absent from the Docker Compose file paths, Docker Compose separates them with it.";
+      _ = Guard.Argument(composeFiles, nameof(DockerResourceConfiguration.ComposeFiles))
+        .ThrowIf(argument => argument.Value.Length > 0 && GetPathSeparator(argument.Value.Select(GetContainerPath)) == null, argument => new ArgumentException(string.Format(composeFilePathSeparatorNotFound, string.Join(" ", PathSeparators)), argument.Name));
 
       const string projectNamePrefixInvalid = "The Docker Compose project name prefix must start with a lowercase letter or digit and can only contain lowercase letters, digits, dashes, and underscores.";
       _ = Guard.Argument(DockerResourceConfiguration.ProjectNamePrefix, nameof(DockerResourceConfiguration.ProjectNamePrefix))
@@ -471,12 +495,30 @@ namespace DotNet.Testcontainers.Builders
 
       // Convert a Windows drive letter to the path notation that the Docker daemon
       // understands, e.g. C:/Users/Default to /c/Users/Default.
-      if (containerPath.Length > 1 && ':'.Equals(containerPath[1]))
+      if (containerPath.Length > 1 && char.IsLetter(containerPath[0]) && ':'.Equals(containerPath[1]))
       {
         containerPath = "/" + char.ToLowerInvariant(containerPath[0]) + containerPath.Substring(2);
       }
 
       return containerPath;
+    }
+
+    /// <summary>
+    /// Gets the path separator that separates the Docker Compose file paths in
+    /// <c>COMPOSE_FILE</c>.
+    /// </summary>
+    /// <remarks>
+    /// Docker Compose splits <c>COMPOSE_FILE</c> on the path separator that
+    /// <c>COMPOSE_PATH_SEPARATOR</c> configures. A path that contains the path
+    /// separator is read as multiple Docker Compose files, which is why the path
+    /// separator must not occur in any of the paths.
+    /// </remarks>
+    /// <param name="containerPaths">The Docker Compose file paths inside the container.</param>
+    /// <returns>The first supported path separator that none of the paths contains; otherwise, null.</returns>
+    [CanBeNull]
+    private static string GetPathSeparator(IEnumerable<string> containerPaths)
+    {
+      return PathSeparators.FirstOrDefault(pathSeparator => !containerPaths.Any(containerPath => containerPath.Contains(pathSeparator)));
     }
 
     /// <summary>

--- a/src/Testcontainers/Builders/ComposeBuilder.cs
+++ b/src/Testcontainers/Builders/ComposeBuilder.cs
@@ -1,0 +1,507 @@
+namespace DotNet.Testcontainers.Builders
+{
+  using System;
+  using System.Collections.Generic;
+  using System.IO;
+  using System.Linq;
+  using System.Text.RegularExpressions;
+  using Docker.DotNet.Models;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Containers;
+  using DotNet.Testcontainers.Images;
+  using JetBrains.Annotations;
+
+  /// <inheritdoc cref="ContainerBuilder{TBuilderEntity, TContainerEntity, TConfigurationEntity}" />
+  /// <remarks>
+  /// Runs the Docker Compose CLI inside a container. The Docker Compose files are
+  /// copied into the container, and the Docker socket is mounted to interact with
+  /// the Docker host. This does not require a Docker Compose installation on the
+  /// test host.
+  ///
+  /// Not only the Docker Compose files are copied, but every file in their
+  /// directories (see <see cref="WithComposeFile(string[])" />). They keep the
+  /// path they have on the test host, which allows Docker Compose to resolve
+  /// relative bind mounts to a path that exists on the test host.
+  /// </remarks>
+  [PublicAPI]
+  public sealed class ComposeBuilder : ContainerBuilder<ComposeBuilder, ComposeContainer, ComposeConfiguration>
+  {
+    /// <summary>
+    /// The Docker Compose project name prefix that is used if no prefix is set.
+    /// </summary>
+    private const string DefaultProjectNamePrefix = "testcontainers-compose";
+
+    /// <summary>
+    /// The number of random characters that the Docker Compose project name ends with.
+    /// </summary>
+    private const int ProjectNameSuffixLength = 8;
+
+    private static readonly Regex ProjectNameRegex = new Regex("^[a-z0-9][a-z0-9_-]*$", RegexOptions.None, TimeSpan.FromSeconds(1));
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeBuilder" /> class.
+    /// </summary>
+    /// <param name="image">
+    /// The full Docker image name, including the image repository and tag
+    /// (e.g., <c>docker:28-cli</c>).
+    /// </param>
+    /// <remarks>
+    /// The image requires the Docker Compose plugin.
+    /// Docker image tags available at <see href="https://hub.docker.com/_/docker/tags" />.
+    /// </remarks>
+    public ComposeBuilder(string image)
+      : this(new DockerImage(image))
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeBuilder" /> class.
+    /// </summary>
+    /// <param name="image">
+    /// An <see cref="IImage" /> instance that specifies the Docker image to be used
+    /// for the container builder configuration.
+    /// </param>
+    /// <remarks>
+    /// The image requires the Docker Compose plugin.
+    /// Docker image tags available at <see href="https://hub.docker.com/_/docker/tags" />.
+    /// </remarks>
+    public ComposeBuilder(IImage image)
+      : this(new ComposeConfiguration())
+    {
+      DockerResourceConfiguration = Init().WithImage(image).DockerResourceConfiguration;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeBuilder" /> class.
+    /// </summary>
+    /// <param name="resourceConfiguration">The Docker resource configuration.</param>
+    private ComposeBuilder(ComposeConfiguration resourceConfiguration)
+      : base(resourceConfiguration)
+    {
+      DockerResourceConfiguration = resourceConfiguration;
+    }
+
+    /// <inheritdoc />
+    protected override ComposeConfiguration DockerResourceConfiguration { get; }
+
+    /// <summary>
+    /// Sets the Docker Compose files.
+    /// </summary>
+    /// <remarks>
+    /// The directory of each Docker Compose file is copied into the container
+    /// recursively, not just the Docker Compose file itself. Docker Compose
+    /// resolves relative references, such as build contexts, environment files and
+    /// included Docker Compose files, against that directory.
+    ///
+    /// Keep the Docker Compose files in a directory that contains only the files
+    /// they reference. Placing them next to build output or other large directories
+    /// copies those too, and slows down the start of the Docker Compose services.
+    /// Use <see cref="WithCopyFilesInContainer(string[])" /> to copy the referenced
+    /// files only.
+    /// </remarks>
+    /// <param name="composeFiles">A list of Docker Compose file paths.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WithComposeFile(params string[] composeFiles)
+    {
+      return Merge(DockerResourceConfiguration, new ComposeConfiguration(composeFiles: composeFiles));
+    }
+
+    /// <summary>
+    /// Sets the files and directories to copy into the container.
+    /// </summary>
+    /// <remarks>
+    /// By default, the entire directory of each Docker Compose file is copied into
+    /// the container. Set the inclusions to copy the Docker Compose files and the
+    /// listed files and directories only. Use it when the Docker Compose files sit
+    /// next to files they do not reference, such as build output.
+    ///
+    /// The inclusions are resolved relative to the directory of the first Docker
+    /// Compose file, and keep their relative path inside the container.
+    /// </remarks>
+    /// <param name="fileCopyInclusions">A list of file and directory paths, relative to the directory of the first Docker Compose file.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WithCopyFilesInContainer(params string[] fileCopyInclusions)
+    {
+      return Merge(DockerResourceConfiguration, new ComposeConfiguration(fileCopyInclusions: fileCopyInclusions));
+    }
+
+    /// <summary>
+    /// Sets the Docker Compose project name prefix.
+    /// </summary>
+    /// <remarks>
+    /// The project name is the prefix followed by a random suffix. A unique project
+    /// name keeps concurrent test runs apart, and prevents the Resource Reaper from
+    /// removing the Docker resources of a Docker Compose project that it does not
+    /// own.
+    /// </remarks>
+    /// <param name="projectNamePrefix">The Docker Compose project name prefix.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WithProjectNamePrefix(string projectNamePrefix)
+    {
+      return Merge(DockerResourceConfiguration, new ComposeConfiguration(projectNamePrefix: projectNamePrefix));
+    }
+
+    /// <summary>
+    /// Sets the Docker Compose services to start.
+    /// </summary>
+    /// <remarks>
+    /// If no services are set, all services are started.
+    /// </remarks>
+    /// <param name="services">A list of Docker Compose service names.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WithService(params string[] services)
+    {
+      return Merge(DockerResourceConfiguration, new ComposeConfiguration(services: services));
+    }
+
+    /// <summary>
+    /// Sets the number of containers that a Docker Compose service runs.
+    /// </summary>
+    /// <remarks>
+    /// Each container is one instance of the service, addressed by the service name
+    /// and the container number. Use
+    /// <see cref="WithExposedServiceInstance(string, ushort, ushort)" /> to expose
+    /// the port of a specific instance.
+    /// </remarks>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="count">The number of containers that the Docker Compose service runs.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WithScaledService(string serviceName, ushort count)
+    {
+      var scaledServices = new Dictionary<string, ushort> { { serviceName, count } };
+      return Merge(DockerResourceConfiguration, new ComposeConfiguration(scaledServices: scaledServices));
+    }
+
+    /// <summary>
+    /// Exposes a Docker Compose service port.
+    /// </summary>
+    /// <remarks>
+    /// The service port does not need to be published (bound to a host port) in the
+    /// Docker Compose file. An ambassador container proxies the service port and
+    /// makes it accessible to the test host.
+    ///
+    /// The readiness check waits until the service port accepts connections. It
+    /// runs inside the ambassador container, and does not require anything from the
+    /// service image.
+    ///
+    /// The service name addresses the first instance of the service. Use
+    /// <see cref="WithExposedServiceInstance(string, ushort, ushort)" /> to address
+    /// one container of a service that runs more than one.
+    /// </remarks>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="port">The Docker Compose service port.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WithExposedService(string serviceName, ushort port)
+    {
+      return WithExposedServiceInstance(serviceName, ComposeServiceName.FirstInstance, port);
+    }
+
+    /// <summary>
+    /// Exposes a Docker Compose service port.
+    /// </summary>
+    /// <remarks>
+    /// The service is ready when the service port accepts connections and the wait
+    /// strategy indicates readiness.
+    /// </remarks>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="port">The Docker Compose service port.</param>
+    /// <param name="waitStrategy">The wait strategy that indicates the readiness of the service.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WithExposedService(string serviceName, ushort port, IWaitForContainerOS waitStrategy)
+    {
+      return WithExposedServiceInstance(serviceName, ComposeServiceName.FirstInstance, port, waitStrategy);
+    }
+
+    /// <summary>
+    /// Exposes the port of a Docker Compose service instance.
+    /// </summary>
+    /// <remarks>
+    /// Use this member to address one container of a Docker Compose service that
+    /// runs more than one (see <see cref="WithScaledService" />).
+    /// </remarks>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="instance">The number of the container within the Docker Compose service.</param>
+    /// <param name="port">The Docker Compose service port.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WithExposedServiceInstance(string serviceName, ushort instance, ushort port)
+    {
+      var exposedServices = new[] { new ComposeExposedService(serviceName, instance, port) };
+      return Merge(DockerResourceConfiguration, new ComposeConfiguration(exposedServices: exposedServices));
+    }
+
+    /// <summary>
+    /// Exposes the port of a Docker Compose service instance.
+    /// </summary>
+    /// <remarks>
+    /// Use this member to address one container of a Docker Compose service that
+    /// runs more than one (see <see cref="WithScaledService" />).
+    /// </remarks>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="instance">The number of the container within the Docker Compose service.</param>
+    /// <param name="port">The Docker Compose service port.</param>
+    /// <param name="waitStrategy">The wait strategy that indicates the readiness of the service.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WithExposedServiceInstance(string serviceName, ushort instance, ushort port, IWaitForContainerOS waitStrategy)
+    {
+      return WithExposedServiceInstance(serviceName, instance, port)
+        .WaitingForInstance(serviceName, instance, waitStrategy);
+    }
+
+    /// <summary>
+    /// Sets the wait strategy that indicates the readiness of a Docker Compose
+    /// service.
+    /// </summary>
+    /// <remarks>
+    /// In contrast to <see cref="WithExposedService(string, ushort)" />, this does
+    /// not expose a service port. Use it to wait for a service that the test host
+    /// does not need to reach, such as a database that only another service
+    /// connects to.
+    ///
+    /// The service name addresses the first instance of the service. Use
+    /// <see cref="WaitingForInstance" /> to address one container of a service that
+    /// runs more than one.
+    /// </remarks>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="waitStrategy">The wait strategy that indicates the readiness of the service.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WaitingFor(string serviceName, IWaitForContainerOS waitStrategy)
+    {
+      return WaitingForInstance(serviceName, ComposeServiceName.FirstInstance, waitStrategy);
+    }
+
+    /// <summary>
+    /// Sets the wait strategy that indicates the readiness of a Docker Compose
+    /// service instance.
+    /// </summary>
+    /// <remarks>
+    /// Use this member to address one container of a Docker Compose service that
+    /// runs more than one (see <see cref="WithScaledService" />).
+    /// </remarks>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="instance">The number of the container within the Docker Compose service.</param>
+    /// <param name="waitStrategy">The wait strategy that indicates the readiness of the service.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WaitingForInstance(string serviceName, ushort instance, IWaitForContainerOS waitStrategy)
+    {
+      var serviceReadiness = new[] { new ComposeServiceReadiness(serviceName, instance, waitStrategy.Build()) };
+      return Merge(DockerResourceConfiguration, new ComposeConfiguration(serviceReadiness: serviceReadiness));
+    }
+
+    /// <summary>
+    /// Sets whether the Docker Compose images are pulled before the services start
+    /// or not.
+    /// </summary>
+    /// <remarks>
+    /// Enabled by default. The images are pulled from the test host instead of from
+    /// inside the container, so that the Docker credentials and credential helpers
+    /// of the test host apply. Docker Compose cannot use them, it does not have
+    /// access to the Docker configuration of the test host.
+    ///
+    /// Images that are already present on the Docker host are not pulled again, and
+    /// a failing pull does not fail the start. Docker Compose still tries to pull
+    /// the image afterward.
+    /// </remarks>
+    /// <param name="pull">Determines whether the Docker Compose images are pulled before the services start or not.</param>
+    /// <returns>A configured instance of <see cref="ComposeBuilder" />.</returns>
+    public ComposeBuilder WithPull(bool pull)
+    {
+      return Merge(DockerResourceConfiguration, new ComposeConfiguration(pull: pull));
+    }
+
+    /// <inheritdoc />
+    public override ComposeContainer Build()
+    {
+      Validate();
+
+      // Keep the project name short. Docker Compose prefixes the container names with
+      // it, and a DNS label is limited to 63 characters.
+      var projectName = $"{DockerResourceConfiguration.ProjectNamePrefix ?? DefaultProjectNamePrefix}-{Guid.NewGuid().ToString("D").Substring(0, ProjectNameSuffixLength)}";
+
+      var composeFiles = GetComposeFilePaths();
+
+      var composeFile = string.Join(":", composeFiles.Select(GetContainerPath));
+
+      // Docker Compose resolves relative references, such as bind mount sources,
+      // against the directory of the first Docker Compose file.
+      var projectDirectoryPath = GetContainerPath(Path.GetDirectoryName(composeFiles[0]));
+
+      var fileCopyInclusions = GetFileCopyInclusionPaths();
+
+      // Without inclusions, the entire directory of each Docker Compose file is
+      // copied. With inclusions, only the inclusions and the Docker Compose files
+      // themselves are copied. Docker Compose cannot read the Docker Compose files
+      // otherwise.
+      var resourcePaths = fileCopyInclusions.Length == 0
+        ? composeFiles.Select(Path.GetDirectoryName).Distinct()
+        : composeFiles.Concat(fileCopyInclusions);
+
+      var composeBuilder = Merge(DockerResourceConfiguration, new ComposeConfiguration(projectName: projectName))
+        .WithEnvironment("COMPOSE_PROJECT_NAME", projectName)
+        .WithEnvironment("COMPOSE_FILE", composeFile)
+        .WithWorkingDirectory(projectDirectoryPath)
+        .WithMount(new UnixSocketMount(DockerResourceConfiguration.DockerEndpointAuthConfig.Endpoint));
+
+      composeBuilder = resourcePaths.Select(GetResourceMapping)
+        .Aggregate(composeBuilder, (builder, resourceMapping) => builder.WithResourceMapping(resourceMapping));
+
+      return new ComposeContainer(composeBuilder.DockerResourceConfiguration);
+    }
+
+    /// <inheritdoc />
+    protected override ComposeBuilder Init()
+    {
+      return base.Init()
+        .WithEntrypoint("/bin/sh", "-c")
+        .WithCommand("trap 'exit 0' TERM; sleep infinity & wait $!")
+        .WithPull(true);
+    }
+
+    /// <inheritdoc />
+    protected override void Validate()
+    {
+      base.Validate();
+
+      const string reuseNotSupported = "Reuse is not supported in conjunction with the Docker Compose builder.";
+      _ = Guard.Argument(DockerResourceConfiguration, nameof(DockerResourceConfiguration.Reuse))
+        .ThrowIf(argument => argument.Value.Reuse.HasValue && argument.Value.Reuse.Value, argument => new ArgumentException(reuseNotSupported, argument.Name));
+
+      var composeFiles = GetComposeFilePaths();
+
+      const string composeFileNotSet = "Missing Docker Compose file. At least one Docker Compose file must be specified.";
+      _ = Guard.Argument(composeFiles, nameof(DockerResourceConfiguration.ComposeFiles))
+        .ThrowIf(argument => argument.Value.Length == 0, argument => new ArgumentException(composeFileNotSet, argument.Name));
+
+      const string composeFileNotFound = "Docker Compose file '{0}' was not found.";
+      _ = Guard.Argument(composeFiles, nameof(DockerResourceConfiguration.ComposeFiles))
+        .ThrowIf(argument => argument.Value.Any(filePath => !File.Exists(filePath)), argument => new FileNotFoundException(string.Format(composeFileNotFound, argument.Value.First(filePath => !File.Exists(filePath)))));
+
+      const string fileCopyInclusionNotFound = "The file or directory '{0}' was not found.";
+      _ = Guard.Argument(GetFileCopyInclusionPaths(), nameof(DockerResourceConfiguration.FileCopyInclusions))
+        .ThrowIf(argument => argument.Value.Any(FileCopyInclusionNotFound), argument => new FileNotFoundException(string.Format(fileCopyInclusionNotFound, argument.Value.First(FileCopyInclusionNotFound))));
+
+      const string composeFileNotOnLocalDrive = "The Docker Compose file '{0}' is on a UNC path. The Docker Compose files must be on a local drive, the Docker daemon cannot resolve a UNC path.";
+      _ = Guard.Argument(composeFiles, nameof(DockerResourceConfiguration.ComposeFiles))
+        .ThrowIf(argument => argument.Value.Any(IsUncPath), argument => new ArgumentException(string.Format(composeFileNotOnLocalDrive, argument.Value.First(IsUncPath)), argument.Name));
+
+      const string projectNamePrefixInvalid = "The Docker Compose project name prefix must start with a lowercase letter or digit and can only contain lowercase letters, digits, dashes, and underscores.";
+      _ = Guard.Argument(DockerResourceConfiguration.ProjectNamePrefix, nameof(DockerResourceConfiguration.ProjectNamePrefix))
+        .ThrowIf(argument => argument.Value != null && !ProjectNameRegex.IsMatch(argument.Value), argument => new ArgumentException(projectNamePrefixInvalid, argument.Name));
+    }
+
+    /// <inheritdoc />
+    protected override ComposeBuilder Clone(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
+    {
+      return Merge(DockerResourceConfiguration, new ComposeConfiguration(resourceConfiguration));
+    }
+
+    /// <inheritdoc />
+    protected override ComposeBuilder Clone(IContainerConfiguration resourceConfiguration)
+    {
+      return Merge(DockerResourceConfiguration, new ComposeConfiguration(resourceConfiguration));
+    }
+
+    /// <inheritdoc />
+    protected override ComposeBuilder Merge(ComposeConfiguration oldValue, ComposeConfiguration newValue)
+    {
+      return new ComposeBuilder(new ComposeConfiguration(oldValue, newValue));
+    }
+
+    /// <summary>
+    /// Gets the resolved Docker Compose file paths.
+    /// </summary>
+    /// <returns>The distinct, absolute Docker Compose file paths.</returns>
+    private string[] GetComposeFilePaths()
+    {
+      return DockerResourceConfiguration.ComposeFiles.Select(Path.GetFullPath).Distinct().ToArray();
+    }
+
+    /// <summary>
+    /// Gets the resolved file copy inclusion paths.
+    /// </summary>
+    /// <remarks>
+    /// Returns an empty list if the Docker Compose files are not set. The directory
+    /// of the first Docker Compose file resolves the relative inclusion paths.
+    /// </remarks>
+    /// <returns>The absolute file copy inclusion paths on the test host.</returns>
+    private string[] GetFileCopyInclusionPaths()
+    {
+      var composeFiles = GetComposeFilePaths();
+
+      if (composeFiles.Length == 0)
+      {
+        return Array.Empty<string>();
+      }
+
+      var projectDirectoryPath = Path.GetDirectoryName(composeFiles[0]);
+      return DockerResourceConfiguration.FileCopyInclusions.Select(fileCopyInclusion => Path.GetFullPath(Path.Combine(projectDirectoryPath, fileCopyInclusion))).ToArray();
+    }
+
+    /// <summary>
+    /// Gets the resource mapping that copies a file or directory into the container.
+    /// </summary>
+    /// <remarks>
+    /// A directory is copied into the container directory that corresponds to it, a
+    /// file into the container directory that corresponds to its parent directory.
+    /// Both keep the path they have on the test host (see
+    /// <see cref="GetContainerPath" />).
+    /// </remarks>
+    /// <param name="path">The absolute file or directory path on the test host.</param>
+    /// <returns>The resource mapping that copies the file or directory into the container.</returns>
+    private static IResourceMapping GetResourceMapping(string path)
+    {
+      var targetDirectoryPath = Directory.Exists(path) ? path : Path.GetDirectoryName(path);
+      return new FileResourceMapping(path, GetContainerPath(targetDirectoryPath), 0, 0, Unix.FileMode644);
+    }
+
+    /// <summary>
+    /// Gets the path inside the container that corresponds to a path on the test
+    /// host.
+    /// </summary>
+    /// <remarks>
+    /// Docker Compose resolves relative references against the directory of the
+    /// Docker Compose file and passes the resolved path to the Docker daemon, which
+    /// interprets it on the test host. Keeping the path inside the container equal
+    /// to the path on the test host is what makes relative bind mounts work.
+    /// </remarks>
+    /// <param name="path">The absolute path on the test host.</param>
+    /// <returns>The corresponding path inside the container.</returns>
+    private static string GetContainerPath(string path)
+    {
+      var containerPath = Unix.Instance.NormalizePath(path);
+
+      // Convert a Windows drive letter to the path notation that the Docker daemon
+      // understands, e.g. C:/Users/Default to /c/Users/Default.
+      if (containerPath.Length > 1 && ':'.Equals(containerPath[1]))
+      {
+        containerPath = "/" + char.ToLowerInvariant(containerPath[0]) + containerPath.Substring(2);
+      }
+
+      return containerPath;
+    }
+
+    /// <summary>
+    /// Checks whether a path on the test host is a UNC path, e.g.
+    /// <c>\\wsl$\Ubuntu\home</c>.
+    /// </summary>
+    /// <remarks>
+    /// A UNC path has no equivalent inside the container, and the Docker daemon
+    /// cannot resolve it either (see <see cref="GetContainerPath" />).
+    /// </remarks>
+    /// <param name="path">The absolute path on the test host.</param>
+    /// <returns>True if the path is a UNC path; otherwise, false.</returns>
+    private static bool IsUncPath(string path)
+    {
+      return path.StartsWith("\\\\", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Checks whether the file copy inclusion does not exist on the test host.
+    /// </summary>
+    /// <param name="fileCopyInclusion">The absolute file copy inclusion path on the test host.</param>
+    /// <returns>True if the file copy inclusion does not exist; otherwise, false.</returns>
+    private static bool FileCopyInclusionNotFound(string fileCopyInclusion)
+    {
+      return !File.Exists(fileCopyInclusion) && !Directory.Exists(fileCopyInclusion);
+    }
+  }
+}

--- a/src/Testcontainers/Builders/ComposeBuilder.cs
+++ b/src/Testcontainers/Builders/ComposeBuilder.cs
@@ -419,13 +419,13 @@ namespace DotNet.Testcontainers.Builders
       _ = Guard.Argument(GetFileCopyInclusionPaths(), nameof(DockerResourceConfiguration.FileCopyInclusions))
         .ThrowIf(argument => argument.Value.Any(IsFileCopyInclusionMissing), argument => new FileNotFoundException(string.Format(fileCopyInclusionDoesNotExist, argument.Value.First(IsFileCopyInclusionMissing))));
 
-      const string projectNamePrefixTooLong = "The Docker Compose project name prefix must not exceed {0} characters because Docker Compose prefixes the container names with the project name, and a DNS label is limited to 63 characters.";
-      _ = Guard.Argument(DockerResourceConfiguration.ProjectNamePrefix, nameof(DockerResourceConfiguration.ProjectNamePrefix))
-        .ThrowIf(argument => argument.Value != null && argument.Value.Length > ProjectNamePrefixMaxLength, argument => new ArgumentException(string.Format(projectNamePrefixTooLong, ProjectNamePrefixMaxLength), argument.Name));
-
       const string projectNamePrefixInvalid = "The Docker Compose project name prefix must start with a lowercase letter or digit and can only contain lowercase letters, digits, dashes, and underscores.";
       _ = Guard.Argument(DockerResourceConfiguration.ProjectNamePrefix, nameof(DockerResourceConfiguration.ProjectNamePrefix))
         .ThrowIf(argument => argument.Value != null && !ProjectNameRegex.IsMatch(argument.Value), argument => new ArgumentException(projectNamePrefixInvalid, argument.Name));
+
+      const string projectNamePrefixTooLong = "The Docker Compose project name prefix must not exceed {0} characters, keeping the project name Docker Compose derives from it within the 63-character DNS label limit.";
+      _ = Guard.Argument(DockerResourceConfiguration.ProjectNamePrefix, nameof(DockerResourceConfiguration.ProjectNamePrefix))
+        .ThrowIf(argument => argument.Value != null && argument.Value.Length > ProjectNamePrefixMaxLength, argument => new ArgumentException(string.Format(projectNamePrefixTooLong, ProjectNamePrefixMaxLength), argument.Name));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/ComposeBuilder.cs
+++ b/src/Testcontainers/Builders/ComposeBuilder.cs
@@ -381,31 +381,31 @@ namespace DotNet.Testcontainers.Builders
     {
       base.Validate();
 
-      const string reuseNotSupported = "Reuse is not supported in conjunction with the Docker Compose builder.";
+      const string reuseNotSupported = "Reuse cannot be used in conjunction with the Docker Compose builder.";
       _ = Guard.Argument(DockerResourceConfiguration, nameof(DockerResourceConfiguration.Reuse))
         .ThrowIf(argument => argument.Value.Reuse.HasValue && argument.Value.Reuse.Value, argument => new ArgumentException(reuseNotSupported, argument.Name));
 
       var composeFiles = GetComposeFilePaths();
 
-      const string composeFileNotSet = "Missing Docker Compose file. At least one Docker Compose file must be specified.";
+      const string composeFileNotSet = "At least one Docker Compose file must be set.";
       _ = Guard.Argument(composeFiles, nameof(DockerResourceConfiguration.ComposeFiles))
         .ThrowIf(argument => argument.Value.Length == 0, argument => new ArgumentException(composeFileNotSet, argument.Name));
 
-      const string composeFileNotFound = "Docker Compose file '{0}' was not found.";
+      const string composeFileDoesNotExist = "The Docker Compose file '{0}' does not exist.";
       _ = Guard.Argument(composeFiles, nameof(DockerResourceConfiguration.ComposeFiles))
-        .ThrowIf(argument => argument.Value.Any(filePath => !File.Exists(filePath)), argument => new FileNotFoundException(string.Format(composeFileNotFound, argument.Value.First(filePath => !File.Exists(filePath)))));
+        .ThrowIf(argument => argument.Value.Any(filePath => !File.Exists(filePath)), argument => new FileNotFoundException(string.Format(composeFileDoesNotExist, argument.Value.First(filePath => !File.Exists(filePath)))));
 
-      const string fileCopyInclusionNotFound = "The file or directory '{0}' was not found.";
-      _ = Guard.Argument(GetFileCopyInclusionPaths(), nameof(DockerResourceConfiguration.FileCopyInclusions))
-        .ThrowIf(argument => argument.Value.Any(FileCopyInclusionNotFound), argument => new FileNotFoundException(string.Format(fileCopyInclusionNotFound, argument.Value.First(FileCopyInclusionNotFound))));
-
-      const string composeFileNotOnLocalDrive = "The Docker Compose file '{0}' is on a UNC path. The Docker Compose files must be on a local drive, the Docker daemon cannot resolve a UNC path.";
+      const string composeFileOnUncPath = "The Docker Compose file '{0}' is on a UNC path. The Docker Compose files must be on a local drive because the Docker daemon cannot resolve a UNC path.";
       _ = Guard.Argument(composeFiles, nameof(DockerResourceConfiguration.ComposeFiles))
-        .ThrowIf(argument => argument.Value.Any(IsUncPath), argument => new ArgumentException(string.Format(composeFileNotOnLocalDrive, argument.Value.First(IsUncPath)), argument.Name));
+        .ThrowIf(argument => argument.Value.Any(IsUncPath), argument => new ArgumentException(string.Format(composeFileOnUncPath, argument.Value.First(IsUncPath)), argument.Name));
 
-      const string composeFilePathSeparatorNotFound = "The Docker Compose file paths contain every supported path separator character ({0}). At least one of them must be absent from the Docker Compose file paths, Docker Compose separates them with it.";
+      const string composeFilePathSeparatorNotFound = "The Docker Compose file paths contain every supported path separator character ({0}). At least one of these characters must not occur in any Docker Compose file path because Docker Compose separates the paths with it.";
       _ = Guard.Argument(composeFiles, nameof(DockerResourceConfiguration.ComposeFiles))
         .ThrowIf(argument => argument.Value.Length > 0 && GetPathSeparator(argument.Value.Select(GetContainerPath)) == null, argument => new ArgumentException(string.Format(composeFilePathSeparatorNotFound, string.Join(" ", PathSeparators)), argument.Name));
+
+      const string fileCopyInclusionDoesNotExist = "The file or directory '{0}' does not exist.";
+      _ = Guard.Argument(GetFileCopyInclusionPaths(), nameof(DockerResourceConfiguration.FileCopyInclusions))
+        .ThrowIf(argument => argument.Value.Any(IsFileCopyInclusionMissing), argument => new FileNotFoundException(string.Format(fileCopyInclusionDoesNotExist, argument.Value.First(IsFileCopyInclusionMissing))));
 
       const string projectNamePrefixInvalid = "The Docker Compose project name prefix must start with a lowercase letter or digit and can only contain lowercase letters, digits, dashes, and underscores.";
       _ = Guard.Argument(DockerResourceConfiguration.ProjectNamePrefix, nameof(DockerResourceConfiguration.ProjectNamePrefix))
@@ -461,23 +461,6 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <summary>
-    /// Gets the resource mapping that copies a file or directory into the container.
-    /// </summary>
-    /// <remarks>
-    /// A directory is copied into the container directory that corresponds to it, a
-    /// file into the container directory that corresponds to its parent directory.
-    /// Both keep the path they have on the test host (see
-    /// <see cref="GetContainerPath" />).
-    /// </remarks>
-    /// <param name="path">The absolute file or directory path on the test host.</param>
-    /// <returns>The resource mapping that copies the file or directory into the container.</returns>
-    private static IResourceMapping GetResourceMapping(string path)
-    {
-      var targetDirectoryPath = Directory.Exists(path) ? path : Path.GetDirectoryName(path);
-      return new FileResourceMapping(path, GetContainerPath(targetDirectoryPath), 0, 0, Unix.FileMode644);
-    }
-
-    /// <summary>
     /// Gets the path inside the container that corresponds to a path on the test
     /// host.
     /// </summary>
@@ -522,6 +505,23 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <summary>
+    /// Gets the resource mapping that copies a file or directory into the container.
+    /// </summary>
+    /// <remarks>
+    /// A directory is copied into the container directory that corresponds to it, a
+    /// file into the container directory that corresponds to its parent directory.
+    /// Both keep the path they have on the test host (see
+    /// <see cref="GetContainerPath" />).
+    /// </remarks>
+    /// <param name="path">The absolute file or directory path on the test host.</param>
+    /// <returns>The resource mapping that copies the file or directory into the container.</returns>
+    private static IResourceMapping GetResourceMapping(string path)
+    {
+      var targetDirectoryPath = Directory.Exists(path) ? path : Path.GetDirectoryName(path);
+      return new FileResourceMapping(path, GetContainerPath(targetDirectoryPath), 0, 0, Unix.FileMode644);
+    }
+
+    /// <summary>
     /// Checks whether a path on the test host is a UNC path, e.g.
     /// <c>\\wsl$\Ubuntu\home</c>.
     /// </summary>
@@ -537,11 +537,11 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <summary>
-    /// Checks whether the file copy inclusion does not exist on the test host.
+    /// Checks whether a file copy inclusion is missing on the test host.
     /// </summary>
     /// <param name="fileCopyInclusion">The absolute file copy inclusion path on the test host.</param>
-    /// <returns>True if the file copy inclusion does not exist; otherwise, false.</returns>
-    private static bool FileCopyInclusionNotFound(string fileCopyInclusion)
+    /// <returns>True if the file copy inclusion is missing; otherwise, false.</returns>
+    private static bool IsFileCopyInclusionMissing(string fileCopyInclusion)
     {
       return !File.Exists(fileCopyInclusion) && !Directory.Exists(fileCopyInclusion);
     }

--- a/src/Testcontainers/Builders/ComposeBuilder.cs
+++ b/src/Testcontainers/Builders/ComposeBuilder.cs
@@ -426,6 +426,13 @@ namespace DotNet.Testcontainers.Builders
       const string projectNamePrefixTooLong = "The Docker Compose project name prefix must not exceed {0} characters, keeping the project name Docker Compose derives from it within the 63-character DNS label limit.";
       _ = Guard.Argument(DockerResourceConfiguration.ProjectNamePrefix, nameof(DockerResourceConfiguration.ProjectNamePrefix))
         .ThrowIf(argument => argument.Value != null && argument.Value.Length > ProjectNamePrefixMaxLength, argument => new ArgumentException(string.Format(projectNamePrefixTooLong, ProjectNamePrefixMaxLength), argument.Name));
+
+      const string serviceInstanceInvalid = "The Docker Compose service instance must be {0} or greater.";
+      _ = Guard.Argument(DockerResourceConfiguration.ExposedServices, nameof(DockerResourceConfiguration.ExposedServices))
+        .ThrowIf(argument => argument.Value != null && argument.Value.Any(exposedService => exposedService.Instance < ComposeServiceName.FirstInstance), argument => new ArgumentException(string.Format(serviceInstanceInvalid, ComposeServiceName.FirstInstance), argument.Name));
+
+      _ = Guard.Argument(DockerResourceConfiguration.ServiceReadiness, nameof(DockerResourceConfiguration.ServiceReadiness))
+        .ThrowIf(argument => argument.Value != null && argument.Value.Any(serviceReadiness => serviceReadiness.Instance < ComposeServiceName.FirstInstance), argument => new ArgumentException(string.Format(serviceInstanceInvalid, ComposeServiceName.FirstInstance), argument.Name));
     }
 
     /// <inheritdoc />

--- a/src/Testcontainers/Builders/ComposeBuilder.cs
+++ b/src/Testcontainers/Builders/ComposeBuilder.cs
@@ -34,7 +34,19 @@ namespace DotNet.Testcontainers.Builders
     /// <summary>
     /// The number of random characters that the Docker Compose project name ends with.
     /// </summary>
-    private const int ProjectNameSuffixLength = 8;
+    private const ushort ProjectNameSuffixLength = 8;
+
+    /// <summary>
+    /// The maximum length of the Docker Compose project name. Docker Compose prefixes
+    /// the container names with it, and a DNS label is limited to 63 characters.
+    /// </summary>
+    private const ushort ProjectNameMaxLength = 63;
+
+    /// <summary>
+    /// The maximum length of the Docker Compose project name prefix, that is, the
+    /// project name without its random suffix and the dash that separates them.
+    /// </summary>
+    private const ushort ProjectNamePrefixMaxLength = ProjectNameMaxLength - ProjectNameSuffixLength - 1;
 
     /// <summary>
     /// The path separator characters that separate the Docker Compose file paths in
@@ -407,6 +419,10 @@ namespace DotNet.Testcontainers.Builders
       _ = Guard.Argument(GetFileCopyInclusionPaths(), nameof(DockerResourceConfiguration.FileCopyInclusions))
         .ThrowIf(argument => argument.Value.Any(IsFileCopyInclusionMissing), argument => new FileNotFoundException(string.Format(fileCopyInclusionDoesNotExist, argument.Value.First(IsFileCopyInclusionMissing))));
 
+      const string projectNamePrefixTooLong = "The Docker Compose project name prefix must not exceed {0} characters because Docker Compose prefixes the container names with the project name, and a DNS label is limited to 63 characters.";
+      _ = Guard.Argument(DockerResourceConfiguration.ProjectNamePrefix, nameof(DockerResourceConfiguration.ProjectNamePrefix))
+        .ThrowIf(argument => argument.Value != null && argument.Value.Length > ProjectNamePrefixMaxLength, argument => new ArgumentException(string.Format(projectNamePrefixTooLong, ProjectNamePrefixMaxLength), argument.Name));
+
       const string projectNamePrefixInvalid = "The Docker Compose project name prefix must start with a lowercase letter or digit and can only contain lowercase letters, digits, dashes, and underscores.";
       _ = Guard.Argument(DockerResourceConfiguration.ProjectNamePrefix, nameof(DockerResourceConfiguration.ProjectNamePrefix))
         .ThrowIf(argument => argument.Value != null && !ProjectNameRegex.IsMatch(argument.Value), argument => new ArgumentException(projectNamePrefixInvalid, argument.Name));
@@ -517,6 +533,8 @@ namespace DotNet.Testcontainers.Builders
     /// <returns>The resource mapping that copies the file or directory into the container.</returns>
     private static IResourceMapping GetResourceMapping(string path)
     {
+      // Despite its name, FileResourceMapping works for directories too, the copy
+      // logic picks the strategy based on the source path at copy time.
       var targetDirectoryPath = Directory.Exists(path) ? path : Path.GetDirectoryName(path);
       return new FileResourceMapping(path, GetContainerPath(targetDirectoryPath), 0, 0, Unix.FileMode644);
     }

--- a/src/Testcontainers/Builders/ComposeBuilder.cs
+++ b/src/Testcontainers/Builders/ComposeBuilder.cs
@@ -58,8 +58,8 @@ namespace DotNet.Testcontainers.Builders
     /// (e.g., <c>docker:28-cli</c>).
     /// </param>
     /// <remarks>
-    /// The image requires the Docker Compose plugin.
-    /// Docker image tags available at <see href="https://hub.docker.com/_/docker/tags" />.
+    /// The image requires the Docker Compose plugin. Docker image tags available at
+    /// <see href="https://hub.docker.com/_/docker/tags" />.
     /// </remarks>
     public ComposeBuilder(string image)
       : this(new DockerImage(image))
@@ -74,8 +74,8 @@ namespace DotNet.Testcontainers.Builders
     /// for the container builder configuration.
     /// </param>
     /// <remarks>
-    /// The image requires the Docker Compose plugin.
-    /// Docker image tags available at <see href="https://hub.docker.com/_/docker/tags" />.
+    /// The image requires the Docker Compose plugin. Docker image tags available at
+    /// <see href="https://hub.docker.com/_/docker/tags" />.
     /// </remarks>
     public ComposeBuilder(IImage image)
       : this(new ComposeConfiguration())

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -7,6 +7,7 @@ namespace DotNet.Testcontainers.Clients
   using System.Threading.Tasks;
   using DotNet.Testcontainers.Configurations;
   using DotNet.Testcontainers.Containers;
+  using DotNet.Testcontainers.Images;
 
   /// <summary>
   /// This class represents a Testcontainers client.
@@ -179,5 +180,13 @@ namespace DotNet.Testcontainers.Clients
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Task that completes when the Docker image has been built.</returns>
     Task<string> BuildAsync(IImageFromDockerfileConfiguration configuration, CancellationToken ct = default);
+
+    /// <summary>
+    /// Pulls an image from a registry.
+    /// </summary>
+    /// <param name="image">The image to pull.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the image has been pulled.</returns>
+    Task PullImageAsync(IImage image, CancellationToken ct = default);
   }
 }

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -402,12 +402,8 @@ namespace DotNet.Testcontainers.Clients
       return configuration.Image.FullName;
     }
 
-    /// <summary>
-    /// Pulls an image from a registry.
-    /// </summary>
-    /// <param name="image">The image to pull.</param>
-    /// <param name="ct">Cancellation token.</param>
-    private async Task PullImageAsync(IImage image, CancellationToken ct = default)
+    /// <inheritdoc />
+    public async Task PullImageAsync(IImage image, CancellationToken ct = default)
     {
       var dockerRegistryServerAddress = image.GetHostname();
 

--- a/src/Testcontainers/Configurations/Containers/ComposeConfiguration.cs
+++ b/src/Testcontainers/Configurations/Containers/ComposeConfiguration.cs
@@ -1,0 +1,142 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System.Collections.Generic;
+  using Docker.DotNet.Models;
+  using DotNet.Testcontainers.Builders;
+  using JetBrains.Annotations;
+
+  /// <inheritdoc cref="ContainerConfiguration" />
+  [PublicAPI]
+  public sealed class ComposeConfiguration : ContainerConfiguration
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeConfiguration" /> class.
+    /// </summary>
+    /// <param name="composeFiles">A list of Docker Compose files.</param>
+    /// <param name="projectName">The Docker Compose project name.</param>
+    /// <param name="projectNamePrefix">The Docker Compose project name prefix.</param>
+    /// <param name="services">A list of Docker Compose services to start.</param>
+    /// <param name="scaledServices">A dictionary of Docker Compose services and the number of containers they run.</param>
+    /// <param name="exposedServices">A list of exposed Docker Compose service ports.</param>
+    /// <param name="serviceReadiness">A list that indicates the readiness of the Docker Compose services.</param>
+    /// <param name="fileCopyInclusions">A list of files and directories to copy into the container.</param>
+    /// <param name="pull">A value indicating whether the Docker Compose images are pulled before the services start or not.</param>
+    public ComposeConfiguration(
+      IEnumerable<string> composeFiles = null,
+      string projectName = null,
+      string projectNamePrefix = null,
+      IEnumerable<string> services = null,
+      IReadOnlyDictionary<string, ushort> scaledServices = null,
+      IEnumerable<ComposeExposedService> exposedServices = null,
+      IEnumerable<ComposeServiceReadiness> serviceReadiness = null,
+      IEnumerable<string> fileCopyInclusions = null,
+      bool? pull = null)
+    {
+      ComposeFiles = composeFiles;
+      ProjectName = projectName;
+      ProjectNamePrefix = projectNamePrefix;
+      Services = services;
+      ScaledServices = scaledServices;
+      ExposedServices = exposedServices;
+      ServiceReadiness = serviceReadiness;
+      FileCopyInclusions = fileCopyInclusions;
+      Pull = pull;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeConfiguration" /> class.
+    /// </summary>
+    /// <param name="resourceConfiguration">The Docker resource configuration.</param>
+    public ComposeConfiguration(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
+      : base(resourceConfiguration)
+    {
+      // Passes the configuration upwards to the base implementations to create an updated immutable copy.
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeConfiguration" /> class.
+    /// </summary>
+    /// <param name="resourceConfiguration">The Docker resource configuration.</param>
+    public ComposeConfiguration(IContainerConfiguration resourceConfiguration)
+      : base(resourceConfiguration)
+    {
+      // Passes the configuration upwards to the base implementations to create an updated immutable copy.
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeConfiguration" /> class.
+    /// </summary>
+    /// <param name="resourceConfiguration">The Docker resource configuration.</param>
+    public ComposeConfiguration(ComposeConfiguration resourceConfiguration)
+      : this(new ComposeConfiguration(), resourceConfiguration)
+    {
+      // Passes the configuration upwards to the base implementations to create an updated immutable copy.
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeConfiguration" /> class.
+    /// </summary>
+    /// <param name="oldValue">The old Docker resource configuration.</param>
+    /// <param name="newValue">The new Docker resource configuration.</param>
+    public ComposeConfiguration(ComposeConfiguration oldValue, ComposeConfiguration newValue)
+      : base(oldValue, newValue)
+    {
+      ComposeFiles = BuildConfiguration.Combine(oldValue.ComposeFiles, newValue.ComposeFiles);
+      ProjectName = BuildConfiguration.Combine(oldValue.ProjectName, newValue.ProjectName);
+      ProjectNamePrefix = BuildConfiguration.Combine(oldValue.ProjectNamePrefix, newValue.ProjectNamePrefix);
+      Services = BuildConfiguration.Combine(oldValue.Services, newValue.Services);
+      ScaledServices = BuildConfiguration.Combine(oldValue.ScaledServices, newValue.ScaledServices);
+      ExposedServices = BuildConfiguration.Combine(oldValue.ExposedServices, newValue.ExposedServices);
+      ServiceReadiness = BuildConfiguration.Combine(oldValue.ServiceReadiness, newValue.ServiceReadiness);
+      FileCopyInclusions = BuildConfiguration.Combine(oldValue.FileCopyInclusions, newValue.FileCopyInclusions);
+      Pull = BuildConfiguration.Combine(oldValue.Pull, newValue.Pull);
+    }
+
+    /// <summary>
+    /// Gets a list of Docker Compose files.
+    /// </summary>
+    public IEnumerable<string> ComposeFiles { get; }
+
+    /// <summary>
+    /// Gets the Docker Compose project name.
+    /// </summary>
+    public string ProjectName { get; }
+
+    /// <summary>
+    /// Gets the Docker Compose project name prefix.
+    /// </summary>
+    public string ProjectNamePrefix { get; }
+
+    /// <summary>
+    /// Gets a list of Docker Compose services to start.
+    /// </summary>
+    public IEnumerable<string> Services { get; }
+
+    /// <summary>
+    /// Gets a dictionary of Docker Compose services and the number of containers they run.
+    /// </summary>
+    public IReadOnlyDictionary<string, ushort> ScaledServices { get; }
+
+    /// <summary>
+    /// Gets a list of exposed Docker Compose service ports.
+    /// </summary>
+    public IEnumerable<ComposeExposedService> ExposedServices { get; }
+
+    /// <summary>
+    /// Gets a list that indicates the readiness of the Docker Compose services.
+    /// </summary>
+    public IEnumerable<ComposeServiceReadiness> ServiceReadiness { get; }
+
+    /// <summary>
+    /// Gets a list of files and directories to copy into the container, relative to
+    /// the directory of the first Docker Compose file.
+    /// </summary>
+    public IEnumerable<string> FileCopyInclusions { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the Docker Compose images are pulled before
+    /// the services start or not.
+    /// </summary>
+    public bool? Pull { get; }
+  }
+}

--- a/src/Testcontainers/Configurations/Containers/ComposeExposedService.cs
+++ b/src/Testcontainers/Configurations/Containers/ComposeExposedService.cs
@@ -1,0 +1,39 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// An exposed Docker Compose service port.
+  /// </summary>
+  [PublicAPI]
+  public sealed class ComposeExposedService
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeExposedService" /> class.
+    /// </summary>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="instance">The number of the container within the Docker Compose service.</param>
+    /// <param name="port">The Docker Compose service port.</param>
+    public ComposeExposedService(string serviceName, ushort instance, ushort port)
+    {
+      ServiceName = serviceName;
+      Instance = instance;
+      Port = port;
+    }
+
+    /// <summary>
+    /// Gets the Docker Compose service name.
+    /// </summary>
+    public string ServiceName { get; }
+
+    /// <summary>
+    /// Gets the number of the container within the Docker Compose service.
+    /// </summary>
+    public ushort Instance { get; }
+
+    /// <summary>
+    /// Gets the Docker Compose service port.
+    /// </summary>
+    public ushort Port { get; }
+  }
+}

--- a/src/Testcontainers/Configurations/Containers/ComposeServiceReadiness.cs
+++ b/src/Testcontainers/Configurations/Containers/ComposeServiceReadiness.cs
@@ -1,0 +1,40 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System.Collections.Generic;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// The readiness of a Docker Compose service.
+  /// </summary>
+  [PublicAPI]
+  public sealed class ComposeServiceReadiness
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeServiceReadiness" /> class.
+    /// </summary>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="instance">The number of the container within the Docker Compose service.</param>
+    /// <param name="waitStrategies">The wait strategies that indicate the readiness of the service.</param>
+    public ComposeServiceReadiness(string serviceName, ushort instance, IEnumerable<WaitStrategy> waitStrategies)
+    {
+      ServiceName = serviceName;
+      Instance = instance;
+      WaitStrategies = waitStrategies;
+    }
+
+    /// <summary>
+    /// Gets the Docker Compose service name.
+    /// </summary>
+    public string ServiceName { get; }
+
+    /// <summary>
+    /// Gets the number of the container within the Docker Compose service.
+    /// </summary>
+    public ushort Instance { get; }
+
+    /// <summary>
+    /// Gets the wait strategies that indicate the readiness of the service.
+    /// </summary>
+    public IEnumerable<WaitStrategy> WaitStrategies { get; }
+  }
+}

--- a/src/Testcontainers/Configurations/Volumes/UnixSocketMount.cs
+++ b/src/Testcontainers/Configurations/Volumes/UnixSocketMount.cs
@@ -1,0 +1,56 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System;
+  using System.Threading;
+  using System.Threading.Tasks;
+  using JetBrains.Annotations;
+
+  /// <inheritdoc cref="IMount" />
+  internal readonly struct UnixSocketMount : IMount
+  {
+    private const string DockerSocketFilePath = "/var/run/docker.sock";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnixSocketMount" /> struct.
+    /// </summary>
+    /// <param name="dockerEndpoint">The Docker endpoint.</param>
+    public UnixSocketMount([NotNull] Uri dockerEndpoint)
+    {
+      // If the Docker endpoint is a Unix socket, extract the socket path from the
+      // URI; otherwise, fallback to the default Unix socket path.
+      var source = "unix".Equals(dockerEndpoint.Scheme, StringComparison.OrdinalIgnoreCase) ? dockerEndpoint.AbsolutePath : DockerSocketFilePath;
+
+      Type = MountType.Bind;
+
+      // If the user has overridden the Docker socket path, use the user-specified
+      // path; otherwise, keep the previously determined source.
+      Source = !string.IsNullOrEmpty(TestcontainersSettings.DockerSocketOverride) ? TestcontainersSettings.DockerSocketOverride : source;
+      Target = DockerSocketFilePath;
+      AccessMode = AccessMode.ReadOnly;
+    }
+
+    /// <inheritdoc />
+    public MountType Type { get; }
+
+    /// <inheritdoc />
+    public AccessMode AccessMode { get; }
+
+    /// <inheritdoc />
+    public string Source { get; }
+
+    /// <inheritdoc />
+    public string Target { get; }
+
+    /// <inheritdoc />
+    public Task CreateAsync(CancellationToken ct = default)
+    {
+      return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task DeleteAsync(CancellationToken ct = default)
+    {
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/src/Testcontainers/Configurations/WaitStrategies/UntilComposeServicePortIsAvailable.cs
+++ b/src/Testcontainers/Configurations/WaitStrategies/UntilComposeServicePortIsAvailable.cs
@@ -1,0 +1,49 @@
+namespace DotNet.Testcontainers.Configurations
+{
+  using System.Globalization;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Containers;
+
+  /// <summary>
+  /// Waits until a Docker Compose service port accepts connections.
+  /// </summary>
+  /// <remarks>
+  /// The check runs inside the ambassador container that proxies the exposed
+  /// service port, not inside the service container. This keeps the readiness
+  /// check independent of the service image. A service that does not ship a
+  /// shell, such as a distroless image, cannot run a check itself.
+  /// </remarks>
+  internal sealed class UntilComposeServicePortIsAvailable : IWaitUntil
+  {
+    /// <summary>
+    /// 2 seconds connect timeout. It bounds a single check, the wait strategy
+    /// retries until its own timeout is exceeded.
+    /// </summary>
+    private const int ConnectTimeoutInSeconds = 2;
+
+    private readonly IContainer _ambassadorContainer;
+
+    private readonly string[] _command;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UntilComposeServicePortIsAvailable" /> class.
+    /// </summary>
+    /// <param name="ambassadorContainer">The ambassador container that proxies the exposed service port.</param>
+    /// <param name="ipAddress">The IP address of the Docker Compose service container.</param>
+    /// <param name="port">The Docker Compose service port.</param>
+    public UntilComposeServicePortIsAvailable(IContainer ambassadorContainer, string ipAddress, ushort port)
+    {
+      _ambassadorContainer = ambassadorContainer;
+      _command = new[] { "socat", "-u", "OPEN:/dev/null", string.Format(CultureInfo.InvariantCulture, "TCP:{0}:{1},connect-timeout={2}", ipAddress, port, ConnectTimeoutInSeconds) };
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> UntilAsync(IContainer container)
+    {
+      var execResult = await _ambassadorContainer.ExecAsync(_command)
+        .ConfigureAwait(false);
+
+      return 0L.Equals(execResult.ExitCode);
+    }
+  }
+}

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -241,8 +241,8 @@ namespace DotNet.Testcontainers.Containers
       var serviceContainersByExited = _serviceContainers
         .ToLookup(serviceContainer => TestcontainersStates.Exited.Equals(serviceContainer.Value.State));
 
-      // Check the exit code of the services that already exited first. It fails faster
-      // and reports the cause more accurately than the readiness checks of the
+      // Check the exit code of the services that already exited first. It fails
+      // faster and reports the cause more accurately than the readiness checks of the
       // services that depend on them.
       await ThrowIfAnyServiceFailedAsync(serviceContainersByExited[true]
           .Select(serviceContainer => GetExitCodeFailureAsync(serviceContainer.Key, serviceContainer.Value.Id, ct)))

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -601,7 +601,8 @@ namespace DotNet.Testcontainers.Containers
       // the service run. Materialize them, the container configuration outlives this
       // method and would create new wait strategies on every enumeration.
       var waitStrategies = servicePortWaitStrategies
-        .Concat(serviceReadinessWaitStrategies);
+        .Concat(serviceReadinessWaitStrategies)
+        .ToArray();
 
       // The cast selects the constructor overload that copies the resource
       // configuration (Docker endpoint, session id, logger) and intentionally drops

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -439,8 +439,6 @@ namespace DotNet.Testcontainers.Containers
         return;
       }
 
-      _isComposeUp = false;
-
       _serviceContainers = new Dictionary<(string, ushort), ComposeServiceContainer>();
 
       try
@@ -467,6 +465,11 @@ namespace DotNet.Testcontainers.Containers
         _ = await ExecAsync(ComposeDownCommand, ct)
           .ThrowOnFailure()
           .ConfigureAwait(false);
+
+        // Only clear the flag once `docker compose down` actually succeeds. Keeping
+        // it set on failure lets a later Stop or Dispose call retry the cleanup
+        // instead of silently leaving the Docker Compose resources running.
+        _isComposeUp = false;
       }
       catch (Exception e)
       {

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -401,9 +401,25 @@ namespace DotNet.Testcontainers.Containers
       // removes. Set the flag before running the command.
       _isComposeUp = true;
 
-      _ = await ExecAsync(upCommand, ct)
-        .ThrowOnFailure()
+      var execResult = await ExecAsync(upCommand, ct)
         .ConfigureAwait(false);
+
+      if (0L.Equals(execResult.ExitCode))
+      {
+        return;
+      }
+
+      // Docker Compose fails the command if a service that another service depends on
+      // did not complete successfully. It reports the exit code of the service, but
+      // not its logs. Report the service that caused the failure instead of the
+      // Docker Compose command that failed.
+      var composeContainers = await GetComposeContainersAsync(ct)
+        .ConfigureAwait(false);
+
+      await ThrowIfServiceExitedUnsuccessfullyAsync(composeContainers.Values, ct)
+        .ConfigureAwait(false);
+
+      throw new ExecFailedException(execResult);
     }
 
     /// <summary>
@@ -512,11 +528,7 @@ namespace DotNet.Testcontainers.Containers
       {
         // An exposed service that exited unsuccessfully is the actual cause. Report its
         // exit code and logs instead of the ambassador container that cannot reach it.
-        var exitedContainers = unreachableServices
-          .Select(service => composeContainers[service])
-          .Where(container => nameof(TestcontainersStates.Exited).Equals(container.State, StringComparison.OrdinalIgnoreCase));
-
-        await Task.WhenAll(exitedContainers.Select(container => ThrowIfContainerExitedUnsuccessfullyAsync(container.ID, ct)))
+        await ThrowIfServiceExitedUnsuccessfullyAsync(unreachableServices.Select(service => composeContainers[service]), ct)
           .ConfigureAwait(false);
 
         var serviceNames = unreachableServices
@@ -606,6 +618,22 @@ namespace DotNet.Testcontainers.Containers
         containerConfiguration);
 
       return new ComposeServiceContainer(serviceConfiguration, container.ID, _ambassadorContainer, ambassadorPorts);
+    }
+
+    /// <summary>
+    /// Throws an exception when a Docker Compose service that already exited has an
+    /// unsuccessful exit code.
+    /// </summary>
+    /// <param name="composeContainers">The Docker Compose containers.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the exit codes have been checked.</returns>
+    /// <exception cref="ContainerNotRunningException">A Docker Compose service exited unexpectedly.</exception>
+    private Task ThrowIfServiceExitedUnsuccessfullyAsync(IEnumerable<ContainerListResponse> composeContainers, CancellationToken ct = default)
+    {
+      var exitedContainers = composeContainers
+        .Where(container => nameof(TestcontainersStates.Exited).Equals(container.State, StringComparison.OrdinalIgnoreCase));
+
+      return Task.WhenAll(exitedContainers.Select(container => ThrowIfContainerExitedUnsuccessfullyAsync(container.ID, ct)));
     }
 
     /// <summary>

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -232,25 +232,28 @@ namespace DotNet.Testcontainers.Containers
       _serviceContainers = composeContainers
         .ToDictionary(composeContainer => composeContainer.Key, composeContainer => CreateServiceContainer(composeContainer.Key, composeContainer.Value));
 
-      await Task.WhenAll(_serviceContainers.Values.Select(serviceContainer => serviceContainer.AttachAsync(ct)))
+      await ThrowIfAnyServiceFailedAsync(_serviceContainers
+          .Select(serviceContainer => GetOperationFailureAsync(serviceContainer.Key, serviceContainer.Value.AttachAsync(ct), ct)))
         .ConfigureAwait(false);
 
       // Group the service containers by whether they already exited or not.
       // Docker Compose does not fail if a service exits immediately.
-      var serviceContainersByExited = _serviceContainers.Values
-        .ToLookup(serviceContainer => TestcontainersStates.Exited.Equals(serviceContainer.State));
+      var serviceContainersByExited = _serviceContainers
+        .ToLookup(serviceContainer => TestcontainersStates.Exited.Equals(serviceContainer.Value.State));
 
       // Check the exit code of the services that already exited first. It fails faster
       // and reports the cause more accurately than the readiness checks of the
       // services that depend on them.
-      await Task.WhenAll(serviceContainersByExited[true].Select(serviceContainer => ThrowIfContainerExitedUnsuccessfullyAsync(serviceContainer.Id, ct)))
+      await ThrowIfAnyServiceFailedAsync(serviceContainersByExited[true]
+          .Select(serviceContainer => GetExitCodeFailureAsync(serviceContainer.Key, serviceContainer.Value.Id, ct)))
         .ConfigureAwait(false);
 
       // Docker Compose already started the services, the service containers run the
       // readiness checks only. A service that ran to completion, like a one-shot
       // migration service, does not become ready anymore. Every other state, such as
       // a service that is still restarting, does run its readiness check.
-      await Task.WhenAll(serviceContainersByExited[false].Select(serviceContainer => serviceContainer.StartAsync(ct)))
+      await ThrowIfAnyServiceFailedAsync(serviceContainersByExited[false]
+          .Select(serviceContainer => GetOperationFailureAsync(serviceContainer.Key, serviceContainer.Value.StartAsync(ct), ct)))
         .ConfigureAwait(false);
     }
 
@@ -416,7 +419,7 @@ namespace DotNet.Testcontainers.Containers
       var composeContainers = await GetComposeContainersAsync(ct)
         .ConfigureAwait(false);
 
-      await ThrowIfServiceExitedUnsuccessfullyAsync(composeContainers.Values, ct)
+      await ThrowIfServiceExitedUnsuccessfullyAsync(composeContainers, ct)
         .ConfigureAwait(false);
 
       throw new ExecFailedException(execResult);
@@ -528,7 +531,7 @@ namespace DotNet.Testcontainers.Containers
       {
         // An exposed service that exited unsuccessfully is the actual cause. Report its
         // exit code and logs instead of the ambassador container that cannot reach it.
-        await ThrowIfServiceExitedUnsuccessfullyAsync(unreachableServices.Select(service => composeContainers[service]), ct)
+        await ThrowIfServiceExitedUnsuccessfullyAsync(composeContainers.Where(composeContainer => unreachableServices.Contains(composeContainer.Key)), ct)
           .ConfigureAwait(false);
 
         var serviceNames = unreachableServices
@@ -621,43 +624,99 @@ namespace DotNet.Testcontainers.Containers
     }
 
     /// <summary>
-    /// Throws an exception when a Docker Compose service that already exited has an
-    /// unsuccessful exit code.
+    /// Throws an exception when one or more Docker Compose services failed.
     /// </summary>
-    /// <param name="composeContainers">The Docker Compose containers.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the exit codes have been checked.</returns>
-    /// <exception cref="ContainerNotRunningException">A Docker Compose service exited unexpectedly.</exception>
-    private Task ThrowIfServiceExitedUnsuccessfullyAsync(IEnumerable<ContainerListResponse> composeContainers, CancellationToken ct = default)
+    /// <remarks>
+    /// Gather the failure of every service before reporting it. Docker Compose runs
+    /// the services at the same time, and more than one of them can fail.
+    /// </remarks>
+    /// <param name="serviceFailures">The gathered failure of each Docker Compose service instance.</param>
+    /// <returns>Task that completes when the failures have been gathered.</returns>
+    /// <exception cref="ComposeServiceFailedException">One or more Docker Compose services failed.</exception>
+    private async Task ThrowIfAnyServiceFailedAsync(IEnumerable<Task<KeyValuePair<string, Exception>>> serviceFailures)
     {
-      var exitedContainers = composeContainers
-        .Where(container => nameof(TestcontainersStates.Exited).Equals(container.State, StringComparison.OrdinalIgnoreCase));
+      var services = await Task.WhenAll(serviceFailures)
+        .ConfigureAwait(false);
 
-      return Task.WhenAll(exitedContainers.Select(container => ThrowIfContainerExitedUnsuccessfullyAsync(container.ID, ct)));
+      var failures = services
+        .Where(service => service.Value != null)
+        .ToArray();
+
+      if (failures.Length > 0)
+      {
+        throw new ComposeServiceFailedException(ProjectName, failures);
+      }
     }
 
     /// <summary>
-    /// Throws an exception when the Docker Compose service exited with an
-    /// unsuccessful exit code.
+    /// Throws an exception when one or more Docker Compose services that already
+    /// exited have an unsuccessful exit code.
     /// </summary>
+    /// <param name="composeContainers">The Docker Compose containers indexed by their service instance.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the exit codes have been checked.</returns>
+    /// <exception cref="ComposeServiceFailedException">One or more Docker Compose services exited unsuccessfully.</exception>
+    private Task ThrowIfServiceExitedUnsuccessfullyAsync(IEnumerable<KeyValuePair<(string ServiceName, ushort Instance), ContainerListResponse>> composeContainers, CancellationToken ct = default)
+    {
+      var exitedContainers = composeContainers
+        .Where(composeContainer => nameof(TestcontainersStates.Exited).Equals(composeContainer.Value.State, StringComparison.OrdinalIgnoreCase));
+
+      return ThrowIfAnyServiceFailedAsync(exitedContainers
+        .Select(composeContainer => GetExitCodeFailureAsync(composeContainer.Key, composeContainer.Value.ID, ct)));
+    }
+
+    /// <summary>
+    /// Gets the failure of a Docker Compose service that exited unsuccessfully.
+    /// </summary>
+    /// <param name="service">The Docker Compose service instance.</param>
     /// <param name="id">The id of the Docker Compose container.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the exit code has been checked.</returns>
-    /// <exception cref="ContainerNotRunningException">The Docker Compose service exited unexpectedly.</exception>
-    private async Task ThrowIfContainerExitedUnsuccessfullyAsync(string id, CancellationToken ct = default)
+    /// <returns>Task that completes when the exit code has been checked, returning the failure of the service, or <c>null</c> if it succeeded.</returns>
+    private async Task<KeyValuePair<string, Exception>> GetExitCodeFailureAsync((string ServiceName, ushort Instance) service, string id, CancellationToken ct = default)
     {
+      var serviceName = ComposeServiceName.GetDisplayName(service.ServiceName, service.Instance);
+
       var exitCode = await _client.GetContainerExitCodeAsync(id, ct)
         .ConfigureAwait(false);
 
       if (exitCode == 0)
       {
-        return;
+        return new KeyValuePair<string, Exception>(serviceName, null);
       }
 
       var (stdout, stderr) = await _client.GetContainerLogsAsync(id, ct: ct)
         .ConfigureAwait(false);
 
-      throw new ContainerNotRunningException(id, stdout, stderr, exitCode, null);
+      return new KeyValuePair<string, Exception>(serviceName, new ContainerNotRunningException(id, stdout, stderr, exitCode, null));
+    }
+
+    /// <summary>
+    /// Gets the failure of an operation that a Docker Compose service ran.
+    /// </summary>
+    /// <remarks>
+    /// An operation that starts or attaches a container reports its failure by
+    /// throwing. Capture it, so that the failures of all services can be gathered
+    /// before one of them is reported.
+    /// </remarks>
+    /// <param name="service">The Docker Compose service instance.</param>
+    /// <param name="operation">The operation that the Docker Compose service ran.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the operation has run, returning its failure, or <c>null</c> if the operation succeeded.</returns>
+    private static async Task<KeyValuePair<string, Exception>> GetOperationFailureAsync((string ServiceName, ushort Instance) service, Task operation, CancellationToken ct = default)
+    {
+      var serviceName = ComposeServiceName.GetDisplayName(service.ServiceName, service.Instance);
+
+      try
+      {
+        await operation
+          .ConfigureAwait(false);
+
+        return new KeyValuePair<string, Exception>(serviceName, null);
+      }
+      catch (Exception e) when (!ct.IsCancellationRequested)
+      {
+        return new KeyValuePair<string, Exception>(serviceName, e);
+      }
     }
 
     /// <summary>

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -297,11 +297,13 @@ namespace DotNet.Testcontainers.Containers
       var resourceReaper = await ResourceReaper.GetAndStartDefaultAsync(_configuration.DockerEndpointAuthConfig, Logger, isWindowsEngineEnabled, ct)
         .ConfigureAwait(false);
 
-      if (resourceReaper != null)
+      if (resourceReaper == null)
       {
-        await resourceReaper.RegisterFilterAsync($"label={ComposeProjectLabel}={ProjectName}", ct)
-          .ConfigureAwait(false);
+        return;
       }
+
+      await resourceReaper.RegisterFilterAsync($"label={ComposeProjectLabel}={ProjectName}", ct)
+        .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -486,8 +488,8 @@ namespace DotNet.Testcontainers.Containers
       var containers = await _client.Container.GetAllAsync(filters, ct)
         .ConfigureAwait(false);
 
-      // Each container of a Docker Compose service is one instance, e.g. web-1 and
-      // web-2. Do not collapse them, the instances are addressed individually.
+      // Each container of a Docker Compose service is one instance, e.g. web-1 and web-2.
+      // Do not collapse them, the instances are addressed individually.
       return containers
         .Select(container => (Service: ComposeServiceName.GetInstance(container.Labels), Container: container))
         .Where(item => item.Service.HasValue)
@@ -599,8 +601,7 @@ namespace DotNet.Testcontainers.Containers
       // the service run. Materialize them, the container configuration outlives this
       // method and would create new wait strategies on every enumeration.
       var waitStrategies = servicePortWaitStrategies
-        .Concat(serviceReadinessWaitStrategies)
-        .ToArray();
+        .Concat(serviceReadinessWaitStrategies);
 
       // The cast selects the constructor overload that copies the resource
       // configuration (Docker endpoint, session id, logger) and intentionally drops

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -587,17 +587,6 @@ namespace DotNet.Testcontainers.Containers
         .Concat(serviceReadinessWaitStrategies)
         .ToArray();
 
-      // Docker Compose already published the service ports. Mirror them in the
-      // configuration, otherwise the readiness check that waits until the port
-      // bindings are mapped does not pass. A service that does not declare any port
-      // does not contain a port list at all. Docker reports one entry per published
-      // address, so the same port shows up for IPv4 and IPv6.
-      var portBindings = (container.Ports ?? Array.Empty<PortSummary>())
-        .Where(port => port.PublicPort > 0)
-        .Select(port => $"{port.PrivatePort}/{port.Type}")
-        .Distinct()
-        .ToDictionary(containerPort => containerPort, _ => string.Empty);
-
       // The cast selects the constructor overload that copies the resource
       // configuration (Docker endpoint, session id, logger) and intentionally drops
       // the Docker Compose container configuration. Inheriting it would create the
@@ -608,7 +597,6 @@ namespace DotNet.Testcontainers.Containers
 
       var containerConfiguration = new ContainerConfiguration(
         image: GetServiceImage(container),
-        portBindings: portBindings,
         outputConsumer: Consume.DoNotConsumeStdoutAndStderr(),
         waitStrategies: waitStrategies,
         startupCallback: (_, _, _) => Task.CompletedTask);

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -46,11 +46,11 @@ namespace DotNet.Testcontainers.Containers
 
     private const ushort FirstAmbassadorPort = 2000;
 
-    private static readonly string[] ComposeConfigCommand = new[] { "docker", "compose", "config", "--images" };
+    private static readonly string[] ComposeConfigCommand = { "docker", "compose", "config", "--images" };
 
-    private static readonly string[] ComposeUpCommand = new[] { "docker", "compose", "up", "--detach" };
+    private static readonly string[] ComposeUpCommand = { "docker", "compose", "up", "--detach" };
 
-    private static readonly string[] ComposeDownCommand = new[] { "docker", "compose", "down", "--volumes" };
+    private static readonly string[] ComposeDownCommand = { "docker", "compose", "down", "--volumes" };
 
     private static readonly IImage AmbassadorImage = new DockerImage("alpine/socat:1.8.0.3");
 

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -336,7 +336,7 @@ namespace DotNet.Testcontainers.Containers
       {
         // Do not fail the start. Resolving the images is best-effort, the Docker
         // Compose up command reports an invalid configuration itself.
-        Logger.DockerComposeResolveImagesFailed(ProjectName, e);
+        Logger.CanNotResolveComposeServiceImages(ProjectName, e);
         return;
       }
 
@@ -370,7 +370,7 @@ namespace DotNet.Testcontainers.Containers
       {
         // A service that Docker Compose builds does not have an image to pull yet. Do
         // not fail the start, Docker Compose reports a missing image itself.
-        Logger.DockerComposePullImageFailed(image, e);
+        Logger.CanNotPullComposeServiceImage(image, e);
       }
     }
 
@@ -434,7 +434,7 @@ namespace DotNet.Testcontainers.Containers
       }
       catch (Exception e)
       {
-        Logger.DockerComposeDownFailed(ProjectName, e);
+        Logger.CanNotCleanUpComposeProject(ProjectName, e);
       }
       finally
       {
@@ -451,7 +451,7 @@ namespace DotNet.Testcontainers.Containers
       {
         // Do not throw if the cleanup fails. The Resource Reaper removes the remaining
         // Docker resources that belong to the project.
-        Logger.DockerComposeDownFailed(ProjectName, e);
+        Logger.CanNotCleanUpComposeProject(ProjectName, e);
       }
     }
 

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -1,0 +1,724 @@
+namespace DotNet.Testcontainers.Containers
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Globalization;
+  using System.Linq;
+  using System.Threading;
+  using System.Threading.Tasks;
+  using Docker.DotNet.Models;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Clients;
+  using DotNet.Testcontainers.Configurations;
+  using DotNet.Testcontainers.Images;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// A container that runs the Docker Compose CLI and manages the lifecycle of
+  /// the Docker Compose services. It runs <c>docker compose up</c> on start and
+  /// <c>docker compose down</c> on stop or dispose.
+  /// </summary>
+  /// <remarks>
+  /// Exposed service ports
+  /// (<see cref="ComposeBuilder.WithExposedService(string, ushort)" />) are
+  /// proxied by an ambassador container that runs on the Docker Compose network.
+  /// Use <see cref="GetServiceHost" /> and <see cref="GetServicePort" /> to
+  /// access them from the test host.
+  /// </remarks>
+  [PublicAPI]
+  public sealed class ComposeContainer : DockerContainer
+  {
+    /// <summary>
+    /// The label that contains the Docker Compose project name.
+    /// </summary>
+    public const string ComposeProjectLabel = "com.docker.compose.project";
+
+    /// <summary>
+    /// The label that contains the Docker Compose service name.
+    /// </summary>
+    public const string ComposeServiceLabel = ComposeServiceName.ServiceLabel;
+
+    /// <summary>
+    /// The label that contains the number of the container within the Docker
+    /// Compose service.
+    /// </summary>
+    public const string ComposeContainerNumberLabel = ComposeServiceName.ContainerNumberLabel;
+
+    private const ushort FirstAmbassadorPort = 2000;
+
+    private static readonly string[] ComposeConfigCommand = new[] { "docker", "compose", "config", "--images" };
+
+    private static readonly string[] ComposeUpCommand = new[] { "docker", "compose", "up", "--detach" };
+
+    private static readonly string[] ComposeDownCommand = new[] { "docker", "compose", "down", "--volumes" };
+
+    private static readonly IImage AmbassadorImage = new DockerImage("alpine/socat:1.8.0.3");
+
+    private readonly ITestcontainersClient _client;
+
+    private readonly ComposeConfiguration _configuration;
+
+    private readonly IReadOnlyDictionary<(string ServiceName, ushort Instance, ushort Port), ushort> _ambassadorPorts;
+
+    private IReadOnlyDictionary<(string ServiceName, ushort Instance), ComposeServiceContainer> _serviceContainers = new Dictionary<(string, ushort), ComposeServiceContainer>();
+
+    private SocatContainer _ambassadorContainer;
+
+    private bool _isComposeUp;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeContainer" /> class.
+    /// </summary>
+    /// <param name="configuration">The container configuration.</param>
+    public ComposeContainer(ComposeConfiguration configuration)
+      : base(configuration)
+    {
+      _client = new TestcontainersClient(configuration.SessionId, configuration.DockerEndpointAuthConfig, configuration.Logger);
+      _configuration = configuration;
+
+      // Each exposed service port gets its own ambassador container port, starting at
+      // FirstAmbassadorPort. A service port that is exposed more than once keeps the
+      // ambassador container port that it got assigned first.
+      var ambassadorPorts = new Dictionary<(string ServiceName, ushort Instance, ushort Port), ushort>();
+
+      foreach (var exposedService in configuration.ExposedServices)
+      {
+        var service = (exposedService.ServiceName, exposedService.Instance, exposedService.Port);
+
+        if (!ambassadorPorts.ContainsKey(service))
+        {
+          ambassadorPorts.Add(service, (ushort)(FirstAmbassadorPort + ambassadorPorts.Count));
+        }
+      }
+
+      _ambassadorPorts = ambassadorPorts;
+    }
+
+    /// <summary>
+    /// Gets the Docker Compose project name.
+    /// </summary>
+    public string ProjectName
+    {
+      get
+      {
+        return _configuration.ProjectName;
+      }
+    }
+
+    /// <summary>
+    /// Gets the host that exposes the Docker Compose service port.
+    /// </summary>
+    /// <remarks>
+    /// The service name addresses the first instance of the service. Use
+    /// <see cref="GetServiceInstanceHost" /> to address one container of a service
+    /// that runs more than one.
+    /// </remarks>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="servicePort">The Docker Compose service port.</param>
+    /// <returns>The host that exposes the Docker Compose service port.</returns>
+    public string GetServiceHost(string serviceName, ushort servicePort)
+    {
+      return GetServiceInstanceHost(serviceName, ComposeServiceName.FirstInstance, servicePort);
+    }
+
+    /// <summary>
+    /// Gets the host that exposes the port of a Docker Compose service instance.
+    /// </summary>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="instance">The number of the container within the Docker Compose service.</param>
+    /// <param name="servicePort">The Docker Compose service port.</param>
+    /// <returns>The host that exposes the Docker Compose service port.</returns>
+    public string GetServiceInstanceHost(string serviceName, ushort instance, ushort servicePort)
+    {
+      ThrowIfServiceNotExposed(serviceName, instance, servicePort);
+      return _ambassadorContainer.Hostname;
+    }
+
+    /// <summary>
+    /// Gets the public host port that is mapped to the Docker Compose service port.
+    /// </summary>
+    /// <remarks>
+    /// The service name addresses the first instance of the service. Use
+    /// <see cref="GetServiceInstancePort" /> to address one container of a service
+    /// that runs more than one.
+    /// </remarks>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="servicePort">The Docker Compose service port.</param>
+    /// <returns>The public host port that is mapped to the Docker Compose service port.</returns>
+    public ushort GetServicePort(string serviceName, ushort servicePort)
+    {
+      return GetServiceInstancePort(serviceName, ComposeServiceName.FirstInstance, servicePort);
+    }
+
+    /// <summary>
+    /// Gets the public host port that is mapped to the port of a Docker Compose
+    /// service instance.
+    /// </summary>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="instance">The number of the container within the Docker Compose service.</param>
+    /// <param name="servicePort">The Docker Compose service port.</param>
+    /// <returns>The public host port that is mapped to the Docker Compose service port.</returns>
+    public ushort GetServiceInstancePort(string serviceName, ushort instance, ushort servicePort)
+    {
+      ThrowIfServiceNotExposed(serviceName, instance, servicePort);
+      return _ambassadorContainer.GetMappedPublicPort(_ambassadorPorts[(serviceName, instance, servicePort)]);
+    }
+
+    /// <summary>
+    /// Gets the container that belongs to the Docker Compose service.
+    /// </summary>
+    /// <remarks>
+    /// Docker Compose manages the lifecycle of the container. Stopping or disposing
+    /// the returned container does not affect it. Stop or dispose the
+    /// <see cref="ComposeContainer" /> instead.
+    ///
+    /// The service name addresses the first instance of the service. Use
+    /// <see cref="GetServiceInstanceContainer" /> to address one container of a
+    /// service that runs more than one.
+    /// </remarks>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <returns>The container that belongs to the Docker Compose service.</returns>
+    /// <exception cref="ComposeServiceNotFoundException">The Docker Compose service was not found.</exception>
+    public IContainer GetServiceContainer(string serviceName)
+    {
+      return GetServiceInstanceContainer(serviceName, ComposeServiceName.FirstInstance);
+    }
+
+    /// <summary>
+    /// Gets the container that belongs to a Docker Compose service instance.
+    /// </summary>
+    /// <remarks>
+    /// Docker Compose manages the lifecycle of the container. Stopping or disposing
+    /// the returned container does not affect it. Stop or dispose the
+    /// <see cref="ComposeContainer" /> instead.
+    /// </remarks>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="instance">The number of the container within the Docker Compose service.</param>
+    /// <returns>The container that belongs to the Docker Compose service instance.</returns>
+    /// <exception cref="ComposeServiceNotFoundException">The Docker Compose service was not found.</exception>
+    public IContainer GetServiceInstanceContainer(string serviceName, ushort instance)
+    {
+      if (_serviceContainers.TryGetValue((serviceName, instance), out var serviceContainer))
+      {
+        return serviceContainer;
+      }
+
+      throw new ComposeServiceNotFoundException(ComposeServiceName.GetDisplayName(serviceName, instance), ProjectName);
+    }
+
+    /// <inheritdoc />
+    protected override async Task UnsafeStartAsync(CancellationToken ct = default)
+    {
+      await base.UnsafeStartAsync(ct)
+        .ConfigureAwait(false);
+
+      await RegisterProjectFilterAsync(ct)
+        .ConfigureAwait(false);
+
+      await PullImagesAsync(ct)
+        .ConfigureAwait(false);
+
+      await ComposeUpAsync(ct)
+        .ConfigureAwait(false);
+
+      var composeContainers = await GetComposeContainersAsync(ct)
+        .ConfigureAwait(false);
+
+      ThrowIfServiceNotFound(composeContainers);
+
+      await StartAmbassadorContainerAsync(composeContainers, ct)
+        .ConfigureAwait(false);
+
+      _serviceContainers = composeContainers
+        .ToDictionary(composeContainer => composeContainer.Key, composeContainer => CreateServiceContainer(composeContainer.Key, composeContainer.Value));
+
+      await Task.WhenAll(_serviceContainers.Values.Select(serviceContainer => serviceContainer.AttachAsync(ct)))
+        .ConfigureAwait(false);
+
+      // Group the service containers by whether they already exited or not.
+      // Docker Compose does not fail if a service exits immediately.
+      var serviceContainersByExited = _serviceContainers.Values
+        .ToLookup(serviceContainer => TestcontainersStates.Exited.Equals(serviceContainer.State));
+
+      // Check the exit code of the services that already exited first. It fails faster
+      // and reports the cause more accurately than the readiness checks of the
+      // services that depend on them.
+      await Task.WhenAll(serviceContainersByExited[true].Select(serviceContainer => ThrowIfContainerExitedUnsuccessfullyAsync(serviceContainer.Id, ct)))
+        .ConfigureAwait(false);
+
+      // Docker Compose already started the services, the service containers run the
+      // readiness checks only. A service that ran to completion, like a one-shot
+      // migration service, does not become ready anymore. Every other state, such as
+      // a service that is still restarting, does run its readiness check.
+      await Task.WhenAll(serviceContainersByExited[false].Select(serviceContainer => serviceContainer.StartAsync(ct)))
+        .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    protected override async Task UnsafeStopAsync(CancellationToken ct = default)
+    {
+      await ComposeDownAsync(ct)
+        .ConfigureAwait(false);
+
+      await base.UnsafeStopAsync(ct)
+        .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    protected override async Task UnsafeDeleteAsync(CancellationToken ct = default)
+    {
+      await ComposeDownAsync(ct)
+        .ConfigureAwait(false);
+
+      await base.UnsafeDeleteAsync(ct)
+        .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Registers the Docker Compose project label with the Resource Reaper. The
+    /// Resource Reaper removes the Docker resources that belong to the project when
+    /// the test process does not clean them up (e.g. when it crashes).
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the filter has been registered.</returns>
+    private async Task RegisterProjectFilterAsync(CancellationToken ct = default)
+    {
+      if (!TestcontainersSettings.ResourceReaperEnabled || !ResourceReaper.DefaultSessionId.Equals(_configuration.SessionId))
+      {
+        return;
+      }
+
+      var isWindowsEngineEnabled = await _client.System.GetIsWindowsEngineEnabled(ct)
+        .ConfigureAwait(false);
+
+      var resourceReaper = await ResourceReaper.GetAndStartDefaultAsync(_configuration.DockerEndpointAuthConfig, Logger, isWindowsEngineEnabled, ct)
+        .ConfigureAwait(false);
+
+      if (resourceReaper != null)
+      {
+        await resourceReaper.RegisterFilterAsync($"label={ComposeProjectLabel}={ProjectName}", ct)
+          .ConfigureAwait(false);
+      }
+    }
+
+    /// <summary>
+    /// Pulls the images of the Docker Compose services.
+    /// </summary>
+    /// <remarks>
+    /// Docker Compose runs inside a container and does not have access to the
+    /// Docker configuration of the test host. Pull the images from the test host
+    /// instead, so that its Docker credentials and credential helpers apply. Docker
+    /// Compose pulls the images that are still missing itself.
+    /// </remarks>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the images have been pulled.</returns>
+    private async Task PullImagesAsync(CancellationToken ct = default)
+    {
+      if (false.Equals(_configuration.Pull))
+      {
+        return;
+      }
+
+      IEnumerable<string> images;
+
+      try
+      {
+        var execResult = await ExecAsync(ComposeConfigCommand, ct)
+          .ThrowOnFailure()
+          .ConfigureAwait(false);
+
+        images = execResult.Stdout.Split('\n')
+          .Select(image => image.Trim())
+          .Where(image => image.Length > 0)
+          .Distinct();
+      }
+      catch (Exception e)
+      {
+        // Do not fail the start. Resolving the images is best-effort, the Docker
+        // Compose up command reports an invalid configuration itself.
+        Logger.DockerComposeResolveImagesFailed(ProjectName, e);
+        return;
+      }
+
+      await Task.WhenAll(images.Select(image => PullImageAsync(image, ct)))
+        .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Pulls the image of a Docker Compose service if it is not present on the
+    /// Docker host.
+    /// </summary>
+    /// <param name="image">The image of the Docker Compose service.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the image has been pulled.</returns>
+    private async Task PullImageAsync(string image, CancellationToken ct = default)
+    {
+      try
+      {
+        var imageExists = await _client.Image.ExistsWithIdAsync(image, ct)
+          .ConfigureAwait(false);
+
+        if (imageExists)
+        {
+          return;
+        }
+
+        await _client.PullImageAsync(new DockerImage(image), ct)
+          .ConfigureAwait(false);
+      }
+      catch (Exception e)
+      {
+        // A service that Docker Compose builds does not have an image to pull yet. Do
+        // not fail the start, Docker Compose reports a missing image itself.
+        Logger.DockerComposePullImageFailed(image, e);
+      }
+    }
+
+    /// <summary>
+    /// Creates and starts the Docker Compose services (<c>docker compose up</c>).
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the Docker Compose services have been started.</returns>
+    private async Task ComposeUpAsync(CancellationToken ct = default)
+    {
+      var upCommand = new List<string>(ComposeUpCommand);
+
+      foreach (var scaledService in _configuration.ScaledServices)
+      {
+        upCommand.Add("--scale");
+        upCommand.Add($"{scaledService.Key}={scaledService.Value.ToString(CultureInfo.InvariantCulture)}");
+      }
+
+      // Docker Compose starts every service if no service is set. Only when the
+      // services are restricted do the scaled services have to be named as well,
+      // otherwise Docker Compose does not start them.
+      if (_configuration.Services.Any())
+      {
+        upCommand.AddRange(_configuration.Services.Concat(_configuration.ScaledServices.Keys).Distinct());
+      }
+
+      // A failed `up` can leave partially created Docker resources behind that `down`
+      // removes. Set the flag before running the command.
+      _isComposeUp = true;
+
+      _ = await ExecAsync(upCommand, ct)
+        .ThrowOnFailure()
+        .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Stops and removes the Docker Compose services (<c>docker compose down</c>).
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the Docker Compose services have been removed.</returns>
+    private async Task ComposeDownAsync(CancellationToken ct = default)
+    {
+      if (!_isComposeUp)
+      {
+        return;
+      }
+
+      _isComposeUp = false;
+
+      _serviceContainers = new Dictionary<(string, ushort), ComposeServiceContainer>();
+
+      try
+      {
+        // Remove the ambassador container before the Docker Compose networks. Docker
+        // does not remove networks that still have containers connected.
+        if (_ambassadorContainer != null)
+        {
+          await _ambassadorContainer.DisposeAsync()
+            .ConfigureAwait(false);
+        }
+      }
+      catch (Exception e)
+      {
+        Logger.DockerComposeDownFailed(ProjectName, e);
+      }
+      finally
+      {
+        _ambassadorContainer = null;
+      }
+
+      try
+      {
+        _ = await ExecAsync(ComposeDownCommand, ct)
+          .ThrowOnFailure()
+          .ConfigureAwait(false);
+      }
+      catch (Exception e)
+      {
+        // Do not throw if the cleanup fails. The Resource Reaper removes the remaining
+        // Docker resources that belong to the project.
+        Logger.DockerComposeDownFailed(ProjectName, e);
+      }
+    }
+
+    /// <summary>
+    /// Gets the containers that belong to the Docker Compose project.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the containers have been listed, returning the containers indexed by their service instance.</returns>
+    private async Task<IReadOnlyDictionary<(string ServiceName, ushort Instance), ContainerListResponse>> GetComposeContainersAsync(CancellationToken ct = default)
+    {
+      var filters = new FilterByProperty().Add("label", $"{ComposeProjectLabel}={ProjectName}");
+
+      var containers = await _client.Container.GetAllAsync(filters, ct)
+        .ConfigureAwait(false);
+
+      // Each container of a Docker Compose service is one instance, e.g. web-1 and
+      // web-2. Do not collapse them, the instances are addressed individually.
+      return containers
+        .Select(container => (Service: ComposeServiceName.GetInstance(container.Labels), Container: container))
+        .Where(item => item.Service.HasValue)
+        .ToDictionary(item => item.Service.Value, item => item.Container);
+    }
+
+    /// <summary>
+    /// Starts the ambassador container that proxies the exposed Docker Compose
+    /// service ports.
+    /// </summary>
+    /// <param name="composeContainers">The Docker Compose containers indexed by their service instance.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the ambassador container has been started.</returns>
+    private async Task StartAmbassadorContainerAsync(IReadOnlyDictionary<(string ServiceName, ushort Instance), ContainerListResponse> composeContainers, CancellationToken ct = default)
+    {
+      if (_ambassadorPorts.Count == 0)
+      {
+        return;
+      }
+
+      // Target the IP address of the container instead of the service name. The
+      // service name resolves to any container of the service, which does not address
+      // a single instance, and the container name is not guaranteed to be a
+      // resolvable DNS name. It exceeds the 63 character label limit for a long
+      // Docker Compose project name.
+      var serviceIpAddresses = _ambassadorPorts.Keys
+        .Select(ambassadorPort => (ambassadorPort.ServiceName, ambassadorPort.Instance))
+        .Distinct()
+        .ToDictionary(service => service, service => GetContainerIpAddress(composeContainers[service]));
+
+      // A service that ran to completion does not have an IP address anymore. Neither
+      // does a service that shares another container's network namespace, e.g.
+      // `network_mode: service:app`, it is not attached to a network itself. The
+      // ambassador container cannot reach such a service.
+      var unreachableServices = serviceIpAddresses
+        .Where(serviceIpAddress => serviceIpAddress.Value == null)
+        .Select(serviceIpAddress => serviceIpAddress.Key)
+        .ToArray();
+
+      if (unreachableServices.Length > 0)
+      {
+        // An exposed service that exited unsuccessfully is the actual cause. Report its
+        // exit code and logs instead of the ambassador container that cannot reach it.
+        var exitedContainers = unreachableServices
+          .Select(service => composeContainers[service])
+          .Where(container => nameof(TestcontainersStates.Exited).Equals(container.State, StringComparison.OrdinalIgnoreCase));
+
+        await Task.WhenAll(exitedContainers.Select(container => ThrowIfContainerExitedUnsuccessfullyAsync(container.ID, ct)))
+          .ConfigureAwait(false);
+
+        var serviceNames = unreachableServices
+          .Select(service => ComposeServiceName.GetDisplayName(service.ServiceName, service.Instance));
+
+        throw new InvalidOperationException($"The exposed Docker Compose service(s) '{string.Join("', '", serviceNames)}' do not have an IP address. Exposing a service port requires the service to run and to be attached to a Docker network that the ambassador container can join.");
+      }
+
+      // The ambassador container shares the Resource Reaper session of the Docker
+      // Compose container. The session is not necessarily the default one, disabling
+      // the cleanup sets an empty session id that the Resource Reaper ignores.
+      var socatBuilder = new SocatBuilder(AmbassadorImage)
+        .WithDockerEndpoint(_configuration.DockerEndpointAuthConfig)
+        .WithLabel(ResourceReaper.ResourceReaperSessionLabel, _configuration.SessionId.ToString("D"))
+        .WithLogger(Logger);
+
+      _ambassadorContainer = _ambassadorPorts
+        .Aggregate(socatBuilder, (builder, ambassadorPort) => builder.WithTarget(ambassadorPort.Value, serviceIpAddresses[(ambassadorPort.Key.ServiceName, ambassadorPort.Key.Instance)], ambassadorPort.Key.Port))
+        .Build();
+
+      await _ambassadorContainer.StartAsync(ct)
+        .ConfigureAwait(false);
+
+      // Docker Compose usually attaches each service to at least one network. The
+      // ambassador container connects to them after it started. Socat resolves the
+      // target when it accepts a connection, not when it starts, and the readiness
+      // check of the exposed service ports runs after this.
+      var networks = serviceIpAddresses.Keys
+        .SelectMany(service => composeContainers[service].NetworkSettings.Networks.Keys)
+        .Distinct();
+
+      foreach (var network in networks)
+      {
+        await _ambassadorContainer.ConnectAsync(network, ct)
+          .ConfigureAwait(false);
+      }
+    }
+
+    /// <summary>
+    /// Creates a container that attaches to an existing Docker Compose service
+    /// container.
+    /// </summary>
+    /// <param name="service">The Docker Compose service instance.</param>
+    /// <param name="container">The Docker Compose container.</param>
+    /// <returns>The container that attaches to the Docker Compose service container.</returns>
+    private ComposeServiceContainer CreateServiceContainer((string ServiceName, ushort Instance) service, ContainerListResponse container)
+    {
+      var ipAddress = GetContainerIpAddress(container);
+
+      var ambassadorPorts = _ambassadorPorts
+        .Where(ambassadorPort => ambassadorPort.Key.ServiceName == service.ServiceName && ambassadorPort.Key.Instance == service.Instance)
+        .ToDictionary(ambassadorPort => ambassadorPort.Key.Port, ambassadorPort => ambassadorPort.Value);
+
+      // Wait until the exposed service ports accept connections. The check runs
+      // inside the ambassador container, which keeps it independent of the service
+      // image.
+      var servicePortWaitStrategies = ambassadorPorts.Keys
+        .Select(servicePort => new WaitStrategy(new UntilComposeServicePortIsAvailable(_ambassadorContainer, ipAddress, servicePort)));
+
+      var serviceReadinessWaitStrategies = _configuration.ServiceReadiness
+        .Where(serviceReadiness => serviceReadiness.ServiceName == service.ServiceName && serviceReadiness.Instance == service.Instance)
+        .SelectMany(serviceReadiness => serviceReadiness.WaitStrategies);
+
+      // The exposed service ports accept connections before the wait strategies of
+      // the service run. Materialize them, the container configuration outlives this
+      // method and would create new wait strategies on every enumeration.
+      var waitStrategies = servicePortWaitStrategies
+        .Concat(serviceReadinessWaitStrategies)
+        .ToArray();
+
+      // Docker Compose already published the service ports. Mirror them in the
+      // configuration, otherwise the readiness check that waits until the port
+      // bindings are mapped does not pass. A service that does not declare any port
+      // does not contain a port list at all. Docker reports one entry per published
+      // address, so the same port shows up for IPv4 and IPv6.
+      var portBindings = (container.Ports ?? Array.Empty<PortSummary>())
+        .Where(port => port.PublicPort > 0)
+        .Select(port => $"{port.PrivatePort}/{port.Type}")
+        .Distinct()
+        .ToDictionary(containerPort => containerPort, _ => string.Empty);
+
+      // The cast selects the constructor overload that copies the resource
+      // configuration (Docker endpoint, session id, logger) and intentionally drops
+      // the Docker Compose container configuration. Inheriting it would create the
+      // Docker Compose container's networks and restart its dependent containers once
+      // per service.
+      var resourceConfiguration = new ContainerConfiguration(
+        (IResourceConfiguration<CreateContainerParameters>)_configuration);
+
+      var containerConfiguration = new ContainerConfiguration(
+        image: GetServiceImage(container),
+        portBindings: portBindings,
+        outputConsumer: Consume.DoNotConsumeStdoutAndStderr(),
+        waitStrategies: waitStrategies,
+        startupCallback: (_, _, _) => Task.CompletedTask);
+
+      var serviceConfiguration = new ContainerConfiguration(
+        resourceConfiguration,
+        containerConfiguration);
+
+      return new ComposeServiceContainer(serviceConfiguration, container.ID, _ambassadorContainer, ambassadorPorts);
+    }
+
+    /// <summary>
+    /// Throws an exception when the Docker Compose service exited with an
+    /// unsuccessful exit code.
+    /// </summary>
+    /// <param name="id">The id of the Docker Compose container.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the exit code has been checked.</returns>
+    /// <exception cref="ContainerNotRunningException">The Docker Compose service exited unexpectedly.</exception>
+    private async Task ThrowIfContainerExitedUnsuccessfullyAsync(string id, CancellationToken ct = default)
+    {
+      var exitCode = await _client.GetContainerExitCodeAsync(id, ct)
+        .ConfigureAwait(false);
+
+      if (exitCode == 0)
+      {
+        return;
+      }
+
+      var (stdout, stderr) = await _client.GetContainerLogsAsync(id, ct: ct)
+        .ConfigureAwait(false);
+
+      throw new ContainerNotRunningException(id, stdout, stderr, exitCode, null);
+    }
+
+    /// <summary>
+    /// Throws an exception when a Docker Compose service that the configuration
+    /// references does not belong to the Docker Compose project.
+    /// </summary>
+    /// <param name="composeContainers">The Docker Compose containers indexed by their service instance.</param>
+    /// <exception cref="ComposeServiceNotFoundException">The Docker Compose service was not found.</exception>
+    private void ThrowIfServiceNotFound(IReadOnlyDictionary<(string ServiceName, ushort Instance), ContainerListResponse> composeContainers)
+    {
+      // A wait strategy or exposed port that references a service that does not exist
+      // would otherwise pass silently, e.g. when the service name contains a typo.
+      var serviceNotFound = _configuration.ExposedServices
+        .Select(exposedService => (exposedService.ServiceName, exposedService.Instance))
+        .Concat(_configuration.ServiceReadiness.Select(serviceReadiness => (serviceReadiness.ServiceName, serviceReadiness.Instance)))
+        .Where(service => !composeContainers.ContainsKey(service))
+        .Select(service => ComposeServiceName.GetDisplayName(service.ServiceName, service.Instance))
+        .FirstOrDefault();
+
+      if (serviceNotFound != null)
+      {
+        throw new ComposeServiceNotFoundException(serviceNotFound, ProjectName);
+      }
+    }
+
+    /// <summary>
+    /// Throws an exception when the Docker Compose service port is not exposed or
+    /// when the ambassador container is not running.
+    /// </summary>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="instance">The number of the container within the Docker Compose service.</param>
+    /// <param name="servicePort">The Docker Compose service port.</param>
+    /// <exception cref="ComposeServiceNotExposedException">The Docker Compose service port is not exposed.</exception>
+    /// <exception cref="ComposeServiceNotFoundException">The Docker Compose services have not been started.</exception>
+    private void ThrowIfServiceNotExposed(string serviceName, ushort instance, ushort servicePort)
+    {
+      if (!_ambassadorPorts.ContainsKey((serviceName, instance, servicePort)))
+      {
+        throw new ComposeServiceNotExposedException(ComposeServiceName.GetDisplayName(serviceName, instance), servicePort);
+      }
+
+      if (_ambassadorContainer == null)
+      {
+        throw new ComposeServiceNotFoundException(ComposeServiceName.GetDisplayName(serviceName, instance), ProjectName);
+      }
+    }
+
+    /// <summary>
+    /// Gets the IP address of a Docker Compose container.
+    /// </summary>
+    /// <param name="container">The Docker Compose container.</param>
+    /// <returns>The IP address of the Docker Compose container on the first network it is attached to, or <c>null</c> if it does not have one.</returns>
+    private static string GetContainerIpAddress(ContainerListResponse container)
+    {
+      return container.NetworkSettings.Networks.Values
+        .Select(network => network.IPAddress)
+        .FirstOrDefault(ipAddress => !string.IsNullOrEmpty(ipAddress));
+    }
+
+    /// <summary>
+    /// Gets the image of the Docker Compose service container.
+    /// </summary>
+    /// <param name="container">The Docker Compose container.</param>
+    /// <returns>The image of the Docker Compose service container, or <c>null</c> if the image reference cannot be parsed.</returns>
+    private static IImage GetServiceImage(ContainerListResponse container)
+    {
+      try
+      {
+        return new DockerImage(container.Image);
+      }
+      catch (ArgumentException)
+      {
+        // The image reference comes from the Docker daemon and is not necessarily a
+        // valid repository/tag reference, e.g. when the service runs an untagged image.
+        // The image is informational only, do not fail the start.
+        return null;
+      }
+    }
+  }
+}

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -691,35 +691,6 @@ namespace DotNet.Testcontainers.Containers
     }
 
     /// <summary>
-    /// Gets the failure of an operation that a Docker Compose service ran.
-    /// </summary>
-    /// <remarks>
-    /// An operation that starts or attaches a container reports its failure by
-    /// throwing. Capture it, so that the failures of all services can be gathered
-    /// before one of them is reported.
-    /// </remarks>
-    /// <param name="service">The Docker Compose service instance.</param>
-    /// <param name="operation">The operation that the Docker Compose service ran.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the operation has run, returning its failure, or <c>null</c> if the operation succeeded.</returns>
-    private static async Task<KeyValuePair<string, Exception>> GetOperationFailureAsync((string ServiceName, ushort Instance) service, Task operation, CancellationToken ct = default)
-    {
-      var serviceName = ComposeServiceName.GetDisplayName(service.ServiceName, service.Instance);
-
-      try
-      {
-        await operation
-          .ConfigureAwait(false);
-
-        return new KeyValuePair<string, Exception>(serviceName, null);
-      }
-      catch (Exception e) when (!ct.IsCancellationRequested)
-      {
-        return new KeyValuePair<string, Exception>(serviceName, e);
-      }
-    }
-
-    /// <summary>
     /// Throws an exception when a Docker Compose service that the configuration
     /// references does not belong to the Docker Compose project.
     /// </summary>
@@ -761,6 +732,35 @@ namespace DotNet.Testcontainers.Containers
       if (_ambassadorContainer == null)
       {
         throw new ComposeServiceNotFoundException(ComposeServiceName.GetDisplayName(serviceName, instance), ProjectName);
+      }
+    }
+
+    /// <summary>
+    /// Gets the failure of an operation that a Docker Compose service ran.
+    /// </summary>
+    /// <remarks>
+    /// An operation that starts or attaches a container reports its failure by
+    /// throwing. Capture it, so that the failures of all services can be gathered
+    /// before one of them is reported.
+    /// </remarks>
+    /// <param name="service">The Docker Compose service instance.</param>
+    /// <param name="operation">The operation that the Docker Compose service ran.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the operation has run, returning its failure, or <c>null</c> if the operation succeeded.</returns>
+    private static async Task<KeyValuePair<string, Exception>> GetOperationFailureAsync((string ServiceName, ushort Instance) service, Task operation, CancellationToken ct = default)
+    {
+      var serviceName = ComposeServiceName.GetDisplayName(service.ServiceName, service.Instance);
+
+      try
+      {
+        await operation
+          .ConfigureAwait(false);
+
+        return new KeyValuePair<string, Exception>(serviceName, null);
+      }
+      catch (Exception e) when (!ct.IsCancellationRequested)
+      {
+        return new KeyValuePair<string, Exception>(serviceName, e);
       }
     }
 

--- a/src/Testcontainers/Containers/ComposeServiceContainer.cs
+++ b/src/Testcontainers/Containers/ComposeServiceContainer.cs
@@ -1,0 +1,149 @@
+namespace DotNet.Testcontainers.Containers
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Globalization;
+  using System.Linq;
+  using System.Threading;
+  using System.Threading.Tasks;
+  using DotNet.Testcontainers.Configurations;
+
+  /// <summary>
+  /// A container that attaches to an existing container that Docker Compose
+  /// created, instead of creating a new one.
+  /// </summary>
+  /// <remarks>
+  /// If the service port is exposed through the ambassador container, the port
+  /// members resolve to the ambassador container's mapped port instead of the
+  /// service container's (usually unbound) port. This allows wait strategies to
+  /// run against Docker Compose services like against any other container.
+  ///
+  /// Docker Compose owns the lifecycle of the container. The members that create,
+  /// start, stop or remove a container do not affect it. Only
+  /// <see cref="ComposeContainer" /> starts and removes the Docker Compose
+  /// services.
+  /// </remarks>
+  internal sealed class ComposeServiceContainer : DockerContainer
+  {
+    /// <summary>
+    /// The protocol that the ambassador container proxies.
+    /// </summary>
+    private const string TcpProtocol = "tcp";
+
+    private readonly string _containerId;
+
+    private readonly SocatContainer _ambassadorContainer;
+
+    private readonly IReadOnlyDictionary<ushort, ushort> _ambassadorPorts;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeServiceContainer" /> class.
+    /// </summary>
+    /// <param name="configuration">The container configuration.</param>
+    /// <param name="containerId">The id of the existing container that Docker Compose created.</param>
+    /// <param name="ambassadorContainer">The ambassador container that proxies the exposed service ports, or <c>null</c> if no service port is exposed.</param>
+    /// <param name="ambassadorPorts">A dictionary that maps the exposed service ports to the ambassador container ports.</param>
+    public ComposeServiceContainer(IContainerConfiguration configuration, string containerId, SocatContainer ambassadorContainer, IReadOnlyDictionary<ushort, ushort> ambassadorPorts)
+      : base(configuration)
+    {
+      _containerId = containerId;
+      _ambassadorContainer = ambassadorContainer;
+      _ambassadorPorts = ambassadorPorts;
+    }
+
+    /// <inheritdoc />
+    public override ushort GetMappedPublicPort(string containerPort)
+    {
+      // The container port may include the protocol (e.g. 80/tcp). The ambassador
+      // container proxies TCP only; leave every other protocol to the base
+      // implementation, which resolves the port that Docker Compose published.
+      var port = containerPort == null ? Array.Empty<string>() : containerPort.Split('/');
+
+      var isTcpPort = port.Length == 1 || (port.Length == 2 && TcpProtocol.Equals(port[1], StringComparison.OrdinalIgnoreCase));
+
+      if (_ambassadorContainer != null && isTcpPort && ushort.TryParse(port[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var servicePort) && _ambassadorPorts.TryGetValue(servicePort, out var ambassadorPort))
+      {
+        return _ambassadorContainer.GetMappedPublicPort(ambassadorPort);
+      }
+
+      return base.GetMappedPublicPort(containerPort);
+    }
+
+    /// <inheritdoc />
+    public override IReadOnlyDictionary<ushort, ushort> GetMappedPublicPorts()
+    {
+      var mappedPublicPorts = base.GetMappedPublicPorts().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+      if (_ambassadorContainer == null)
+      {
+        return mappedPublicPorts;
+      }
+
+      // The exposed service ports take precedence over the ports that Docker Compose
+      // published. They are reachable from the test host either way, but only the
+      // ambassador container port is covered by the service's readiness check.
+      foreach (var ambassadorPort in _ambassadorPorts)
+      {
+        mappedPublicPorts[ambassadorPort.Key] = _ambassadorContainer.GetMappedPublicPort(ambassadorPort.Value);
+      }
+
+      return mappedPublicPorts;
+    }
+
+    /// <summary>
+    /// Attaches to the container that Docker Compose created.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been attached.</returns>
+    public async Task AttachAsync(CancellationToken ct = default)
+    {
+      using var disposable = await AcquireLockAsync(ct)
+        .ConfigureAwait(false);
+
+      await UnsafeCreateAsync(ct)
+        .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Docker Compose already created the container. Attach to it instead of
+    /// creating a new one.
+    /// </remarks>
+    protected override Task<string> UnsafeCreateContainerAsync(CancellationToken ct = default)
+    {
+      return Task.FromResult(_containerId);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Docker Compose already started the container. Starting it again would run a
+    /// service that ran to completion, such as a one-shot migration service, a
+    /// second time. Run the readiness checks only.
+    /// </remarks>
+    protected override Task UnsafeStartContainerAsync(CancellationToken ct = default)
+    {
+      return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Docker Compose owns the lifecycle of the container. Stopping it behind
+    /// Docker Compose's back would break the services that depend on it.
+    /// </remarks>
+    protected override Task UnsafeStopAsync(CancellationToken ct = default)
+    {
+      return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Docker Compose owns the lifecycle of the container. Removing it behind
+    /// Docker Compose's back would break the services that depend on it, and leave
+    /// <c>docker compose down</c> with a container that does not exist anymore.
+    /// </remarks>
+    protected override Task UnsafeDeleteAsync(CancellationToken ct = default)
+    {
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/src/Testcontainers/Containers/ComposeServiceContainer.cs
+++ b/src/Testcontainers/Containers/ComposeServiceContainer.cs
@@ -72,7 +72,7 @@ namespace DotNet.Testcontainers.Containers
     /// <inheritdoc />
     public override IReadOnlyDictionary<ushort, ushort> GetMappedPublicPorts()
     {
-      var mappedPublicPorts = base.GetMappedPublicPorts().ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+      var mappedPublicPorts = base.GetMappedPublicPorts().ToDictionary(item => item.Key, item => item.Value);
 
       if (_ambassadorContainer == null)
       {

--- a/src/Testcontainers/Containers/ComposeServiceFailedException.cs
+++ b/src/Testcontainers/Containers/ComposeServiceFailedException.cs
@@ -1,0 +1,54 @@
+namespace DotNet.Testcontainers.Containers
+{
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+  using System.Text;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Represents an exception that is thrown when one or more Docker Compose
+  /// services did not start successfully.
+  /// </summary>
+  [PublicAPI]
+  public sealed class ComposeServiceFailedException : Exception
+  {
+    private static readonly string[] LineEndings = { "\r\n", "\n" };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeServiceFailedException" /> class.
+    /// </summary>
+    /// <param name="projectName">The Docker Compose project name.</param>
+    /// <param name="failures">The exception of each Docker Compose service that failed, indexed by its display name.</param>
+    public ComposeServiceFailedException(string projectName, IEnumerable<KeyValuePair<string, Exception>> failures)
+      : this(projectName, failures.ToArray())
+    {
+    }
+
+    private ComposeServiceFailedException(string projectName, IReadOnlyCollection<KeyValuePair<string, Exception>> failures)
+      : base(CreateMessage(projectName, failures), new AggregateException(failures.Select(failure => failure.Value)))
+    {
+    }
+
+    private static string CreateMessage(string projectName, IReadOnlyCollection<KeyValuePair<string, Exception>> failures)
+    {
+      var serviceNames = failures.Select(failure => failure.Key);
+
+      var exceptionInfo = new StringBuilder(256);
+      exceptionInfo.Append($"The Docker Compose service(s) '{string.Join("', '", serviceNames)}' in the project '{projectName}' did not start successfully.");
+
+      foreach (var failure in failures)
+      {
+        var failureLines = failure.Value.Message
+          .Split(LineEndings, StringSplitOptions.RemoveEmptyEntries)
+          .Select(line => "    " + line);
+
+        exceptionInfo.AppendLine();
+        exceptionInfo.AppendLine($"  {failure.Key}: ");
+        exceptionInfo.Append(string.Join(Environment.NewLine, failureLines));
+      }
+
+      return exceptionInfo.ToString();
+    }
+  }
+}

--- a/src/Testcontainers/Containers/ComposeServiceName.cs
+++ b/src/Testcontainers/Containers/ComposeServiceName.cs
@@ -1,0 +1,71 @@
+namespace DotNet.Testcontainers.Containers
+{
+  using System.Collections.Generic;
+  using System.Globalization;
+  using DotNet.Testcontainers.Builders;
+
+  /// <summary>
+  /// Resolves the Docker Compose service instance of a Docker Compose container.
+  /// </summary>
+  /// <remarks>
+  /// A Docker Compose service can run more than one container (see
+  /// <see cref="ComposeBuilder.WithScaledService" />). Each container is one
+  /// instance of the service, addressed by the service name and the container
+  /// number. The service name always addresses the service as it is declared in
+  /// the Docker Compose file. The instance number addresses one of its
+  /// containers.
+  /// </remarks>
+  internal static class ComposeServiceName
+  {
+    /// <summary>
+    /// The label that contains the Docker Compose service name.
+    /// </summary>
+    public const string ServiceLabel = "com.docker.compose.service";
+
+    /// <summary>
+    /// The label that contains the number of the container within the Docker
+    /// Compose service.
+    /// </summary>
+    public const string ContainerNumberLabel = "com.docker.compose.container-number";
+
+    /// <summary>
+    /// The instance that a Docker Compose service name addresses if no instance is
+    /// set.
+    /// </summary>
+    public const ushort FirstInstance = 1;
+
+    /// <summary>
+    /// Gets the Docker Compose service instance of a Docker Compose container.
+    /// </summary>
+    /// <param name="labels">The labels of the Docker Compose container.</param>
+    /// <returns>The Docker Compose service instance, or <c>null</c> if the container does not belong to a Docker Compose service.</returns>
+    public static (string ServiceName, ushort Instance)? GetInstance(IDictionary<string, string> labels)
+    {
+      if (labels == null || !labels.TryGetValue(ServiceLabel, out var serviceName))
+      {
+        return null;
+      }
+
+      // Docker Compose sets the container number for every service container.
+      // Fall back to the first instance if a container does not carry the label.
+      if (!labels.TryGetValue(ContainerNumberLabel, out var containerNumber) || !ushort.TryParse(containerNumber, NumberStyles.Integer, CultureInfo.InvariantCulture, out var instance))
+      {
+        instance = FirstInstance;
+      }
+
+      return (serviceName, instance);
+    }
+
+    /// <summary>
+    /// Gets the display name of a Docker Compose service instance, e.g.
+    /// <c>web-2</c>.
+    /// </summary>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="instance">The number of the container within the Docker Compose service.</param>
+    /// <returns>The display name of the Docker Compose service instance.</returns>
+    public static string GetDisplayName(string serviceName, ushort instance)
+    {
+      return serviceName + "-" + instance.ToString(CultureInfo.InvariantCulture);
+    }
+  }
+}

--- a/src/Testcontainers/Containers/ComposeServiceName.cs
+++ b/src/Testcontainers/Containers/ComposeServiceName.cs
@@ -57,8 +57,7 @@ namespace DotNet.Testcontainers.Containers
     }
 
     /// <summary>
-    /// Gets the display name of a Docker Compose service instance, e.g.
-    /// <c>web-2</c>.
+    /// Gets the display name of a Docker Compose service instance, e.g. <c>web-2</c>.
     /// </summary>
     /// <param name="serviceName">The Docker Compose service name.</param>
     /// <param name="instance">The number of the container within the Docker Compose service.</param>

--- a/src/Testcontainers/Containers/ComposeServiceNotExposedException.cs
+++ b/src/Testcontainers/Containers/ComposeServiceNotExposedException.cs
@@ -1,0 +1,23 @@
+namespace DotNet.Testcontainers.Containers
+{
+  using System;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Represents an exception that is thrown when a Docker Compose service port is
+  /// not exposed.
+  /// </summary>
+  [PublicAPI]
+  public sealed class ComposeServiceNotExposedException : InvalidOperationException
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeServiceNotExposedException" /> class.
+    /// </summary>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="servicePort">The Docker Compose service port.</param>
+    public ComposeServiceNotExposedException(string serviceName, ushort servicePort)
+      : base($"The port {servicePort} of the Docker Compose service '{serviceName}' is not exposed. Expose the service port using the builder method WithExposedService(string, ushort).")
+    {
+    }
+  }
+}

--- a/src/Testcontainers/Containers/ComposeServiceNotFoundException.cs
+++ b/src/Testcontainers/Containers/ComposeServiceNotFoundException.cs
@@ -1,0 +1,24 @@
+namespace DotNet.Testcontainers.Containers
+{
+  using System;
+  using JetBrains.Annotations;
+
+  /// <summary>
+  /// Represents an exception that is thrown when a Docker Compose service does
+  /// not belong to the Docker Compose project, or when the Docker Compose
+  /// services have not been started yet.
+  /// </summary>
+  [PublicAPI]
+  public sealed class ComposeServiceNotFoundException : InvalidOperationException
+  {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ComposeServiceNotFoundException" /> class.
+    /// </summary>
+    /// <param name="serviceName">The Docker Compose service name.</param>
+    /// <param name="projectName">The Docker Compose project name.</param>
+    public ComposeServiceNotFoundException(string serviceName, string projectName)
+      : base($"The Docker Compose service '{serviceName}' was not found in the project '{projectName}'. Make sure the service is part of the Docker Compose file and that the Docker Compose services have been started by calling StartAsync(CancellationToken).")
+    {
+    }
+  }
+}

--- a/src/Testcontainers/Containers/ContainerNotRunningException.cs
+++ b/src/Testcontainers/Containers/ContainerNotRunningException.cs
@@ -12,7 +12,7 @@ namespace DotNet.Testcontainers.Containers
   [PublicAPI]
   public sealed class ContainerNotRunningException : Exception
   {
-    private static readonly string[] LineEndings = new[] { "\r\n", "\n" };
+    private static readonly string[] LineEndings = { "\r\n", "\n" };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ContainerNotRunningException" /> class.

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -256,20 +256,20 @@ namespace DotNet.Testcontainers.Containers
     }
 
     /// <inheritdoc />
-    public ushort GetMappedPublicPort()
+    public virtual ushort GetMappedPublicPort()
     {
       using var enumerator = GetMappedPublicPorts().Values.GetEnumerator();
       return enumerator.MoveNext() ? enumerator.Current : throw new InvalidOperationException("No mapped port found.");
     }
 
     /// <inheritdoc />
-    public ushort GetMappedPublicPort(int containerPort)
+    public virtual ushort GetMappedPublicPort(int containerPort)
     {
       return GetMappedPublicPort(Convert.ToString(containerPort, CultureInfo.InvariantCulture));
     }
 
     /// <inheritdoc />
-    public ushort GetMappedPublicPort(string containerPort)
+    public virtual ushort GetMappedPublicPort(string containerPort)
     {
       ThrowIfResourceNotFound();
 
@@ -286,7 +286,7 @@ namespace DotNet.Testcontainers.Containers
     }
 
     /// <inheritdoc />
-    public IReadOnlyDictionary<ushort, ushort> GetMappedPublicPorts()
+    public virtual IReadOnlyDictionary<ushort, ushort> GetMappedPublicPorts()
     {
       ThrowIfResourceNotFound();
 
@@ -529,13 +529,13 @@ namespace DotNet.Testcontainers.Containers
         {
           Logger.ReusableResourceNotFound();
 
-          id = await _client.RunAsync(_configuration, ct)
+          id = await UnsafeCreateContainerAsync(ct)
             .ConfigureAwait(false);
         }
       }
       else
       {
-        id = await _client.RunAsync(_configuration, ct)
+        id = await UnsafeCreateContainerAsync(ct)
           .ConfigureAwait(false);
       }
 
@@ -544,6 +544,35 @@ namespace DotNet.Testcontainers.Containers
 
       CreatedTime = _container.Created;
       Created?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Creates the container and returns its id.
+    /// </summary>
+    /// <remarks>
+    /// Derived classes override this member to attach to an existing container
+    /// instead of creating a new one.
+    /// </remarks>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been created, returning the container id.</returns>
+    protected virtual Task<string> UnsafeCreateContainerAsync(CancellationToken ct = default)
+    {
+      return _client.RunAsync(_configuration, ct);
+    }
+
+    /// <summary>
+    /// Starts the container.
+    /// </summary>
+    /// <remarks>
+    /// Derived classes override this member when another process manages the
+    /// lifecycle of the container, and only the readiness checks of
+    /// <see cref="UnsafeStartAsync" /> apply.
+    /// </remarks>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when the container has been started.</returns>
+    protected virtual Task UnsafeStartContainerAsync(CancellationToken ct = default)
+    {
+      return _client.StartAsync(_container.ID, ct);
     }
 
     /// <inheritdoc />
@@ -586,7 +615,7 @@ namespace DotNet.Testcontainers.Containers
       await _client.AttachAsync(_container.ID, _configuration.OutputConsumer, ct)
         .ConfigureAwait(false);
 
-      await _client.StartAsync(_container.ID, ct)
+      await UnsafeStartContainerAsync(ct)
         .ConfigureAwait(false);
 
       _ = await CheckReadinessAsync(new[] { portBindingsMapped }, ct)

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -855,7 +855,7 @@ namespace DotNet.Testcontainers.Containers
       public override Task<bool> UntilAsync(IContainer container, CancellationToken ct = default)
       {
         var boundPorts = _parent._container.NetworkSettings.Ports.Values.Where(portBindings => portBindings != null).SelectMany(portBinding => portBinding).Count(portBinding => !string.IsNullOrEmpty(portBinding.HostPort));
-        return Task.FromResult(_parent._configuration.PortBindings == null || /* IPv4 or IPv6 */ _parent._configuration.PortBindings.Count == boundPorts || /* IPv4 and IPv6 */ 2 * _parent._configuration.PortBindings.Count == boundPorts);
+        return Task.FromResult(_parent._configuration.PortBindings == null || /* not configured */ _parent._configuration.PortBindings.Count == 0 || /* IPv4 or IPv6 */ _parent._configuration.PortBindings.Count == boundPorts || /* IPv4 and IPv6 */ 2 * _parent._configuration.PortBindings.Count == boundPorts);
       }
     }
   }

--- a/src/Testcontainers/Containers/ExecFailedException.cs
+++ b/src/Testcontainers/Containers/ExecFailedException.cs
@@ -12,7 +12,7 @@ namespace DotNet.Testcontainers.Containers
   [PublicAPI]
   public sealed class ExecFailedException : Exception
   {
-    private static readonly string[] LineEndings = new[] { "\r\n", "\n" };
+    private static readonly string[] LineEndings = { "\r\n", "\n" };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ExecFailedException" /> class.

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -33,6 +33,11 @@ namespace DotNet.Testcontainers.Containers
     /// </summary>
     private const int RetryTimeoutInSeconds = 2;
 
+    /// <summary>
+    /// 512 bytes acknowledgement buffer size.
+    /// </summary>
+    private const int AcknowledgementBufferSizeInBytes = 512;
+
     private static readonly IImage RyukImage = new DockerImage("testcontainers/ryuk:0.14.0@sha256:7c1a8a9a47c780ed0f983770a662f80deb115d95cce3e2daa3d12115b8cd28f0");
 
     private static readonly SemaphoreSlim DefaultLock = new SemaphoreSlim(1, 1);
@@ -258,6 +263,173 @@ namespace DotNet.Testcontainers.Containers
       return resourceReaper;
     }
 
+    /// <summary>
+    /// Registers an additional Docker resource filter with Ryuk.
+    /// </summary>
+    /// <remarks>
+    /// Ryuk keeps received filters until it terminates. It is not necessary to keep
+    /// the connection that registered the filter open. On termination, Ryuk deletes
+    /// all Docker resources matching the filter.
+    /// </remarks>
+    /// <param name="filter">The Docker resource filter, e.g. <c>label=key=value</c>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when Ryuk has acknowledged the filter.</returns>
+    /// <exception cref="ResourceReaperException">Ryuk did not acknowledge the filter within the connection timeout.</exception>
+    internal async Task RegisterFilterAsync(string filter, CancellationToken ct = default)
+    {
+      using (var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(ConnectionTimeoutInSeconds)))
+      {
+        using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, ct))
+        {
+          try
+          {
+            while (!await TryConnectAndRegisterFilterAsync(filter, linkedCts.Token).ConfigureAwait(false))
+            {
+              await Task.Delay(TimeSpan.FromSeconds(RetryTimeoutInSeconds), linkedCts.Token)
+                .ConfigureAwait(false);
+            }
+          }
+          catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+          {
+            throw new ResourceReaperException($"The Resource Reaper did not acknowledge the filter '{filter}' within {ConnectionTimeoutInSeconds} seconds.");
+          }
+        }
+      }
+    }
+
+    /// <summary>
+    /// Connects to Ryuk, sends a Docker resource filter and awaits the
+    /// acknowledgement.
+    /// </summary>
+    /// <remarks>
+    /// A connection that is not ready yet does not fail the registration, just like
+    /// the connection that <see cref="MaintainRyukConnection" /> keeps open. The
+    /// caller retries until Ryuk acknowledges the filter.
+    /// </remarks>
+    /// <param name="filter">The Docker resource filter, e.g. <c>label=key=value</c>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when Ryuk has acknowledged the filter, returning false if the connection was not ready; otherwise, true.</returns>
+    private async Task<bool> TryConnectAndRegisterFilterAsync(string filter, CancellationToken ct)
+    {
+      if (!TryGetEndpoint(out var host, out var port))
+      {
+        return false;
+      }
+
+      using (var tcpClient = new TcpClient())
+      {
+        tcpClient.LingerState = DiscardAllPendingData;
+
+        try
+        {
+#if NET6_0_OR_GREATER
+          await tcpClient.ConnectAsync(host, port, ct)
+            .ConfigureAwait(false);
+#else
+          // The overload that takes a cancellation token is not available. Disposing the
+          // client cancels a pending connection attempt.
+          using (ct.Register(tcpClient.Dispose))
+          {
+            await tcpClient.ConnectAsync(host, port)
+              .ConfigureAwait(false);
+          }
+#endif
+
+          return await TryRegisterFilterAsync(tcpClient.GetStream(), filter, ct)
+            .ConfigureAwait(false);
+        }
+        catch (Exception e) when (e is SocketException || e is IOException || e is ObjectDisposedException)
+        {
+          _resourceReaperContainer.Logger.CanNotConnectToResourceReaper(SessionId, host, port, e);
+          return false;
+        }
+      }
+    }
+
+    /// <summary>
+    /// Sends a Docker resource filter to Ryuk over an established connection and
+    /// awaits the acknowledgement.
+    /// </summary>
+    /// <param name="stream">The network stream of the established Ryuk connection.</param>
+    /// <param name="filter">The Docker resource filter, e.g. <c>label=key=value</c>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Task that completes when Ryuk has acknowledged the filter, returning false if the connection did not return any data; otherwise, true.</returns>
+    private static async Task<bool> TryRegisterFilterAsync(NetworkStream stream, string filter, CancellationToken ct)
+    {
+      var sendBytes = Encoding.ASCII.GetBytes(filter + "\n");
+
+      var readBytes = new byte[AcknowledgementBufferSizeInBytes];
+
+#if NETSTANDARD2_0
+      await stream.WriteAsync(sendBytes, 0, sendBytes.Length, ct)
+        .ConfigureAwait(false);
+#else
+      await stream.WriteAsync(sendBytes, ct)
+        .ConfigureAwait(false);
+#endif
+
+      await stream.FlushAsync(ct)
+        .ConfigureAwait(false);
+
+      using (var messageBuffer = new MemoryStream())
+      {
+        bool hasAcknowledge;
+
+        do
+        {
+#if NETSTANDARD2_0
+          var numberOfBytes = await stream.ReadAsync(readBytes, 0, readBytes.Length, ct)
+            .ConfigureAwait(false);
+#else
+          var numberOfBytes = await stream.ReadAsync(readBytes, ct)
+            .ConfigureAwait(false);
+#endif
+
+          if (numberOfBytes == 0)
+          {
+            // Even if there is no listening socket behind the bound port, the TcpClient
+            // establishes a connection. If we do not receive any data, the socket is not
+            // ready yet.
+            return false;
+          }
+
+          var indexOfNewLine = Array.IndexOf(readBytes, (byte)'\n', 0, numberOfBytes);
+
+          if (indexOfNewLine == -1)
+          {
+            // We have not received the entire message yet. Read from stream again.
+#if NETSTANDARD2_0
+            await messageBuffer.WriteAsync(readBytes, 0, numberOfBytes, ct)
+              .ConfigureAwait(false);
+#else
+            await messageBuffer.WriteAsync(readBytes.AsMemory(0, numberOfBytes), ct)
+              .ConfigureAwait(false);
+#endif
+
+            hasAcknowledge = false;
+          }
+          else
+          {
+#if NETSTANDARD2_0
+            await messageBuffer.WriteAsync(readBytes, 0, indexOfNewLine, ct)
+              .ConfigureAwait(false);
+#else
+            await messageBuffer.WriteAsync(readBytes.AsMemory(0, indexOfNewLine), ct)
+              .ConfigureAwait(false);
+#endif
+
+            var buffer = messageBuffer.GetBuffer();
+
+            hasAcknowledge = "ack".Equals(Encoding.ASCII.GetString(buffer, 0, (int)messageBuffer.Length), StringComparison.OrdinalIgnoreCase);
+            messageBuffer.SetLength(0);
+          }
+        }
+        while (!hasAcknowledge);
+      }
+
+      return true;
+    }
+
     private bool TryGetEndpoint(out string host, out ushort port)
     {
       try
@@ -321,88 +493,26 @@ namespace DotNet.Testcontainers.Containers
 
             var stream = tcpClient.GetStream();
 
-            var filter = $"label={ResourceReaperSessionLabel}={SessionId:D}\n";
-
-            var sendBytes = Encoding.ASCII.GetBytes(filter);
-
             var readBytes = new byte[tcpClient.ReceiveBufferSize];
 
             if (!ryukInitializedTaskSource.Task.IsCompleted)
             {
-              using (var messageBuffer = new MemoryStream())
+              var hasAcknowledge = await TryRegisterFilterAsync(stream, $"label={ResourceReaperSessionLabel}={SessionId:D}", ct)
+                .ConfigureAwait(false);
+
+              if (!hasAcknowledge)
               {
-#if NETSTANDARD2_0
-                await stream.WriteAsync(sendBytes, 0, sendBytes.Length, ct)
+                await Task.Delay(TimeSpan.FromSeconds(RetryTimeoutInSeconds), ct)
                   .ConfigureAwait(false);
-#else
-                await stream.WriteAsync(sendBytes, ct)
-                  .ConfigureAwait(false);
-#endif
-
-                await stream.FlushAsync(ct)
-                  .ConfigureAwait(false);
-
-                bool hasAcknowledge;
-
-                do
-                {
-#if NETSTANDARD2_0
-                  var numberOfBytes = await stream.ReadAsync(readBytes, 0, readBytes.Length, ct)
-                    .ConfigureAwait(false);
-#else
-                  var numberOfBytes = await stream.ReadAsync(readBytes, ct)
-                    .ConfigureAwait(false);
-#endif
-
-                  if (numberOfBytes == 0)
-                  {
-                    // Even if there is no listening socket behind the bound port, the TcpClient establishes a connection.
-                    // If we do not receive any data, the socket is not ready yet.
-                    await Task.Delay(TimeSpan.FromSeconds(RetryTimeoutInSeconds), ct)
-                      .ConfigureAwait(false);
 
 #pragma warning disable S907
 
-                    goto connect_to_ryuk;
+                goto connect_to_ryuk;
 
 #pragma warning restore S907
-                  }
-
-                  var indexOfNewLine = Array.IndexOf(readBytes, (byte)'\n', 0, numberOfBytes);
-
-                  if (indexOfNewLine == -1)
-                  {
-                    // We have not received the entire message yet. Read from stream again.
-#if NETSTANDARD2_0
-                    await messageBuffer.WriteAsync(readBytes, 0, numberOfBytes, ct)
-                      .ConfigureAwait(false);
-#else
-                    await messageBuffer.WriteAsync(readBytes.AsMemory(0, numberOfBytes), ct)
-                      .ConfigureAwait(false);
-#endif
-
-                    hasAcknowledge = false;
-                  }
-                  else
-                  {
-#if NETSTANDARD2_0
-                    await messageBuffer.WriteAsync(readBytes, 0, indexOfNewLine, ct)
-                      .ConfigureAwait(false);
-#else
-                    await messageBuffer.WriteAsync(readBytes.AsMemory(0, indexOfNewLine), ct)
-                      .ConfigureAwait(false);
-#endif
-
-                    var buffer = messageBuffer.GetBuffer();
-
-                    hasAcknowledge = "ack".Equals(Encoding.ASCII.GetString(buffer, 0, (int)messageBuffer.Length), StringComparison.OrdinalIgnoreCase);
-                    messageBuffer.SetLength(0);
-                  }
-                }
-                while (!hasAcknowledge);
-
-                ryukInitializedTaskSource.SetResult(true);
               }
+
+              ryukInitializedTaskSource.SetResult(true);
             }
 
             while (!_maintainConnectionCts.IsCancellationRequested)
@@ -451,41 +561,6 @@ namespace DotNet.Testcontainers.Containers
       else
       {
         ryukInitializedTaskSource.SetException(new ResourceReaperException("Initialization failed."));
-      }
-    }
-
-    private sealed class UnixSocketMount : IMount
-    {
-      private const string DockerSocketFilePath = "/var/run/docker.sock";
-
-      public UnixSocketMount([NotNull] Uri dockerEndpoint)
-      {
-        // If the Docker endpoint is a Unix socket, extract the socket path from the URI; otherwise, fallback to the default Unix socket path.
-        Source = "unix".Equals(dockerEndpoint.Scheme, StringComparison.OrdinalIgnoreCase) ? dockerEndpoint.AbsolutePath : DockerSocketFilePath;
-
-        // If the user has overridden the Docker socket path, use the user-specified path; otherwise, keep the previously determined source.
-        Source = !string.IsNullOrEmpty(TestcontainersSettings.DockerSocketOverride) ? TestcontainersSettings.DockerSocketOverride : Source;
-        Target = DockerSocketFilePath;
-      }
-
-      public MountType Type
-        => MountType.Bind;
-
-      public AccessMode AccessMode
-        => AccessMode.ReadOnly;
-
-      public string Source { get; }
-
-      public string Target { get; }
-
-      public Task CreateAsync(CancellationToken ct = default)
-      {
-        return Task.CompletedTask;
-      }
-
-      public Task DeleteAsync(CancellationToken ct = default)
-      {
-        return Task.CompletedTask;
       }
     }
   }

--- a/src/Testcontainers/Containers/ResourceReaper.cs
+++ b/src/Testcontainers/Containers/ResourceReaper.cs
@@ -155,6 +155,50 @@ namespace DotNet.Testcontainers.Containers
       }
     }
 
+    /// <summary>
+    /// Registers an additional Docker resource filter with Ryuk.
+    /// </summary>
+    /// <remarks>
+    /// Ryuk keeps received filters until it terminates. It is not necessary to keep
+    /// the connection that registered the filter open. On termination, Ryuk deletes
+    /// all Docker resources matching the filter.
+    /// </remarks>
+    /// <param name="filter">The Docker resource filter, e.g. <c>label=key=value</c>.</param>
+    /// <param name="ct">The cancellation token to cancel the filter registration.</param>
+    /// <returns>Task that completes when Ryuk has acknowledged the filter.</returns>
+    /// <exception cref="ResourceReaperException">Ryuk did not acknowledge the filter within the connection timeout.</exception>
+    [PublicAPI]
+    public async Task RegisterFilterAsync(string filter, CancellationToken ct = default)
+    {
+      using (var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(ConnectionTimeoutInSeconds)))
+      {
+        using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, ct))
+        {
+          try
+          {
+            bool hasAcknowledge;
+
+            do
+            {
+              hasAcknowledge = await TryConnectAndRegisterFilterAsync(filter, linkedCts.Token)
+                .ConfigureAwait(false);
+
+              if (!hasAcknowledge)
+              {
+                await Task.Delay(TimeSpan.FromSeconds(RetryTimeoutInSeconds), linkedCts.Token)
+                  .ConfigureAwait(false);
+              }
+            }
+            while (!hasAcknowledge);
+          }
+          catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+          {
+            throw new ResourceReaperException($"The Resource Reaper did not acknowledge the filter '{filter}' within {ConnectionTimeoutInSeconds} seconds.");
+          }
+        }
+      }
+    }
+
     /// <inheritdoc />
     [PublicAPI]
     public async ValueTask DisposeAsync()
@@ -264,95 +308,11 @@ namespace DotNet.Testcontainers.Containers
     }
 
     /// <summary>
-    /// Registers an additional Docker resource filter with Ryuk.
-    /// </summary>
-    /// <remarks>
-    /// Ryuk keeps received filters until it terminates. It is not necessary to keep
-    /// the connection that registered the filter open. On termination, Ryuk deletes
-    /// all Docker resources matching the filter.
-    /// </remarks>
-    /// <param name="filter">The Docker resource filter, e.g. <c>label=key=value</c>.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when Ryuk has acknowledged the filter.</returns>
-    /// <exception cref="ResourceReaperException">Ryuk did not acknowledge the filter within the connection timeout.</exception>
-    internal async Task RegisterFilterAsync(string filter, CancellationToken ct = default)
-    {
-      using (var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(ConnectionTimeoutInSeconds)))
-      {
-        using (var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, ct))
-        {
-          try
-          {
-            while (!await TryConnectAndRegisterFilterAsync(filter, linkedCts.Token).ConfigureAwait(false))
-            {
-              await Task.Delay(TimeSpan.FromSeconds(RetryTimeoutInSeconds), linkedCts.Token)
-                .ConfigureAwait(false);
-            }
-          }
-          catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-          {
-            throw new ResourceReaperException($"The Resource Reaper did not acknowledge the filter '{filter}' within {ConnectionTimeoutInSeconds} seconds.");
-          }
-        }
-      }
-    }
-
-    /// <summary>
-    /// Connects to Ryuk, sends a Docker resource filter and awaits the
-    /// acknowledgement.
-    /// </summary>
-    /// <remarks>
-    /// A connection that is not ready yet does not fail the registration, just like
-    /// the connection that <see cref="MaintainRyukConnection" /> keeps open. The
-    /// caller retries until Ryuk acknowledges the filter.
-    /// </remarks>
-    /// <param name="filter">The Docker resource filter, e.g. <c>label=key=value</c>.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when Ryuk has acknowledged the filter, returning false if the connection was not ready; otherwise, true.</returns>
-    private async Task<bool> TryConnectAndRegisterFilterAsync(string filter, CancellationToken ct)
-    {
-      if (!TryGetEndpoint(out var host, out var port))
-      {
-        return false;
-      }
-
-      using (var tcpClient = new TcpClient())
-      {
-        tcpClient.LingerState = DiscardAllPendingData;
-
-        try
-        {
-#if NET6_0_OR_GREATER
-          await tcpClient.ConnectAsync(host, port, ct)
-            .ConfigureAwait(false);
-#else
-          // The overload that takes a cancellation token is not available. Disposing the
-          // client cancels a pending connection attempt.
-          using (ct.Register(tcpClient.Dispose))
-          {
-            await tcpClient.ConnectAsync(host, port)
-              .ConfigureAwait(false);
-          }
-#endif
-
-          return await TryRegisterFilterAsync(tcpClient.GetStream(), filter, ct)
-            .ConfigureAwait(false);
-        }
-        catch (Exception e) when (e is SocketException || e is IOException || e is ObjectDisposedException)
-        {
-          _resourceReaperContainer.Logger.CanNotConnectToResourceReaper(SessionId, host, port, e);
-          return false;
-        }
-      }
-    }
-
-    /// <summary>
-    /// Sends a Docker resource filter to Ryuk over an established connection and
-    /// awaits the acknowledgement.
+    /// Sends a Docker resource filter to Ryuk and awaits the acknowledgement.
     /// </summary>
     /// <param name="stream">The network stream of the established Ryuk connection.</param>
     /// <param name="filter">The Docker resource filter, e.g. <c>label=key=value</c>.</param>
-    /// <param name="ct">Cancellation token.</param>
+    /// <param name="ct">The cancellation token to cancel the filter registration.</param>
     /// <returns>Task that completes when Ryuk has acknowledged the filter, returning false if the connection did not return any data; otherwise, true.</returns>
     private static async Task<bool> TryRegisterFilterAsync(NetworkStream stream, string filter, CancellationToken ct)
     {
@@ -428,6 +388,54 @@ namespace DotNet.Testcontainers.Containers
       }
 
       return true;
+    }
+
+    /// <summary>
+    /// Connects to Ryuk, sends a Docker resource filter and awaits the acknowledgement.
+    /// </summary>
+    /// <remarks>
+    /// A connection that is not ready yet does not fail the registration, just like
+    /// the connection that <see cref="MaintainRyukConnection" /> keeps open.
+    /// The caller retries until Ryuk acknowledges the filter.
+    /// </remarks>
+    /// <param name="filter">The Docker resource filter, e.g. <c>label=key=value</c>.</param>
+    /// <param name="ct">The cancellation token to cancel the filter registration.</param>
+    /// <returns>Task that completes when Ryuk has acknowledged the filter, returning false if the connection was not ready; otherwise, true.</returns>
+    private async Task<bool> TryConnectAndRegisterFilterAsync(string filter, CancellationToken ct)
+    {
+      if (!TryGetEndpoint(out var host, out var port))
+      {
+        return false;
+      }
+
+      using (var tcpClient = new TcpClient())
+      {
+        tcpClient.LingerState = DiscardAllPendingData;
+
+        try
+        {
+#if NET6_0_OR_GREATER
+          await tcpClient.ConnectAsync(host, port, ct)
+            .ConfigureAwait(false);
+#else
+          // The overload that takes a cancellation token is not available.
+          // Disposing the client cancels a pending connection attempt.
+          using (ct.Register(tcpClient.Dispose))
+          {
+            await tcpClient.ConnectAsync(host, port)
+              .ConfigureAwait(false);
+          }
+#endif
+
+          return await TryRegisterFilterAsync(tcpClient.GetStream(), filter, ct)
+            .ConfigureAwait(false);
+        }
+        catch (Exception e) when (e is SocketException or IOException or ObjectDisposedException)
+        {
+          _resourceReaperContainer.Logger.CanNotConnectToResourceReaper(SessionId, host, port, e);
+          return false;
+        }
+      }
     }
 
     private bool TryGetEndpoint(out string host, out ushort port)

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -99,6 +99,15 @@ namespace DotNet.Testcontainers
     [LoggerMessage(Level = LogLevel.Information, Message = "Add file to tar archive: Source file: \"{Source}\", Target file: \"{Target}\", UID: {Uid}, GID: {Gid}, Mode: {Mode}")]
     private static partial void AddFileToTarArchiveCore(ILogger logger, string source, string target, int uid, int gid, string mode);
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Docker Compose down failed for project {ProjectName}")]
+    private static partial void DockerComposeDownFailedCore(ILogger logger, string projectName, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Cannot pull the Docker Compose image {FullName}. The start continues, but Docker Compose may fail to pull the image itself")]
+    private static partial void DockerComposePullImageFailedCore(ILogger logger, string fullName, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Cannot resolve the Docker Compose images of project {ProjectName}. The start continues without pulling them")]
+    private static partial void DockerComposeResolveImagesFailedCore(ILogger logger, string projectName, Exception exception);
+
     [LoggerMessage(Level = LogLevel.Debug, Message = "Cannot get resource reaper {Id} endpoint")]
     private static partial void CanNotGetResourceReaperEndpointCore(ILogger logger, Guid id, Exception exception);
 
@@ -265,6 +274,21 @@ namespace DotNet.Testcontainers
     public static void AddFileToTarArchive(this ILogger logger, string source, string target, int uid, int gid, string mode)
     {
       AddFileToTarArchiveCore(logger, source, target, uid, gid, mode);
+    }
+
+    public static void DockerComposeDownFailed(this ILogger logger, string projectName, Exception e)
+    {
+      DockerComposeDownFailedCore(logger, projectName, e);
+    }
+
+    public static void DockerComposePullImageFailed(this ILogger logger, string fullName, Exception e)
+    {
+      DockerComposePullImageFailedCore(logger, fullName, e);
+    }
+
+    public static void DockerComposeResolveImagesFailed(this ILogger logger, string projectName, Exception e)
+    {
+      DockerComposeResolveImagesFailedCore(logger, projectName, e);
     }
 
     public static void CanNotGetResourceReaperEndpoint(this ILogger logger, Guid id, Exception e)

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -99,14 +99,14 @@ namespace DotNet.Testcontainers
     [LoggerMessage(Level = LogLevel.Information, Message = "Add file to tar archive: Source file: \"{Source}\", Target file: \"{Target}\", UID: {Uid}, GID: {Gid}, Mode: {Mode}")]
     private static partial void AddFileToTarArchiveCore(ILogger logger, string source, string target, int uid, int gid, string mode);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Docker Compose down failed for project {ProjectName}")]
-    private static partial void DockerComposeDownFailedCore(ILogger logger, string projectName, Exception exception);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Cannot resolve Compose service images for project {ProjectName}")]
+    private static partial void CanNotResolveComposeServiceImagesCore(ILogger logger, string projectName, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Cannot pull the Docker Compose image {FullName}. The start continues, but Docker Compose may fail to pull the image itself")]
-    private static partial void DockerComposePullImageFailedCore(ILogger logger, string fullName, Exception exception);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Cannot pull Compose service image {FullName}")]
+    private static partial void CanNotPullComposeServiceImageCore(ILogger logger, string fullName, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Cannot resolve the Docker Compose images of project {ProjectName}. The start continues without pulling them")]
-    private static partial void DockerComposeResolveImagesFailedCore(ILogger logger, string projectName, Exception exception);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Cannot clean up Compose project {ProjectName}")]
+    private static partial void CanNotCleanUpComposeProjectCore(ILogger logger, string projectName, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Cannot get resource reaper {Id} endpoint")]
     private static partial void CanNotGetResourceReaperEndpointCore(ILogger logger, Guid id, Exception exception);
@@ -276,19 +276,19 @@ namespace DotNet.Testcontainers
       AddFileToTarArchiveCore(logger, source, target, uid, gid, mode);
     }
 
-    public static void DockerComposeDownFailed(this ILogger logger, string projectName, Exception e)
+    public static void CanNotResolveComposeServiceImages(this ILogger logger, string projectName, Exception e)
     {
-      DockerComposeDownFailedCore(logger, projectName, e);
+      CanNotResolveComposeServiceImagesCore(logger, projectName, e);
     }
 
-    public static void DockerComposePullImageFailed(this ILogger logger, string fullName, Exception e)
+    public static void CanNotPullComposeServiceImage(this ILogger logger, string fullName, Exception e)
     {
-      DockerComposePullImageFailedCore(logger, fullName, e);
+      CanNotPullComposeServiceImageCore(logger, fullName, e);
     }
 
-    public static void DockerComposeResolveImagesFailed(this ILogger logger, string projectName, Exception e)
+    public static void CanNotCleanUpComposeProject(this ILogger logger, string projectName, Exception e)
     {
-      DockerComposeResolveImagesFailedCore(logger, projectName, e);
+      CanNotCleanUpComposeProjectCore(logger, projectName, e);
     }
 
     public static void CanNotGetResourceReaperEndpoint(this ILogger logger, Guid id, Exception e)

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -7,11 +7,13 @@ public static class CommonImages
 
     public static readonly IImage HelloWorld = new DockerImage("testcontainers/helloworld:1.3.0");
 
+    public static readonly IImage DockerCli = new DockerImage("docker:29.7-cli");
+
+    public static readonly IImage DockerDind = new DockerImage("docker:29.7-dind");
+
     public static readonly IImage Alpine = new DockerImage("alpine:3.20.0");
 
     public static readonly IImage Socat = new DockerImage("alpine/socat:1.8.0.3");
-
-    public static readonly IImage DockerCli = new DockerImage("docker:28-cli");
 
     public static readonly IImage Curl = new DockerImage("curlimages/curl:8.00.1");
 

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -11,6 +11,8 @@ public static class CommonImages
 
     public static readonly IImage Socat = new DockerImage("alpine/socat:1.8.0.3");
 
+    public static readonly IImage DockerCli = new DockerImage("docker:28-cli");
+
     public static readonly IImage Curl = new DockerImage("curlimages/curl:8.00.1");
 
     public static readonly IImage Nginx = new DockerImage("nginx:1.26.3-alpine3.20");

--- a/tests/Testcontainers.Commons/CommonImages.cs
+++ b/tests/Testcontainers.Commons/CommonImages.cs
@@ -7,9 +7,9 @@ public static class CommonImages
 
     public static readonly IImage HelloWorld = new DockerImage("testcontainers/helloworld:1.3.0");
 
-    public static readonly IImage DockerCli = new DockerImage("docker:29.7-cli");
+    public static readonly IImage DockerCli = new DockerImage("docker:29.7.2-cli");
 
-    public static readonly IImage DockerDind = new DockerImage("docker:29.7-dind");
+    public static readonly IImage DockerDind = new DockerImage("docker:29.7.2-dind");
 
     public static readonly IImage Alpine = new DockerImage("alpine:3.20.0");
 

--- a/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerExampleTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerExampleTest.cs
@@ -1,0 +1,93 @@
+namespace Testcontainers.Tests;
+
+public sealed class ComposeContainerExampleTest : IAsyncLifetime
+{
+    private const string WebServiceName = "web";
+
+    private const string WorkerServiceName = "worker";
+
+    private const ushort WebServicePort = 80;
+
+    // # --8<-- [start:CreateComposeContainer]
+    private readonly ComposeContainer _composeContainer;
+
+    public ComposeContainerExampleTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(composeFilePath, $"""
+            services:
+              {WebServiceName}:
+                image: "{CommonImages.Nginx.FullName}"
+                ports:
+                  - "{WebServicePort}"
+              {WorkerServiceName}:
+                image: "{CommonImages.Alpine.FullName}"
+                command: ["/bin/sh", "-c", "echo Ready; sleep infinity"]
+            """);
+
+        var webServiceIsReady = Wait.ForUnixContainer()
+            .UntilHttpRequestIsSucceeded(request => request.ForPath("/").ForPort(WebServicePort));
+
+        var workerServiceIsReady = Wait.ForUnixContainer()
+            .UntilMessageIsLogged("Ready");
+
+        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WithExposedService(WebServiceName, WebServicePort, webServiceIsReady)
+            .WaitingFor(WorkerServiceName, workerServiceIsReady)
+            .Build();
+    }
+    // # --8<-- [end:CreateComposeContainer]
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task EstablishesConnectionToExposedService()
+    {
+        // Given
+        // # --8<-- [start:ConnectToExposedService]
+        var serviceHost = _composeContainer.GetServiceHost(WebServiceName, WebServicePort);
+
+        var servicePort = _composeContainer.GetServicePort(WebServiceName, WebServicePort);
+
+        using var httpClient = new HttpClient();
+        httpClient.BaseAddress = new UriBuilder(Uri.UriSchemeHttp, serviceHost, servicePort).Uri;
+
+        // When
+        using var httpResponse = await httpClient.GetAsync("/", TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+        // # --8<-- [end:ConnectToExposedService]
+
+        // Then
+        Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task ReadsLogsOfNonExposedService()
+    {
+        // Given
+        // # --8<-- [start:GetServiceContainer]
+        var workerContainer = _composeContainer.GetServiceContainer(WorkerServiceName);
+
+        // When
+        var (stdout, _) = await workerContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+        // # --8<-- [end:GetServiceContainer]
+
+        // Then
+        Assert.Contains("Ready", stdout);
+    }
+}

--- a/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerExampleTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerExampleTest.cs
@@ -57,7 +57,6 @@ public sealed class ComposeContainerExampleTest : IAsyncLifetime
     [Fact]
     public async Task EstablishesConnectionToExposedService()
     {
-        // Given
         // # --8<-- [start:ConnectToExposedService]
         var serviceHost = _composeContainer.GetServiceHost(WebServiceName, WebServicePort);
 
@@ -66,28 +65,23 @@ public sealed class ComposeContainerExampleTest : IAsyncLifetime
         using var httpClient = new HttpClient();
         httpClient.BaseAddress = new UriBuilder(Uri.UriSchemeHttp, serviceHost, servicePort).Uri;
 
-        // When
         using var httpResponse = await httpClient.GetAsync("/", TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
         // # --8<-- [end:ConnectToExposedService]
 
-        // Then
         Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
     }
 
     [Fact]
     public async Task ReadsLogsOfNonExposedService()
     {
-        // Given
         // # --8<-- [start:GetServiceContainer]
         var workerContainer = _composeContainer.GetServiceContainer(WorkerServiceName);
 
-        // When
         var (stdout, _) = await workerContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
         // # --8<-- [end:GetServiceContainer]
 
-        // Then
         Assert.Contains("Ready", stdout);
     }
 }

--- a/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
@@ -91,10 +91,8 @@ public sealed class ComposeContainerScaledServiceTest : IAsyncLifetime
 
         // Each instance gets its own ambassador port, and each instance runs its own
         // readiness check.
-        for (ushort instance = 1; instance <= Instances; instance++)
-        {
-            composeBuilder = composeBuilder.WithExposedServiceInstance(ServiceName, instance, ServicePort);
-        }
+        composeBuilder = Enumerable.Range(1, Instances)
+            .Aggregate(composeBuilder, (builder, instance) => builder.WithExposedServiceInstance(ServiceName, (ushort)instance, ServicePort));
 
         _composeContainer = composeBuilder.Build();
     }
@@ -116,13 +114,11 @@ public sealed class ComposeContainerScaledServiceTest : IAsyncLifetime
     {
         // Given
         var containerIds = Enumerable.Range(1, Instances)
-            .Select(instance => _composeContainer.GetServiceInstanceContainer(ServiceName, (ushort)instance).Id)
-            .ToArray();
+            .Select(instance => _composeContainer.GetServiceInstanceContainer(ServiceName, (ushort)instance).Id);
 
         // When
         var servicePorts = Enumerable.Range(1, Instances)
-            .Select(instance => _composeContainer.GetServiceInstancePort(ServiceName, (ushort)instance, ServicePort))
-            .ToArray();
+            .Select(instance => _composeContainer.GetServiceInstancePort(ServiceName, (ushort)instance, ServicePort));
 
         // Then
         Assert.Equal(Instances, containerIds.Distinct().Count());

--- a/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
@@ -294,7 +294,10 @@ public sealed class ComposeContainerExitedServiceTest
 
         var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
 
-        File.WriteAllText(composeFilePath, $"services:\n  migration:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"exit {exitCode}\"]\n");
+        // The app service depends on the completion of the migration service. Docker
+        // Compose does not wait for a service that no other service depends on. It
+        // returns before a service that exits immediately has exited.
+        File.WriteAllText(composeFilePath, $"services:\n  migration:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"exit {exitCode}\"]\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n    depends_on:\n      migration:\n        condition: service_completed_successfully\n");
 
         return new ComposeBuilder(CommonImages.DockerCli)
             .WithComposeFile(composeFilePath)
@@ -313,6 +316,7 @@ public sealed class ComposeContainerExitedServiceTest
 
         // Then
         Assert.Equal(TestcontainersStates.Exited, composeContainer.GetServiceContainer("migration").State);
+        Assert.Equal(TestcontainersStates.Running, composeContainer.GetServiceContainer("app").State);
     }
 
     [Fact]

--- a/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
@@ -304,6 +304,21 @@ public sealed class ComposeContainerExitedServiceTest
             .Build();
     }
 
+    private static ComposeContainer BuildComposeContainer(int migrationExitCode, int seedingExitCode)
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        // The app service depends on the completion of both services. Docker Compose
+        // starts them at the same time, which lets both of them fail.
+        File.WriteAllText(composeFilePath, $"services:\n  migration:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"exit {migrationExitCode}\"]\n  seeding:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"exit {seedingExitCode}\"]\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n    depends_on:\n      migration:\n        condition: service_completed_successfully\n      seeding:\n        condition: service_completed_successfully\n");
+
+        return new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .Build();
+    }
+
     [Fact]
     public async Task StartsWhenServiceRanToCompletion()
     {
@@ -326,11 +341,29 @@ public sealed class ComposeContainerExitedServiceTest
         await using var composeContainer = BuildComposeContainer(1);
 
         // When
-        var exception = await Assert.ThrowsAsync<ContainerNotRunningException>(() => composeContainer.StartAsync(TestContext.Current.CancellationToken))
+        var exception = await Assert.ThrowsAsync<ComposeServiceFailedException>(() => composeContainer.StartAsync(TestContext.Current.CancellationToken))
             .ConfigureAwait(true);
 
         // Then
+        Assert.Contains("'migration-1'", exception.Message);
         Assert.Contains("exited with code 1", exception.Message);
+    }
+
+    [Fact]
+    public async Task ThrowsWhenMultipleServicesExitedUnsuccessfully()
+    {
+        // Given
+        await using var composeContainer = BuildComposeContainer(1, 2);
+
+        // When
+        var exception = await Assert.ThrowsAsync<ComposeServiceFailedException>(() => composeContainer.StartAsync(TestContext.Current.CancellationToken))
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Contains("'migration-1'", exception.Message);
+        Assert.Contains("'seeding-1'", exception.Message);
+        Assert.Contains("exited with code 1", exception.Message);
+        Assert.Contains("exited with code 2", exception.Message);
     }
 }
 

--- a/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
@@ -1,0 +1,473 @@
+namespace Testcontainers.Tests;
+
+public sealed class ComposeContainerTest : IAsyncLifetime
+{
+    private const string ServiceName = "web";
+
+    private const ushort ServicePort = 80;
+
+    private readonly ComposeContainer _composeContainer;
+
+    public ComposeContainerTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        // The service publishes its port to a random host port to cover the readiness
+        // check that waits until the port bindings are mapped.
+        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Nginx.FullName}\"\n    ports:\n      - \"{ServicePort}\"\n");
+
+        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WithExposedService(ServiceName, ServicePort, Wait.ForUnixContainer().UntilHttpRequestIsSucceeded(request =>
+                request.ForPath("/").ForPort(ServicePort)))
+            .Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task EstablishesConnectionToExposedService()
+    {
+        // Given
+        using var httpClient = new HttpClient();
+        httpClient.BaseAddress = new UriBuilder(Uri.UriSchemeHttp, _composeContainer.GetServiceHost(ServiceName, ServicePort), _composeContainer.GetServicePort(ServiceName, ServicePort)).Uri;
+
+        // When
+        using var httpResponse = await httpClient.GetAsync("/", TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+    }
+
+    [Fact]
+    public void ReturnsServiceContainer()
+    {
+        // Given
+        var serviceContainer = _composeContainer.GetServiceContainer(ServiceName);
+
+        // When
+        var mappedPublicPort = serviceContainer.GetMappedPublicPort(ServicePort);
+
+        // Then
+        Assert.Equal(TestcontainersStates.Running, serviceContainer.State);
+        Assert.Equal(_composeContainer.GetServicePort(ServiceName, ServicePort), mappedPublicPort);
+    }
+}
+
+public sealed class ComposeContainerExitedServiceTest
+{
+    private static ComposeContainer BuildComposeContainer(int exitCode)
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(composeFilePath, $"services:\n  migration:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"exit {exitCode}\"]\n");
+
+        return new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .Build();
+    }
+
+    [Fact]
+    public async Task StartsWhenServiceRanToCompletion()
+    {
+        // Given
+        await using var composeContainer = BuildComposeContainer(0);
+
+        // When
+        await composeContainer.StartAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Equal(TestcontainersStates.Exited, composeContainer.GetServiceContainer("migration").State);
+    }
+
+    [Fact]
+    public async Task ThrowsWhenServiceExitedUnsuccessfully()
+    {
+        // Given
+        await using var composeContainer = BuildComposeContainer(1);
+
+        // When
+        var exception = await Assert.ThrowsAsync<ContainerNotRunningException>(() => composeContainer.StartAsync(TestContext.Current.CancellationToken))
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Contains("exited with code 1", exception.Message);
+    }
+}
+
+public sealed class ComposeContainerFileCopyInclusionTest : IAsyncLifetime
+{
+    private readonly ComposeContainer _composeContainer;
+
+    private readonly string _composeFileDirectoryPath;
+
+    public ComposeContainerFileCopyInclusionTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        _composeFileDirectoryPath = composeFileDirectoryPath;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(composeFilePath, $"services:\n  migration:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"exit 0\"]\n");
+
+        _ = Directory.CreateDirectory(Path.Combine(composeFileDirectoryPath, "included"));
+        File.WriteAllText(Path.Combine(composeFileDirectoryPath, "included", "included-nested.txt"), string.Empty);
+        File.WriteAllText(Path.Combine(composeFileDirectoryPath, "included.txt"), string.Empty);
+        File.WriteAllText(Path.Combine(composeFileDirectoryPath, "excluded.txt"), string.Empty);
+
+        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WithCopyFilesInContainer("included.txt", "included")
+            .Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task CopiesIncludedFilesOnly()
+    {
+        // Given
+        var execResult = await _composeContainer.ExecAsync(new[] { "find", _composeFileDirectoryPath, "-type", "f" }, TestContext.Current.CancellationToken)
+            .ThrowOnFailure()
+            .ConfigureAwait(true);
+
+        // When
+        var filePaths = execResult.Stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries).Select(filePath => filePath.Trim()).ToArray();
+
+        // Then
+        Assert.Contains(Path.Combine(_composeFileDirectoryPath, "compose.yml"), filePaths);
+        Assert.Contains(Path.Combine(_composeFileDirectoryPath, "included.txt"), filePaths);
+        Assert.Contains(Path.Combine(_composeFileDirectoryPath, "included", "included-nested.txt"), filePaths);
+        Assert.DoesNotContain(Path.Combine(_composeFileDirectoryPath, "excluded.txt"), filePaths);
+    }
+}
+
+public sealed class ComposeContainerRelativeBindMountTest : IAsyncLifetime
+{
+    private const string FileContent = "Docker Compose resolves the bind mount source on the test host.";
+
+    private readonly ComposeContainer _composeContainer;
+
+    public ComposeContainerRelativeBindMountTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        _ = Directory.CreateDirectory(Path.Combine(composeFileDirectoryPath, "data"));
+        File.WriteAllText(Path.Combine(composeFileDirectoryPath, "data", "bind-mount.txt"), FileContent);
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(composeFilePath, $"services:\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    volumes:\n      - \"./data:/data\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n");
+
+        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task ResolvesRelativeBindMountToTestHostPath()
+    {
+        // Given
+        var serviceContainer = _composeContainer.GetServiceContainer("app");
+
+        // When
+        var fileContent = await serviceContainer.ReadFileAsync("/data/bind-mount.txt", TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Equal(FileContent, Encoding.Default.GetString(fileContent));
+    }
+}
+
+public sealed class ComposeContainerWaitingForTest : IAsyncLifetime
+{
+    private readonly ComposeContainer _composeContainer;
+
+    public ComposeContainerWaitingForTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        // The service does not publish or expose a port. Its readiness is only
+        // observable through its log message.
+        File.WriteAllText(composeFilePath, $"services:\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep 1; echo Ready; sleep infinity\"]\n");
+
+        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WaitingFor("app", Wait.ForUnixContainer().UntilMessageIsLogged("Ready"))
+            .Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task WaitsForServiceWithoutExposedPort()
+    {
+        // Given
+        var serviceContainer = _composeContainer.GetServiceContainer("app");
+
+        // When
+        var (stdout, _) = await serviceContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Contains("Ready", stdout);
+        Assert.Throws<ComposeServiceNotExposedException>(() => _composeContainer.GetServicePort("app", 80));
+    }
+}
+
+public sealed class ComposeContainerServiceNameWithInstanceSuffixTest : IAsyncLifetime
+{
+    // A Docker Compose service name may end with a dash and a number. It addresses
+    // the service that carries the name, not the second instance of a service that
+    // is named "web".
+    private const string ServiceName = "web-2";
+
+    private readonly ComposeContainer _composeContainer;
+
+    public ComposeContainerServiceNameWithInstanceSuffixTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"echo Ready; sleep infinity\"]\n");
+
+        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WaitingFor(ServiceName, Wait.ForUnixContainer().UntilMessageIsLogged("Ready"))
+            .Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public void ResolvesTheServiceNameThatEndsWithAnInstanceNumber()
+    {
+        Assert.Equal(TestcontainersStates.Running, _composeContainer.GetServiceContainer(ServiceName).State);
+    }
+}
+
+public sealed class ComposeContainerServiceNotFoundTest
+{
+    [Fact]
+    public async Task ThrowsWhenWaitStrategyReferencesUnknownService()
+    {
+        // Given
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(composeFilePath, $"services:\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n");
+
+        await using var composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WaitingFor("aap", Wait.ForUnixContainer().UntilMessageIsLogged("Ready"))
+            .Build();
+
+        // When
+        var exception = await Assert.ThrowsAsync<ComposeServiceNotFoundException>(() => composeContainer.StartAsync(TestContext.Current.CancellationToken))
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Contains("'aap-1'", exception.Message);
+    }
+}
+
+public sealed class ComposeContainerPullTest : IAsyncLifetime
+{
+    private readonly FakeLogger _fakeLogger = new FakeLogger();
+
+    private readonly ComposeContainer _composeContainer;
+
+    public ComposeContainerPullTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        File.WriteAllText(Path.Combine(composeFileDirectoryPath, "Dockerfile"), $"FROM {CommonImages.Alpine.FullName}\nCMD [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n");
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        // Docker Compose builds the image of this service. It does not exist in a
+        // registry, so pulling it fails. That must not fail the start.
+        File.WriteAllText(composeFilePath, "services:\n  app:\n    build: \".\"\n");
+
+        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WithLogger(_fakeLogger)
+            .Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public void StartsWhenImageCannotBePulled()
+    {
+        // Given
+        var logRecords = _fakeLogger.Collector.GetSnapshot();
+
+        // When
+        var pullImageFailed = logRecords.Any(logRecord => logRecord.Message.Contains("Cannot pull the Docker Compose image"));
+
+        // Then
+        Assert.True(pullImageFailed, "Expected a warning about the image that cannot be pulled.");
+        Assert.Equal(TestcontainersStates.Running, _composeContainer.GetServiceContainer("app").State);
+    }
+}
+
+public sealed class ComposeContainerScaledServiceTest : IAsyncLifetime
+{
+    private const string ServiceName = "web";
+
+    private const ushort ServicePort = 80;
+
+    private const ushort Instances = 2;
+
+    private readonly ComposeContainer _composeContainer;
+
+    public ComposeContainerScaledServiceTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Nginx.FullName}\"\n");
+
+        var composeBuilder = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WithScaledService(ServiceName, Instances);
+
+        // Each instance gets its own ambassador port, and each instance runs its own
+        // readiness check.
+        for (ushort instance = 1; instance <= Instances; instance++)
+        {
+            composeBuilder = composeBuilder.WithExposedServiceInstance(ServiceName, instance, ServicePort);
+        }
+
+        _composeContainer = composeBuilder.Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public void ResolvesEachServiceInstanceIndividually()
+    {
+        // Given
+        var containerIds = Enumerable.Range(1, Instances)
+            .Select(instance => _composeContainer.GetServiceInstanceContainer(ServiceName, (ushort)instance).Id)
+            .ToArray();
+
+        // When
+        var servicePorts = Enumerable.Range(1, Instances)
+            .Select(instance => _composeContainer.GetServiceInstancePort(ServiceName, (ushort)instance, ServicePort))
+            .ToArray();
+
+        // Then
+        Assert.Equal(Instances, containerIds.Distinct().Count());
+        Assert.Equal(Instances, servicePorts.Distinct().Count());
+    }
+
+    [Fact]
+    public void ResolvesTheServiceNameToTheFirstInstance()
+    {
+        Assert.Equal(_composeContainer.GetServiceInstanceContainer(ServiceName, 1).Id, _composeContainer.GetServiceContainer(ServiceName).Id);
+        Assert.Equal(_composeContainer.GetServiceInstancePort(ServiceName, 1, ServicePort), _composeContainer.GetServicePort(ServiceName, ServicePort));
+    }
+
+    [Theory]
+    [InlineData((ushort)1)]
+    [InlineData((ushort)2)]
+    public async Task EstablishesConnectionToEachServiceInstance(ushort instance)
+    {
+        // Given
+        using var httpClient = new HttpClient();
+        httpClient.BaseAddress = new UriBuilder(Uri.UriSchemeHttp, _composeContainer.GetServiceInstanceHost(ServiceName, instance, ServicePort), _composeContainer.GetServiceInstancePort(ServiceName, instance, ServicePort)).Uri;
+
+        // When
+        using var httpResponse = await httpClient.GetAsync("/", TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+    }
+}

--- a/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
@@ -371,13 +371,9 @@ public sealed class ComposeContainerFileCopyInclusionTest : IAsyncLifetime
 {
     private readonly ComposeContainer _composeContainer;
 
-    private readonly string _composeFileDirectoryPath;
-
     public ComposeContainerFileCopyInclusionTest()
     {
         var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
-
-        _composeFileDirectoryPath = composeFileDirectoryPath;
 
         var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
 
@@ -410,7 +406,10 @@ public sealed class ComposeContainerFileCopyInclusionTest : IAsyncLifetime
     public async Task CopiesIncludedFilesOnly()
     {
         // Given
-        var execResult = await _composeContainer.ExecAsync(new[] { "find", _composeFileDirectoryPath, "-type", "f" }, TestContext.Current.CancellationToken)
+        // The working directory is the directory of the Docker Compose file. Search it
+        // relative to the working directory, the path inside the container does not
+        // match the path on the test host when the test host is Windows.
+        var execResult = await _composeContainer.ExecAsync(new[] { "find", ".", "-type", "f" }, TestContext.Current.CancellationToken)
             .ThrowOnFailure()
             .ConfigureAwait(true);
 
@@ -418,10 +417,10 @@ public sealed class ComposeContainerFileCopyInclusionTest : IAsyncLifetime
         var filePaths = execResult.Stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries).Select(filePath => filePath.Trim()).ToArray();
 
         // Then
-        Assert.Contains(Path.Combine(_composeFileDirectoryPath, "compose.yml"), filePaths);
-        Assert.Contains(Path.Combine(_composeFileDirectoryPath, "included.txt"), filePaths);
-        Assert.Contains(Path.Combine(_composeFileDirectoryPath, "included", "included-nested.txt"), filePaths);
-        Assert.DoesNotContain(Path.Combine(_composeFileDirectoryPath, "excluded.txt"), filePaths);
+        Assert.Contains("./compose.yml", filePaths);
+        Assert.Contains("./included.txt", filePaths);
+        Assert.Contains("./included/included-nested.txt", filePaths);
+        Assert.DoesNotContain("./excluded.txt", filePaths);
     }
 }
 
@@ -567,7 +566,7 @@ public sealed class ComposeContainerPullTest : IAsyncLifetime
         var logRecords = _fakeLogger.Collector.GetSnapshot();
 
         // When
-        var pullImageFailed = logRecords.Any(logRecord => logRecord.Message.Contains("Cannot pull the Docker Compose image"));
+        var pullImageFailed = logRecords.Any(logRecord => logRecord.Message.Contains("Cannot pull Compose service image"));
 
         // Then
         Assert.True(pullImageFailed, "Expected a warning about the image that cannot be pulled.");

--- a/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
@@ -67,6 +67,225 @@ public sealed class ComposeContainerTest : IAsyncLifetime
     }
 }
 
+public sealed class ComposeContainerScaledServiceTest : IAsyncLifetime
+{
+    private const string ServiceName = "web";
+
+    private const ushort ServicePort = 80;
+
+    private const ushort Instances = 2;
+
+    private readonly ComposeContainer _composeContainer;
+
+    public ComposeContainerScaledServiceTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Nginx.FullName}\"\n");
+
+        var composeBuilder = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WithScaledService(ServiceName, Instances);
+
+        // Each instance gets its own ambassador port, and each instance runs its own
+        // readiness check.
+        for (ushort instance = 1; instance <= Instances; instance++)
+        {
+            composeBuilder = composeBuilder.WithExposedServiceInstance(ServiceName, instance, ServicePort);
+        }
+
+        _composeContainer = composeBuilder.Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public void ResolvesEachServiceInstanceIndividually()
+    {
+        // Given
+        var containerIds = Enumerable.Range(1, Instances)
+            .Select(instance => _composeContainer.GetServiceInstanceContainer(ServiceName, (ushort)instance).Id)
+            .ToArray();
+
+        // When
+        var servicePorts = Enumerable.Range(1, Instances)
+            .Select(instance => _composeContainer.GetServiceInstancePort(ServiceName, (ushort)instance, ServicePort))
+            .ToArray();
+
+        // Then
+        Assert.Equal(Instances, containerIds.Distinct().Count());
+        Assert.Equal(Instances, servicePorts.Distinct().Count());
+    }
+
+    [Fact]
+    public void ResolvesServiceNameToFirstInstance()
+    {
+        // Given
+        var serviceInstanceContainer = _composeContainer.GetServiceInstanceContainer(ServiceName, 1);
+        var serviceInstancePort = _composeContainer.GetServiceInstancePort(ServiceName, 1, ServicePort);
+
+        // When
+        var serviceContainer = _composeContainer.GetServiceContainer(ServiceName);
+        var servicePort = _composeContainer.GetServicePort(ServiceName, ServicePort);
+
+        // Then
+        Assert.Equal(serviceInstanceContainer.Id, serviceContainer.Id);
+        Assert.Equal(serviceInstancePort, servicePort);
+    }
+
+    [Theory]
+    [InlineData((ushort)1)]
+    [InlineData((ushort)2)]
+    public async Task EstablishesConnectionToEachServiceInstance(ushort instance)
+    {
+        // Given
+        using var httpClient = new HttpClient();
+        httpClient.BaseAddress = new UriBuilder(Uri.UriSchemeHttp, _composeContainer.GetServiceInstanceHost(ServiceName, instance, ServicePort), _composeContainer.GetServiceInstancePort(ServiceName, instance, ServicePort)).Uri;
+
+        // When
+        using var httpResponse = await httpClient.GetAsync("/", TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
+    }
+}
+
+public sealed class ComposeContainerServiceNameWithInstanceSuffixTest : IAsyncLifetime
+{
+    // A Docker Compose service name may end with a dash and a number. It addresses
+    // the service that carries the name, not the second instance of a service that
+    // is named "web".
+    private const string ServiceName = "web-2";
+
+    private readonly ComposeContainer _composeContainer;
+
+    public ComposeContainerServiceNameWithInstanceSuffixTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"echo Ready; sleep infinity\"]\n");
+
+        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WaitingFor(ServiceName, Wait.ForUnixContainer().UntilMessageIsLogged("Ready"))
+            .Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public void ResolvesServiceNameThatEndsWithInstanceNumber()
+    {
+        // Given
+        var serviceContainer = _composeContainer.GetServiceContainer(ServiceName);
+
+        // When
+        var state = serviceContainer.State;
+
+        // Then
+        Assert.Equal(TestcontainersStates.Running, state);
+    }
+}
+
+public sealed class ComposeContainerServiceNotFoundTest
+{
+    [Fact]
+    public async Task ThrowsWhenWaitStrategyReferencesUnknownService()
+    {
+        // Given
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(composeFilePath, $"services:\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n");
+
+        await using var composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WaitingFor("aap", Wait.ForUnixContainer().UntilMessageIsLogged("Ready"))
+            .Build();
+
+        // When
+        var exception = await Assert.ThrowsAsync<ComposeServiceNotFoundException>(() => composeContainer.StartAsync(TestContext.Current.CancellationToken))
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Contains("'aap-1'", exception.Message);
+    }
+}
+
+public sealed class ComposeContainerWaitingForTest : IAsyncLifetime
+{
+    private readonly ComposeContainer _composeContainer;
+
+    public ComposeContainerWaitingForTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        // The service does not publish or expose a port. Its readiness is only
+        // observable through its log message.
+        File.WriteAllText(composeFilePath, $"services:\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep 1; echo Ready; sleep infinity\"]\n");
+
+        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .WaitingFor("app", Wait.ForUnixContainer().UntilMessageIsLogged("Ready"))
+            .Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task WaitsForServiceWithoutExposedPort()
+    {
+        // Given
+        var serviceContainer = _composeContainer.GetServiceContainer("app");
+
+        // When
+        var (stdout, _) = await serviceContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        // Then
+        Assert.Contains("Ready", stdout);
+        Assert.Throws<ComposeServiceNotExposedException>(() => _composeContainer.GetServicePort("app", 80));
+    }
+}
+
 public sealed class ComposeContainerExitedServiceTest
 {
     private static ComposeContainer BuildComposeContainer(int exitCode)
@@ -218,7 +437,7 @@ public sealed class ComposeContainerRelativeBindMountTest : IAsyncLifetime
     }
 }
 
-public sealed class ComposeContainerPathContainingPathSeparatorTest : IAsyncLifetime
+public sealed class ComposeContainerPathSeparatorTest : IAsyncLifetime
 {
     private const string ServiceName = "app";
 
@@ -229,7 +448,7 @@ public sealed class ComposeContainerPathContainingPathSeparatorTest : IAsyncLife
 
     private readonly ComposeContainer _composeContainer;
 
-    public ComposeContainerPathContainingPathSeparatorTest()
+    public ComposeContainerPathSeparatorTest()
     {
         var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D") + DirectoryNameSuffix)).FullName;
 
@@ -265,122 +484,6 @@ public sealed class ComposeContainerPathContainingPathSeparatorTest : IAsyncLife
 
         // Then
         Assert.Equal(TestcontainersStates.Running, state);
-    }
-}
-
-public sealed class ComposeContainerWaitingForTest : IAsyncLifetime
-{
-    private readonly ComposeContainer _composeContainer;
-
-    public ComposeContainerWaitingForTest()
-    {
-        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
-
-        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
-
-        // The service does not publish or expose a port. Its readiness is only
-        // observable through its log message.
-        File.WriteAllText(composeFilePath, $"services:\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep 1; echo Ready; sleep infinity\"]\n");
-
-        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
-            .WithComposeFile(composeFilePath)
-            .WaitingFor("app", Wait.ForUnixContainer().UntilMessageIsLogged("Ready"))
-            .Build();
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await _composeContainer.StartAsync()
-            .ConfigureAwait(false);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await _composeContainer.DisposeAsync()
-            .ConfigureAwait(false);
-    }
-
-    [Fact]
-    public async Task WaitsForServiceWithoutExposedPort()
-    {
-        // Given
-        var serviceContainer = _composeContainer.GetServiceContainer("app");
-
-        // When
-        var (stdout, _) = await serviceContainer.GetLogsAsync(ct: TestContext.Current.CancellationToken)
-            .ConfigureAwait(true);
-
-        // Then
-        Assert.Contains("Ready", stdout);
-        Assert.Throws<ComposeServiceNotExposedException>(() => _composeContainer.GetServicePort("app", 80));
-    }
-}
-
-public sealed class ComposeContainerServiceNameWithInstanceSuffixTest : IAsyncLifetime
-{
-    // A Docker Compose service name may end with a dash and a number. It addresses
-    // the service that carries the name, not the second instance of a service that
-    // is named "web".
-    private const string ServiceName = "web-2";
-
-    private readonly ComposeContainer _composeContainer;
-
-    public ComposeContainerServiceNameWithInstanceSuffixTest()
-    {
-        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
-
-        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
-
-        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"echo Ready; sleep infinity\"]\n");
-
-        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
-            .WithComposeFile(composeFilePath)
-            .WaitingFor(ServiceName, Wait.ForUnixContainer().UntilMessageIsLogged("Ready"))
-            .Build();
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await _composeContainer.StartAsync()
-            .ConfigureAwait(false);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await _composeContainer.DisposeAsync()
-            .ConfigureAwait(false);
-    }
-
-    [Fact]
-    public void ResolvesTheServiceNameThatEndsWithAnInstanceNumber()
-    {
-        Assert.Equal(TestcontainersStates.Running, _composeContainer.GetServiceContainer(ServiceName).State);
-    }
-}
-
-public sealed class ComposeContainerServiceNotFoundTest
-{
-    [Fact]
-    public async Task ThrowsWhenWaitStrategyReferencesUnknownService()
-    {
-        // Given
-        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
-
-        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
-
-        File.WriteAllText(composeFilePath, $"services:\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n");
-
-        await using var composeContainer = new ComposeBuilder(CommonImages.DockerCli)
-            .WithComposeFile(composeFilePath)
-            .WaitingFor("aap", Wait.ForUnixContainer().UntilMessageIsLogged("Ready"))
-            .Build();
-
-        // When
-        var exception = await Assert.ThrowsAsync<ComposeServiceNotFoundException>(() => composeContainer.StartAsync(TestContext.Current.CancellationToken))
-            .ConfigureAwait(true);
-
-        // Then
-        Assert.Contains("'aap-1'", exception.Message);
     }
 }
 
@@ -432,92 +535,5 @@ public sealed class ComposeContainerPullTest : IAsyncLifetime
         // Then
         Assert.True(pullImageFailed, "Expected a warning about the image that cannot be pulled.");
         Assert.Equal(TestcontainersStates.Running, _composeContainer.GetServiceContainer("app").State);
-    }
-}
-
-public sealed class ComposeContainerScaledServiceTest : IAsyncLifetime
-{
-    private const string ServiceName = "web";
-
-    private const ushort ServicePort = 80;
-
-    private const ushort Instances = 2;
-
-    private readonly ComposeContainer _composeContainer;
-
-    public ComposeContainerScaledServiceTest()
-    {
-        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
-
-        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
-
-        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Nginx.FullName}\"\n");
-
-        var composeBuilder = new ComposeBuilder(CommonImages.DockerCli)
-            .WithComposeFile(composeFilePath)
-            .WithScaledService(ServiceName, Instances);
-
-        // Each instance gets its own ambassador port, and each instance runs its own
-        // readiness check.
-        for (ushort instance = 1; instance <= Instances; instance++)
-        {
-            composeBuilder = composeBuilder.WithExposedServiceInstance(ServiceName, instance, ServicePort);
-        }
-
-        _composeContainer = composeBuilder.Build();
-    }
-
-    public async ValueTask InitializeAsync()
-    {
-        await _composeContainer.StartAsync()
-            .ConfigureAwait(false);
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        await _composeContainer.DisposeAsync()
-            .ConfigureAwait(false);
-    }
-
-    [Fact]
-    public void ResolvesEachServiceInstanceIndividually()
-    {
-        // Given
-        var containerIds = Enumerable.Range(1, Instances)
-            .Select(instance => _composeContainer.GetServiceInstanceContainer(ServiceName, (ushort)instance).Id)
-            .ToArray();
-
-        // When
-        var servicePorts = Enumerable.Range(1, Instances)
-            .Select(instance => _composeContainer.GetServiceInstancePort(ServiceName, (ushort)instance, ServicePort))
-            .ToArray();
-
-        // Then
-        Assert.Equal(Instances, containerIds.Distinct().Count());
-        Assert.Equal(Instances, servicePorts.Distinct().Count());
-    }
-
-    [Fact]
-    public void ResolvesTheServiceNameToTheFirstInstance()
-    {
-        Assert.Equal(_composeContainer.GetServiceInstanceContainer(ServiceName, 1).Id, _composeContainer.GetServiceContainer(ServiceName).Id);
-        Assert.Equal(_composeContainer.GetServiceInstancePort(ServiceName, 1, ServicePort), _composeContainer.GetServicePort(ServiceName, ServicePort));
-    }
-
-    [Theory]
-    [InlineData((ushort)1)]
-    [InlineData((ushort)2)]
-    public async Task EstablishesConnectionToEachServiceInstance(ushort instance)
-    {
-        // Given
-        using var httpClient = new HttpClient();
-        httpClient.BaseAddress = new UriBuilder(Uri.UriSchemeHttp, _composeContainer.GetServiceInstanceHost(ServiceName, instance, ServicePort), _composeContainer.GetServiceInstancePort(ServiceName, instance, ServicePort)).Uri;
-
-        // When
-        using var httpResponse = await httpClient.GetAsync("/", TestContext.Current.CancellationToken)
-            .ConfigureAwait(true);
-
-        // Then
-        Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
     }
 }

--- a/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
@@ -16,7 +16,13 @@ public sealed class ComposeContainerTest : IAsyncLifetime
 
         // The service publishes its port to a random host port to cover the readiness
         // check that waits until the port bindings are mapped.
-        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Nginx.FullName}\"\n    ports:\n      - \"{ServicePort}\"\n");
+        File.WriteAllText(composeFilePath, $"""
+            services:
+              {ServiceName}:
+                image: "{CommonImages.Nginx.FullName}"
+                ports:
+                  - "{ServicePort}"
+            """);
 
         _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
             .WithComposeFile(composeFilePath)
@@ -83,7 +89,11 @@ public sealed class ComposeContainerScaledServiceTest : IAsyncLifetime
 
         var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
 
-        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Nginx.FullName}\"\n");
+        File.WriteAllText(composeFilePath, $"""
+            services:
+              {ServiceName}:
+                image: "{CommonImages.Nginx.FullName}"
+            """);
 
         var composeBuilder = new ComposeBuilder(CommonImages.DockerCli)
             .WithComposeFile(composeFilePath)
@@ -174,7 +184,12 @@ public sealed class ComposeContainerServiceNameWithInstanceSuffixTest : IAsyncLi
 
         var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
 
-        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"echo Ready; sleep infinity\"]\n");
+        File.WriteAllText(composeFilePath, $"""
+            services:
+              {ServiceName}:
+                image: "{CommonImages.Alpine.FullName}"
+                command: ["/bin/sh", "-c", "echo Ready; sleep infinity"]
+            """);
 
         _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
             .WithComposeFile(composeFilePath)
@@ -218,7 +233,12 @@ public sealed class ComposeContainerServiceNotFoundTest
 
         var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
 
-        File.WriteAllText(composeFilePath, $"services:\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n");
+        File.WriteAllText(composeFilePath, $"""
+            services:
+              app:
+                image: "{CommonImages.Alpine.FullName}"
+                command: ["/bin/sh", "-c", "sleep infinity"]
+            """);
 
         await using var composeContainer = new ComposeBuilder(CommonImages.DockerCli)
             .WithComposeFile(composeFilePath)
@@ -246,7 +266,12 @@ public sealed class ComposeContainerWaitingForTest : IAsyncLifetime
 
         // The service does not publish or expose a port. Its readiness is only
         // observable through its log message.
-        File.WriteAllText(composeFilePath, $"services:\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep 1; echo Ready; sleep infinity\"]\n");
+        File.WriteAllText(composeFilePath, $"""
+            services:
+              app:
+                image: "{CommonImages.Alpine.FullName}"
+                command: ["/bin/sh", "-c", "sleep 1; echo Ready; sleep infinity"]
+            """);
 
         _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
             .WithComposeFile(composeFilePath)
@@ -293,7 +318,18 @@ public sealed class ComposeContainerExitedServiceTest
         // The app service depends on the completion of the migration service. Docker
         // Compose does not wait for a service that no other service depends on. It
         // returns before a service that exits immediately has exited.
-        File.WriteAllText(composeFilePath, $"services:\n  migration:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"exit {exitCode}\"]\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n    depends_on:\n      migration:\n        condition: service_completed_successfully\n");
+        File.WriteAllText(composeFilePath, $"""
+            services:
+              migration:
+                image: "{CommonImages.Alpine.FullName}"
+                command: ["/bin/sh", "-c", "exit {exitCode}"]
+              app:
+                image: "{CommonImages.Alpine.FullName}"
+                command: ["/bin/sh", "-c", "sleep infinity"]
+                depends_on:
+                  migration:
+                    condition: service_completed_successfully
+            """);
 
         return new ComposeBuilder(CommonImages.DockerCli)
             .WithComposeFile(composeFilePath)
@@ -308,7 +344,23 @@ public sealed class ComposeContainerExitedServiceTest
 
         // The app service depends on the completion of both services. Docker Compose
         // starts them at the same time, which lets both of them fail.
-        File.WriteAllText(composeFilePath, $"services:\n  migration:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"exit {migrationExitCode}\"]\n  seeding:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"exit {seedingExitCode}\"]\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n    depends_on:\n      migration:\n        condition: service_completed_successfully\n      seeding:\n        condition: service_completed_successfully\n");
+        File.WriteAllText(composeFilePath, $"""
+            services:
+              migration:
+                image: "{CommonImages.Alpine.FullName}"
+                command: ["/bin/sh", "-c", "exit {migrationExitCode}"]
+              seeding:
+                image: "{CommonImages.Alpine.FullName}"
+                command: ["/bin/sh", "-c", "exit {seedingExitCode}"]
+              app:
+                image: "{CommonImages.Alpine.FullName}"
+                command: ["/bin/sh", "-c", "sleep infinity"]
+                depends_on:
+                  migration:
+                    condition: service_completed_successfully
+                  seeding:
+                    condition: service_completed_successfully
+            """);
 
         return new ComposeBuilder(CommonImages.DockerCli)
             .WithComposeFile(composeFilePath)
@@ -373,7 +425,12 @@ public sealed class ComposeContainerFileCopyInclusionTest : IAsyncLifetime
 
         var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
 
-        File.WriteAllText(composeFilePath, $"services:\n  migration:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"exit 0\"]\n");
+        File.WriteAllText(composeFilePath, $"""
+            services:
+              migration:
+                image: "{CommonImages.Alpine.FullName}"
+                command: ["/bin/sh", "-c", "exit 0"]
+            """);
 
         _ = Directory.CreateDirectory(Path.Combine(composeFileDirectoryPath, "included"));
         File.WriteAllText(Path.Combine(composeFileDirectoryPath, "included", "included-nested.txt"), string.Empty);
@@ -435,7 +492,14 @@ public sealed class ComposeContainerRelativeBindMountTest : IAsyncLifetime
 
         var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
 
-        File.WriteAllText(composeFilePath, $"services:\n  app:\n    image: \"{CommonImages.Alpine.FullName}\"\n    volumes:\n      - \"./data:/data\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n");
+        File.WriteAllText(composeFilePath, $"""
+            services:
+              app:
+                image: "{CommonImages.Alpine.FullName}"
+                volumes:
+                  - "./data:/data"
+                command: ["/bin/sh", "-c", "sleep infinity"]
+            """);
 
         _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
             .WithComposeFile(composeFilePath)
@@ -486,7 +550,12 @@ public sealed class ComposeContainerPathSeparatorTest : IAsyncLifetime
 
         var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
 
-        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n");
+        File.WriteAllText(composeFilePath, $"""
+            services:
+              {ServiceName}:
+                image: "{CommonImages.Alpine.FullName}"
+                command: ["/bin/sh", "-c", "sleep infinity"]
+            """);
 
         _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
             .WithComposeFile(composeFilePath)
@@ -529,13 +598,20 @@ public sealed class ComposeContainerPullTest : IAsyncLifetime
     {
         var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"))).FullName;
 
-        File.WriteAllText(Path.Combine(composeFileDirectoryPath, "Dockerfile"), $"FROM {CommonImages.Alpine.FullName}\nCMD [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n");
-
         var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(Path.Combine(composeFileDirectoryPath, "Dockerfile"), $"""
+            FROM {CommonImages.Alpine.FullName}
+            CMD ["/bin/sh", "-c", "sleep infinity"]
+            """);
 
         // Docker Compose builds the image of this service. It does not exist in a
         // registry, so pulling it fails. That must not fail the start.
-        File.WriteAllText(composeFilePath, "services:\n  app:\n    build: \".\"\n");
+        File.WriteAllText(composeFilePath, """
+            services:
+              app:
+                build: "."
+            """);
 
         _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
             .WithComposeFile(composeFilePath)

--- a/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
+++ b/tests/Testcontainers.Platform.Linux.Tests/ComposeContainerTest.cs
@@ -218,6 +218,56 @@ public sealed class ComposeContainerRelativeBindMountTest : IAsyncLifetime
     }
 }
 
+public sealed class ComposeContainerPathContainingPathSeparatorTest : IAsyncLifetime
+{
+    private const string ServiceName = "app";
+
+    // A colon is a valid character in a Unix path, but it is the default path
+    // separator that Docker Compose splits COMPOSE_FILE on. Windows does not allow
+    // it in a path, there a Docker Compose file path cannot contain it.
+    private static readonly string DirectoryNameSuffix = OperatingSystem.IsWindows() ? string.Empty : ":1";
+
+    private readonly ComposeContainer _composeContainer;
+
+    public ComposeContainerPathContainingPathSeparatorTest()
+    {
+        var composeFileDirectoryPath = Directory.CreateDirectory(Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D") + DirectoryNameSuffix)).FullName;
+
+        var composeFilePath = Path.Combine(composeFileDirectoryPath, "compose.yml");
+
+        File.WriteAllText(composeFilePath, $"services:\n  {ServiceName}:\n    image: \"{CommonImages.Alpine.FullName}\"\n    command: [\"/bin/sh\", \"-c\", \"sleep infinity\"]\n");
+
+        _composeContainer = new ComposeBuilder(CommonImages.DockerCli)
+            .WithComposeFile(composeFilePath)
+            .Build();
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await _composeContainer.StartAsync()
+            .ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _composeContainer.DisposeAsync()
+            .ConfigureAwait(false);
+    }
+
+    [Fact]
+    public void StartsWhenComposeFilePathContainsPathSeparator()
+    {
+        // Given
+        var serviceContainer = _composeContainer.GetServiceContainer(ServiceName);
+
+        // When
+        var state = serviceContainer.State;
+
+        // Then
+        Assert.Equal(TestcontainersStates.Running, state);
+    }
+}
+
 public sealed class ComposeContainerWaitingForTest : IAsyncLifetime
 {
     private readonly ComposeContainer _composeContainer;

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerTlsFixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/DockerTlsFixture.cs
@@ -2,13 +2,14 @@ namespace DotNet.Testcontainers.Tests.Fixtures
 {
   using System.Collections.Generic;
   using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Commons;
   using JetBrains.Annotations;
 
   [UsedImplicitly]
   public sealed class DockerTlsFixture : ProtectDockerDaemonSocket
   {
     public DockerTlsFixture()
-      : base(new ContainerBuilder("docker:29.0.0-dind")
+      : base(new ContainerBuilder(CommonImages.DockerDind)
         .WithCommand("--tlsverify=false"))
     {
     }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/OpenSsl1_1_1Fixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/OpenSsl1_1_1Fixture.cs
@@ -5,7 +5,8 @@ namespace DotNet.Testcontainers.Tests.Fixtures
   [UsedImplicitly]
   public sealed class OpenSsl1_1_1Fixture : DockerMTls
   {
-    public OpenSsl1_1_1Fixture() : base("20.10.18")
+    public OpenSsl1_1_1Fixture()
+      : base("20.10.18")
     {
     }
   }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/OpenSsl3_1Fixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/OpenSsl3_1Fixture.cs
@@ -6,7 +6,7 @@ namespace DotNet.Testcontainers.Tests.Fixtures
   public sealed class OpenSsl3_1Fixture : DockerMTls
   {
     public OpenSsl3_1Fixture()
-      : base("29.7")
+      : base("29.7.2")
     {
     }
   }

--- a/tests/Testcontainers.Tests/Fixtures/Containers/Unix/OpenSsl3_1Fixture.cs
+++ b/tests/Testcontainers.Tests/Fixtures/Containers/Unix/OpenSsl3_1Fixture.cs
@@ -5,7 +5,8 @@ namespace DotNet.Testcontainers.Tests.Fixtures
   [UsedImplicitly]
   public sealed class OpenSsl3_1Fixture : DockerMTls
   {
-    public OpenSsl3_1Fixture() : base("29.0.0")
+    public OpenSsl3_1Fixture()
+      : base("29.7")
     {
     }
   }

--- a/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
@@ -17,6 +17,14 @@ namespace DotNet.Testcontainers.Tests.Unit
       File.WriteAllText(ComposeFilePath, "services:\n  web:\n    image: \"" + CommonImages.Nginx.FullName + "\"\n");
     }
 
+    public static bool IsNotWindows
+    {
+      get
+      {
+        return !OperatingSystem.IsWindows();
+      }
+    }
+
     [Fact]
     public void ShouldThrowArgumentExceptionWhenComposeFileIsNotSet()
     {
@@ -67,6 +75,20 @@ namespace DotNet.Testcontainers.Tests.Unit
       File.Copy(ComposeFilePath, composeFilePath);
 
       _ = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath, composeFilePath).Build();
+    }
+
+    [Fact(SkipUnless = nameof(IsNotWindows), Skip = "A Windows path cannot contain the path separator characters.")]
+    public void ShouldThrowArgumentExceptionWhenComposeFilePathContainsEveryPathSeparator()
+    {
+      // Docker Compose separates the Docker Compose file paths in COMPOSE_FILE with a
+      // path separator character. A path that contains every supported separator
+      // cannot be passed to Docker Compose.
+      var composeFilePath = Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D") + ":;|,", Path.GetFileName(ComposeFilePath));
+      _ = Directory.CreateDirectory(Path.GetDirectoryName(composeFilePath)!);
+      File.Copy(ComposeFilePath, composeFilePath);
+
+      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(composeFilePath).Build());
+      Assert.StartsWith("The Docker Compose file paths contain every supported path separator character", exception.Message);
     }
 
     [Fact]

--- a/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
@@ -115,7 +115,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var exception = Assert.Throws<ArgumentException>(composeBuilder.Build);
 
       // Then
-      Assert.StartsWith("The Docker Compose project name prefix", exception.Message);
+      Assert.StartsWith("The Docker Compose project name prefix must start with", exception.Message);
     }
 
     [Fact]
@@ -129,7 +129,7 @@ namespace DotNet.Testcontainers.Tests.Unit
       var exception = Assert.Throws<ArgumentException>(composeBuilder.Build);
 
       // Then
-      Assert.StartsWith("The Docker Compose project name prefix", exception.Message);
+      Assert.StartsWith("The Docker Compose project name prefix must not exceed", exception.Message);
     }
 
     [Fact]

--- a/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
@@ -1,0 +1,85 @@
+namespace DotNet.Testcontainers.Tests.Unit
+{
+  using System;
+  using System.IO;
+  using DotNet.Testcontainers.Builders;
+  using DotNet.Testcontainers.Commons;
+  using DotNet.Testcontainers.Containers;
+  using Xunit;
+
+  public sealed class ComposeBuilderTest
+  {
+    private static readonly string ComposeFilePath = Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"), "compose.yml");
+
+    static ComposeBuilderTest()
+    {
+      _ = Directory.CreateDirectory(Path.GetDirectoryName(ComposeFilePath)!);
+      File.WriteAllText(ComposeFilePath, "services:\n  web:\n    image: \"" + CommonImages.Nginx.FullName + "\"\n");
+    }
+
+    [Fact]
+    public void ShouldThrowArgumentExceptionWhenComposeFileIsNotSet()
+    {
+      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).Build());
+      Assert.StartsWith("Missing Docker Compose file.", exception.Message);
+    }
+
+    [Fact]
+    public void ShouldThrowFileNotFoundExceptionWhenComposeFileDoesNotExist()
+    {
+      Assert.Throws<FileNotFoundException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(Path.Combine(TestSession.TempDirectoryPath, "not-found.yml")).Build());
+    }
+
+    [Theory]
+    [InlineData("-invalid")]
+    [InlineData("_invalid")]
+    [InlineData("Invalid")]
+    [InlineData("invalid name")]
+    public void ShouldThrowArgumentExceptionWhenProjectNamePrefixIsInvalid(string projectNamePrefix)
+    {
+      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix).Build());
+      Assert.StartsWith("The Docker Compose project name prefix", exception.Message);
+    }
+
+    [Fact]
+    public void ShouldThrowArgumentExceptionWhenReuseIsEnabled()
+    {
+      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithReuse(true).Build());
+      Assert.StartsWith("Reuse is not supported", exception.Message);
+    }
+
+    [Fact]
+    public void ShouldAppendRandomSuffixToProjectNamePrefix()
+    {
+      const string projectNamePrefix = "unit-test";
+      var composeContainer = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix).Build();
+      Assert.StartsWith(projectNamePrefix + "-", composeContainer.ProjectName);
+      Assert.NotEqual(projectNamePrefix, composeContainer.ProjectName);
+    }
+
+    [Fact]
+    public void ShouldBuildWhenComposeFilesInDifferentDirectoriesShareTheirName()
+    {
+      // The Docker Compose files keep the path they have on the test host, which
+      // allows Docker Compose files to share their name.
+      var composeFilePath = Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"), Path.GetFileName(ComposeFilePath));
+      _ = Directory.CreateDirectory(Path.GetDirectoryName(composeFilePath)!);
+      File.Copy(ComposeFilePath, composeFilePath);
+
+      _ = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath, composeFilePath).Build();
+    }
+
+    [Fact]
+    public void ShouldThrowFileNotFoundExceptionWhenFileCopyInclusionDoesNotExist()
+    {
+      Assert.Throws<FileNotFoundException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithCopyFilesInContainer("not-found.txt").Build());
+    }
+
+    [Fact]
+    public void ShouldThrowComposeServiceNotExposedExceptionWhenServiceIsNotExposed()
+    {
+      var composeContainer = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).Build();
+      Assert.Throws<ComposeServiceNotExposedException>(() => composeContainer.GetServicePort("web", 80));
+    }
+  }
+}

--- a/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
@@ -13,8 +13,13 @@ namespace DotNet.Testcontainers.Tests.Unit
 
     static ComposeBuilderTest()
     {
-      _ = Directory.CreateDirectory(Path.GetDirectoryName(ComposeFilePath)!);
-      File.WriteAllText(ComposeFilePath, "services:\n  web:\n    image: \"" + CommonImages.Nginx.FullName + "\"\n");
+      _ = Directory.CreateDirectory(Path.GetDirectoryName(ComposeFilePath));
+
+      File.WriteAllText(ComposeFilePath, $"""
+        services:
+          web:
+            image: "{CommonImages.Nginx.FullName}"
+        """);
     }
 
     public static bool IsNotWindows
@@ -32,7 +37,8 @@ namespace DotNet.Testcontainers.Tests.Unit
       // The Docker Compose files keep the path they have on the test host,
       // which allows Docker Compose files to share their name.
       var composeFilePath = Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"), Path.GetFileName(ComposeFilePath));
-      _ = Directory.CreateDirectory(Path.GetDirectoryName(composeFilePath)!);
+
+      _ = Directory.CreateDirectory(Path.GetDirectoryName(composeFilePath));
       File.Copy(ComposeFilePath, composeFilePath);
 
       // When
@@ -69,7 +75,8 @@ namespace DotNet.Testcontainers.Tests.Unit
       // path separator character. A path that contains every supported separator
       // cannot be passed to Docker Compose.
       var composeFilePath = Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D") + ":;|,", Path.GetFileName(ComposeFilePath));
-      _ = Directory.CreateDirectory(Path.GetDirectoryName(composeFilePath)!);
+
+      _ = Directory.CreateDirectory(Path.GetDirectoryName(composeFilePath));
       File.Copy(ComposeFilePath, composeFilePath);
 
       var composeBuilder = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(composeFilePath);

--- a/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
@@ -28,19 +28,30 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public void BuildsWhenComposeFilesInDifferentDirectoriesShareTheirName()
     {
-      // The Docker Compose files keep the path they have on the test host, which
-      // allows Docker Compose files to share their name.
+      // Given
+      // The Docker Compose files keep the path they have on the test host,
+      // which allows Docker Compose files to share their name.
       var composeFilePath = Path.Combine(TestSession.TempDirectoryPath, Guid.NewGuid().ToString("D"), Path.GetFileName(ComposeFilePath));
       _ = Directory.CreateDirectory(Path.GetDirectoryName(composeFilePath)!);
       File.Copy(ComposeFilePath, composeFilePath);
 
-      _ = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath, composeFilePath).Build();
+      // When
+      var exception = Record.Exception(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath, composeFilePath).Build());
+
+      // Then
+      Assert.Null(exception);
     }
 
     [Fact]
     public void ThrowsArgumentExceptionWhenComposeFileIsNotSet()
     {
-      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).Build());
+      // Given
+      var composeBuilder = new ComposeBuilder(CommonImages.DockerCli);
+
+      // When
+      var exception = Assert.Throws<ArgumentException>(composeBuilder.Build);
+
+      // Then
       Assert.StartsWith("At least one Docker Compose file must be set.", exception.Message);
     }
 
@@ -53,6 +64,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact(SkipUnless = nameof(IsNotWindows), Skip = "A Windows path cannot contain the path separator characters.")]
     public void ThrowsArgumentExceptionWhenComposeFilePathContainsEveryPathSeparator()
     {
+      // Given
       // Docker Compose separates the Docker Compose file paths in COMPOSE_FILE with a
       // path separator character. A path that contains every supported separator
       // cannot be passed to Docker Compose.
@@ -60,7 +72,12 @@ namespace DotNet.Testcontainers.Tests.Unit
       _ = Directory.CreateDirectory(Path.GetDirectoryName(composeFilePath)!);
       File.Copy(ComposeFilePath, composeFilePath);
 
-      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(composeFilePath).Build());
+      var composeBuilder = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(composeFilePath);
+
+      // When
+      var exception = Assert.Throws<ArgumentException>(composeBuilder.Build);
+
+      // Then
       Assert.StartsWith("The Docker Compose file paths contain every supported path separator character", exception.Message);
     }
 
@@ -73,8 +90,13 @@ namespace DotNet.Testcontainers.Tests.Unit
     [Fact]
     public void AppendsRandomSuffixToProjectNamePrefix()
     {
+      // Given
       const string projectNamePrefix = "unit-test";
+
+      // When
       var composeContainer = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix).Build();
+
+      // Then
       Assert.StartsWith(projectNamePrefix + "-", composeContainer.ProjectName);
       Assert.NotEqual(projectNamePrefix, composeContainer.ProjectName);
     }
@@ -86,30 +108,54 @@ namespace DotNet.Testcontainers.Tests.Unit
     [InlineData("invalid name")]
     public void ThrowsArgumentExceptionWhenProjectNamePrefixIsInvalid(string projectNamePrefix)
     {
-      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix).Build());
+      // Given
+      var composeBuilder = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix);
+
+      // When
+      var exception = Assert.Throws<ArgumentException>(composeBuilder.Build);
+
+      // Then
       Assert.StartsWith("The Docker Compose project name prefix", exception.Message);
     }
 
     [Fact]
     public void ThrowsArgumentExceptionWhenProjectNamePrefixIsTooLong()
     {
+      // Given
       var projectNamePrefix = new string('a', 55);
-      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix).Build());
+      var composeBuilder = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix);
+
+      // When
+      var exception = Assert.Throws<ArgumentException>(composeBuilder.Build);
+
+      // Then
       Assert.StartsWith("The Docker Compose project name prefix", exception.Message);
     }
 
     [Fact]
     public void ThrowsArgumentExceptionWhenReuseIsEnabled()
     {
-      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithReuse(true).Build());
+      // Given
+      var composeBuilder = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithReuse(true);
+
+      // When
+      var exception = Assert.Throws<ArgumentException>(composeBuilder.Build);
+
+      // Then
       Assert.StartsWith("Reuse cannot be used", exception.Message);
     }
 
     [Fact]
     public void ThrowsComposeServiceNotExposedExceptionWhenServiceIsNotExposed()
     {
+      // Given
       var composeContainer = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).Build();
-      Assert.Throws<ComposeServiceNotExposedException>(() => composeContainer.GetServicePort("web", 80));
+
+      // When
+      var exception = Assert.Throws<ComposeServiceNotExposedException>(() => composeContainer.GetServicePort("web", 80));
+
+      // Then
+      Assert.Contains("'web-1'", exception.Message);
     }
   }
 }

--- a/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
@@ -91,6 +91,14 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [Fact]
+    public void ThrowsArgumentExceptionWhenProjectNamePrefixIsTooLong()
+    {
+      var projectNamePrefix = new string('a', 55);
+      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix).Build());
+      Assert.StartsWith("The Docker Compose project name prefix", exception.Message);
+    }
+
+    [Fact]
     public void ThrowsArgumentExceptionWhenReuseIsEnabled()
     {
       var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithReuse(true).Build());

--- a/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
+++ b/tests/Testcontainers.Tests/Unit/Builders/ComposeBuilderTest.cs
@@ -26,47 +26,7 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [Fact]
-    public void ShouldThrowArgumentExceptionWhenComposeFileIsNotSet()
-    {
-      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).Build());
-      Assert.StartsWith("Missing Docker Compose file.", exception.Message);
-    }
-
-    [Fact]
-    public void ShouldThrowFileNotFoundExceptionWhenComposeFileDoesNotExist()
-    {
-      Assert.Throws<FileNotFoundException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(Path.Combine(TestSession.TempDirectoryPath, "not-found.yml")).Build());
-    }
-
-    [Theory]
-    [InlineData("-invalid")]
-    [InlineData("_invalid")]
-    [InlineData("Invalid")]
-    [InlineData("invalid name")]
-    public void ShouldThrowArgumentExceptionWhenProjectNamePrefixIsInvalid(string projectNamePrefix)
-    {
-      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix).Build());
-      Assert.StartsWith("The Docker Compose project name prefix", exception.Message);
-    }
-
-    [Fact]
-    public void ShouldThrowArgumentExceptionWhenReuseIsEnabled()
-    {
-      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithReuse(true).Build());
-      Assert.StartsWith("Reuse is not supported", exception.Message);
-    }
-
-    [Fact]
-    public void ShouldAppendRandomSuffixToProjectNamePrefix()
-    {
-      const string projectNamePrefix = "unit-test";
-      var composeContainer = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix).Build();
-      Assert.StartsWith(projectNamePrefix + "-", composeContainer.ProjectName);
-      Assert.NotEqual(projectNamePrefix, composeContainer.ProjectName);
-    }
-
-    [Fact]
-    public void ShouldBuildWhenComposeFilesInDifferentDirectoriesShareTheirName()
+    public void BuildsWhenComposeFilesInDifferentDirectoriesShareTheirName()
     {
       // The Docker Compose files keep the path they have on the test host, which
       // allows Docker Compose files to share their name.
@@ -77,8 +37,21 @@ namespace DotNet.Testcontainers.Tests.Unit
       _ = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath, composeFilePath).Build();
     }
 
+    [Fact]
+    public void ThrowsArgumentExceptionWhenComposeFileIsNotSet()
+    {
+      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).Build());
+      Assert.StartsWith("At least one Docker Compose file must be set.", exception.Message);
+    }
+
+    [Fact]
+    public void ThrowsFileNotFoundExceptionWhenComposeFileDoesNotExist()
+    {
+      Assert.Throws<FileNotFoundException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(Path.Combine(TestSession.TempDirectoryPath, "not-found.yml")).Build());
+    }
+
     [Fact(SkipUnless = nameof(IsNotWindows), Skip = "A Windows path cannot contain the path separator characters.")]
-    public void ShouldThrowArgumentExceptionWhenComposeFilePathContainsEveryPathSeparator()
+    public void ThrowsArgumentExceptionWhenComposeFilePathContainsEveryPathSeparator()
     {
       // Docker Compose separates the Docker Compose file paths in COMPOSE_FILE with a
       // path separator character. A path that contains every supported separator
@@ -92,13 +65,40 @@ namespace DotNet.Testcontainers.Tests.Unit
     }
 
     [Fact]
-    public void ShouldThrowFileNotFoundExceptionWhenFileCopyInclusionDoesNotExist()
+    public void ThrowsFileNotFoundExceptionWhenFileCopyInclusionDoesNotExist()
     {
       Assert.Throws<FileNotFoundException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithCopyFilesInContainer("not-found.txt").Build());
     }
 
     [Fact]
-    public void ShouldThrowComposeServiceNotExposedExceptionWhenServiceIsNotExposed()
+    public void AppendsRandomSuffixToProjectNamePrefix()
+    {
+      const string projectNamePrefix = "unit-test";
+      var composeContainer = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix).Build();
+      Assert.StartsWith(projectNamePrefix + "-", composeContainer.ProjectName);
+      Assert.NotEqual(projectNamePrefix, composeContainer.ProjectName);
+    }
+
+    [Theory]
+    [InlineData("-invalid")]
+    [InlineData("_invalid")]
+    [InlineData("Invalid")]
+    [InlineData("invalid name")]
+    public void ThrowsArgumentExceptionWhenProjectNamePrefixIsInvalid(string projectNamePrefix)
+    {
+      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithProjectNamePrefix(projectNamePrefix).Build());
+      Assert.StartsWith("The Docker Compose project name prefix", exception.Message);
+    }
+
+    [Fact]
+    public void ThrowsArgumentExceptionWhenReuseIsEnabled()
+    {
+      var exception = Assert.Throws<ArgumentException>(() => new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).WithReuse(true).Build());
+      Assert.StartsWith("Reuse cannot be used", exception.Message);
+    }
+
+    [Fact]
+    public void ThrowsComposeServiceNotExposedExceptionWhenServiceIsNotExposed()
     {
       var composeContainer = new ComposeBuilder(CommonImages.DockerCli).WithComposeFile(ComposeFilePath).Build();
       Assert.Throws<ComposeServiceNotExposedException>(() => composeContainer.GetServicePort("web", 80));


### PR DESCRIPTION
## What does this PR do?

The PR adds `ComposeBuilder` and `ComposeContainer` to run Docker Compose projects. The Docker Compose CLI runs inside a container with the Docker socket mounted, so no Docker Compose installation is required on the test host. The compose files are copied into the container and `up` / `down` run via exec.

## Why is it important?

Docker Compose support is a long-standing request. It lets tests reuse an existing compose file instead of duplicating the setup in code, while keeping wait strategies and dynamic port resolution.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #122

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->

## TODOs

- [x] Add docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Docker Compose support for defining, starting, scaling, and managing services in containerized test environments.
  * Added configuration for Compose files, project naming, file copying, image pulling, exposed ports, and readiness checks.
  * Added access to service hosts, ports, instances, logs, and containers.
  * Added public image-pulling support through the Testcontainers client.
* **Bug Fixes**
  * Added clearer errors when services or ports are unavailable.
  * Improved cleanup retry behavior when Compose shutdown fails.
* **Documentation**
  * Added Docker Compose usage guidance and examples.
* **Tests**
  * Added comprehensive Compose lifecycle and validation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->