### PR TITLE
chore: Resolve Sonar findings

### DIFF
--- a/src/Testcontainers/Builders/ComposeBuilder.cs
+++ b/src/Testcontainers/Builders/ComposeBuilder.cs
@@ -503,7 +503,7 @@ namespace DotNet.Testcontainers.Builders
       // understands, e.g. C:/Users/Default to /c/Users/Default.
       if (containerPath.Length > 1 && char.IsLetter(containerPath[0]) && ':'.Equals(containerPath[1]))
       {
-        containerPath = "/" + char.ToLowerInvariant(containerPath[0]) + containerPath.Substring(2);
+        containerPath = $"{Path.AltDirectorySeparatorChar}{char.ToLowerInvariant(containerPath[0])}{containerPath.Substring(2)}";
       }
 
       return containerPath;

--- a/src/Testcontainers/Clients/RetryStrategy.cs
+++ b/src/Testcontainers/Clients/RetryStrategy.cs
@@ -83,7 +83,9 @@ namespace DotNet.Testcontainers.Clients
     /// <returns>A task that represents the asynchronous execute operation.</returns>
     public async Task ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken ct = default)
     {
-      for (var attempt = 1; ; attempt++)
+      var attempt = 1;
+
+      while (true)
       {
         ct.ThrowIfCancellationRequested();
 
@@ -102,6 +104,8 @@ namespace DotNet.Testcontainers.Clients
 
           await DelayAsync(delay, ct)
             .ConfigureAwait(false);
+
+          attempt++;
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?

Replace the hard-coded forward slash in `ComposeBuilder.GetContainerPath(string)` with `Path.AltDirectorySeparatorChar`, and rewrite RetryStrategy's retry loop as a while loop so the attempt counter is incremented where the retry happens instead of in an empty-condition for loop.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of Windows-style container paths for more consistent path processing across environments.
  * Streamlined retry-attempt processing while preserving existing retry behavior, delay calculations, cancellation support, and error handling.
  * No user-facing behavior changes are expected; these updates improve internal consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->