### PR TITLE
fix(GCloud): Bump test image version

### DIFF
--- a/tests/Testcontainers.Bigtable.Tests/Dockerfile
+++ b/tests/Testcontainers.Bigtable.Tests/Dockerfile
@@ -1,1 +1,1 @@
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:446.0.1-emulators@sha256:7d2e60f14bb184c85bfce5f857cc7a23a0c4ab8b94e3e79007a6bb384f2d3cb3
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators@sha256:d343049a5b3fc0c880a51412ba0c53a3f6a3fc727978cef52931ea5f6fda5b9f

--- a/tests/Testcontainers.Firestore.Tests/Dockerfile
+++ b/tests/Testcontainers.Firestore.Tests/Dockerfile
@@ -1,1 +1,1 @@
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:446.0.1-emulators@sha256:7d2e60f14bb184c85bfce5f857cc7a23a0c4ab8b94e3e79007a6bb384f2d3cb3
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators@sha256:d343049a5b3fc0c880a51412ba0c53a3f6a3fc727978cef52931ea5f6fda5b9f

--- a/tests/Testcontainers.PubSub.Tests/Dockerfile
+++ b/tests/Testcontainers.PubSub.Tests/Dockerfile
@@ -1,1 +1,1 @@
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:446.0.1-emulators@sha256:7d2e60f14bb184c85bfce5f857cc7a23a0c4ab8b94e3e79007a6bb384f2d3cb3
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators@sha256:d343049a5b3fc0c880a51412ba0c53a3f6a3fc727978cef52931ea5f6fda5b9f


### PR DESCRIPTION
## What does this PR do?

This PR bumps the `google-cloud-cli` image version used in our tests. It looks like the previous version is no longer available, as neither CI nor local environments can pull it.

## Why is it important?

\-

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Google Cloud emulator environment used by Bigtable, Firestore, and Pub/Sub tests.
  * Improved test environment consistency and reliability with refreshed container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->