### PR TITLE
fix: Detach from the container output before stopping or removing it

### DIFF
--- a/src/Testcontainers/Builders/Consume.cs
+++ b/src/Testcontainers/Builders/Consume.cs
@@ -31,8 +31,13 @@ namespace DotNet.Testcontainers.Builders
     }
 
     /// <summary>
-    /// Redirects the output of the Testcontainer to the given streams..
+    /// Redirects the output of the Testcontainer to the given streams.
     /// </summary>
+    /// <remarks>
+    /// The output consumer takes ownership of the streams and closes them when
+    /// it is disposed. Dispose it only after the containers that write to it
+    /// have stopped, otherwise their remaining output is lost.
+    /// </remarks>
     /// <param name="stdout">Receives Stdout.</param>
     /// <param name="stderr">Receives Stderr.</param>
     /// <returns>A output consumer.</returns>

--- a/src/Testcontainers/Clients/AttachedStream.cs
+++ b/src/Testcontainers/Clients/AttachedStream.cs
@@ -1,0 +1,94 @@
+namespace DotNet.Testcontainers.Clients
+{
+  using System;
+  using System.IO;
+  using System.Threading;
+  using System.Threading.Tasks;
+  using Docker.DotNet;
+  using DotNet.Testcontainers.Configurations;
+  using Microsoft.Extensions.Logging;
+
+  /// <summary>
+  /// A connection to the container's stdout and stderr that copies the output
+  /// to an <see cref="IOutputConsumer" /> until the connection is closed.
+  /// </summary>
+  /// <remarks>
+  /// The Docker daemon writes the container's stdout and stderr to every
+  /// attached client synchronously. A client that stops reading blocks the
+  /// container and every other attached client, including Docker Engine API
+  /// operations such as stopping or removing the container. To avoid blocking
+  /// the container, this instance closes the connection as soon as it is
+  /// disposed, or as soon as the copy operation ends on its own.
+  /// </remarks>
+  internal sealed class AttachedStream : IDisposable
+  {
+    private readonly MultiplexedStream _stream;
+
+    private readonly ILogger _logger;
+
+    private readonly string _id;
+
+    private int _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AttachedStream" /> class.
+    /// </summary>
+    /// <param name="stream">The attached stdout and stderr stream.</param>
+    /// <param name="outputConsumer">The stdout and stderr consumer.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="id">The container id.</param>
+    public AttachedStream(MultiplexedStream stream, IOutputConsumer outputConsumer, ILogger logger, string id)
+    {
+      _stream = stream;
+      _logger = logger;
+      _id = id;
+
+      // The copy operation runs until the connection is closed. Do not pass
+      // the cancellation token of the operation that attached to the container.
+      // It does not cover the lifetime of the connection, and the caller might
+      // dispose its cancellation token source right after the container has
+      // started.
+      _ = stream.CopyOutputToAsync(Stream.Null, outputConsumer.Stdout, outputConsumer.Stderr, CancellationToken.None)
+        .ContinueWith(OnCopyOutputCompleted, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Detaches from the container's stdout and stderr, closing the connection.
+    /// </remarks>
+    public void Dispose()
+    {
+      if (Interlocked.Exchange(ref _disposed, 1) == 0)
+      {
+        _stream.Dispose();
+      }
+    }
+
+    /// <summary>
+    /// Closes the connection once the copy operation has ended.
+    /// </summary>
+    /// <param name="task">The completed copy operation.</param>
+    private void OnCopyOutputCompleted(Task task)
+    {
+      // Read the exception to observe it. Disposing the stream ends the pending
+      // read with an exception too.
+      var exception = task.Exception;
+
+      if (Interlocked.Exchange(ref _disposed, 1) != 0)
+      {
+        return;
+      }
+
+      // The copy operation ended on its own. Either the container's stdout and
+      // stderr reached the end, or the output consumer stopped reading.
+      if (exception != null)
+      {
+        _logger.CanNotReadDockerContainerOutput(_id, exception);
+      }
+
+      // Close the connection instead of leaving a stalled reader attached to
+      // the container.
+      _stream.Dispose();
+    }
+  }
+}

--- a/src/Testcontainers/Clients/DockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/DockerContainerOperations.cs
@@ -131,11 +131,11 @@ namespace DotNet.Testcontainers.Clients
       return tarResponse.Stream;
     }
 
-    public async Task AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default)
+    public async Task<IDisposable> AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default)
     {
       if (!outputConsumer.Enabled)
       {
-        return;
+        return null;
       }
 
       Logger.AttachToDockerContainer(id, outputConsumer.GetType());
@@ -150,8 +150,7 @@ namespace DotNet.Testcontainers.Clients
       var stream = await DockerClient.Containers.AttachContainerAsync(id, attachParameters, ct)
         .ConfigureAwait(false);
 
-      _ = stream.CopyOutputToAsync(Stream.Null, outputConsumer.Stdout, outputConsumer.Stderr, ct)
-        .ConfigureAwait(false);
+      return new AttachedStream(stream, outputConsumer, Logger, id);
     }
 
     public async Task<ExecResult> ExecAsync(string id, IList<string> command, CancellationToken ct = default)

--- a/src/Testcontainers/Clients/IDockerContainerOperations.cs
+++ b/src/Testcontainers/Clients/IDockerContainerOperations.cs
@@ -29,7 +29,7 @@ namespace DotNet.Testcontainers.Clients
 
     Task<Stream> GetArchiveFromContainerAsync(string id, string path, CancellationToken ct = default);
 
-    Task AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default);
+    Task<IDisposable> AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default);
 
     Task<ExecResult> ExecAsync(string id, IList<string> command, CancellationToken ct = default);
 

--- a/src/Testcontainers/Clients/ITestcontainersClient.cs
+++ b/src/Testcontainers/Clients/ITestcontainersClient.cs
@@ -109,8 +109,12 @@ namespace DotNet.Testcontainers.Clients
     /// <param name="id">The container id.</param>
     /// <param name="outputConsumer">The stdout and stderr consumer.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>Task that completes when the container's stdout and stderr has been copied to the consumer.</returns>
-    Task AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default);
+    /// <returns>
+    /// Task that completes when the client has attached to the container's
+    /// stdout and stderr. The result detaches from the container when disposed,
+    /// or is <c>null</c> if the output consumer is disabled.
+    /// </returns>
+    Task<IDisposable> AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default);
 
     /// <summary>
     /// Executes a command in the container.

--- a/src/Testcontainers/Clients/TestcontainersClient.cs
+++ b/src/Testcontainers/Clients/TestcontainersClient.cs
@@ -188,7 +188,7 @@ namespace DotNet.Testcontainers.Clients
     }
 
     /// <inheritdoc />
-    public Task AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default)
+    public Task<IDisposable> AttachAsync(string id, IOutputConsumer outputConsumer, CancellationToken ct = default)
     {
       return Container.AttachAsync(id, outputConsumer, ct);
     }

--- a/src/Testcontainers/Configurations/OutputConsumers/RedirectStdoutAndStderrToStream.cs
+++ b/src/Testcontainers/Configurations/OutputConsumers/RedirectStdoutAndStderrToStream.cs
@@ -6,10 +6,6 @@ namespace DotNet.Testcontainers.Configurations
   /// <inheritdoc cref="IOutputConsumer" />
   internal sealed class RedirectStdoutAndStderrToStream : IOutputConsumer
   {
-    private readonly StreamWriter _stdout;
-
-    private readonly StreamWriter _stderr;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="RedirectStdoutAndStderrToStream" /> class.
     /// </summary>
@@ -23,31 +19,38 @@ namespace DotNet.Testcontainers.Configurations
     /// </summary>
     /// <param name="stdout">The stdout stream.</param>
     /// <param name="stderr">The stderr stream.</param>
+    /// <exception cref="ArgumentException">Thrown when a stream is not writable.</exception>
     public RedirectStdoutAndStderrToStream(Stream stdout, Stream stderr)
     {
-      Enabled = stdout.CanWrite || stderr.CanWrite;
-      _stdout = new StreamWriter(stdout);
-      _stdout.AutoFlush = true;
-      _stderr = new StreamWriter(stderr);
-      _stderr.AutoFlush = true;
+      if (!stdout.CanWrite)
+      {
+        throw new ArgumentException("Stream is not writable.", nameof(stdout));
+      }
+
+      if (!stderr.CanWrite)
+      {
+        throw new ArgumentException("Stream is not writable.", nameof(stderr));
+      }
+
+      Enabled = true;
+      Stdout = stdout;
+      Stderr = stderr;
     }
 
     /// <inheritdoc />
     public bool Enabled { get; }
 
     /// <inheritdoc />
-    public Stream Stdout
-      => _stdout.BaseStream;
+    public Stream Stdout { get; }
 
     /// <inheritdoc />
-    public Stream Stderr
-      => _stderr.BaseStream;
+    public Stream Stderr { get; }
 
     /// <inheritdoc />
     public void Dispose()
     {
-      _stdout.Dispose();
-      _stderr.Dispose();
+      Stdout.Dispose();
+      Stderr.Dispose();
     }
   }
 }

--- a/src/Testcontainers/Containers/ComposeContainer.cs
+++ b/src/Testcontainers/Containers/ComposeContainer.cs
@@ -439,6 +439,22 @@ namespace DotNet.Testcontainers.Containers
         return;
       }
 
+      // Detach from the stdout and stderr of the services before removing them.
+      // A client that stops reading blocks the container it is attached to, and
+      // with it `docker compose down`.
+      foreach (var serviceContainer in _serviceContainers.Values)
+      {
+        try
+        {
+          await serviceContainer.DisposeAsync()
+            .ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+          Logger.CanNotCleanUpComposeProject(ProjectName, e);
+        }
+      }
+
       _serviceContainers = new Dictionary<(string, ushort), ComposeServiceContainer>();
 
       try
@@ -705,9 +721,14 @@ namespace DotNet.Testcontainers.Containers
     {
       // A wait strategy or exposed port that references a service that does not exist
       // would otherwise pass silently, e.g. when the service name contains a typo.
-      var serviceNotFound = _configuration.ExposedServices
-        .Select(exposedService => (exposedService.ServiceName, exposedService.Instance))
-        .Concat(_configuration.ServiceReadiness.Select(serviceReadiness => (serviceReadiness.ServiceName, serviceReadiness.Instance)))
+      var exposedServices = _configuration.ExposedServices
+        .Select(service => (service.ServiceName, service.Instance));
+
+      var serviceReadiness = _configuration.ServiceReadiness
+        .Select(service => (service.ServiceName, service.Instance));
+
+      var serviceNotFound = exposedServices
+        .Concat(serviceReadiness)
         .Where(service => !composeContainers.ContainsKey(service))
         .Select(service => ComposeServiceName.GetDisplayName(service.ServiceName, service.Instance))
         .FirstOrDefault();

--- a/src/Testcontainers/Containers/DockerContainer.cs
+++ b/src/Testcontainers/Containers/DockerContainer.cs
@@ -32,6 +32,8 @@ namespace DotNet.Testcontainers.Containers
 
     private IConnectionStringProvider<IContainer, IContainerConfiguration> _connectionStringProvider;
 
+    private IDisposable _attachedStream;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DockerContainer" /> class.
     /// </summary>
@@ -482,6 +484,12 @@ namespace DotNet.Testcontainers.Containers
           await UnsafeDeleteAsync()
             .ConfigureAwait(false);
         }
+
+        // Derived types such as ComposeServiceContainer neither stop nor delete
+        // the container because another component owns its lifecycle. Detach
+        // from its stdout and stderr either way. This instance opened the
+        // connection and closes it.
+        DisposeAttachedStream();
       }
 
       await base.DisposeAsyncCore()
@@ -588,6 +596,8 @@ namespace DotNet.Testcontainers.Containers
         return;
       }
 
+      DisposeAttachedStream();
+
       await _client.RemoveAsync(_container.ID, ct)
         .ConfigureAwait(false);
 
@@ -610,9 +620,11 @@ namespace DotNet.Testcontainers.Containers
     {
       ThrowIfLockNotAcquired();
 
+      DisposeAttachedStream();
+
       WaitStrategy portBindingsMapped = new WaitUntilPortBindingsMapped(this);
 
-      await _client.AttachAsync(_container.ID, _configuration.OutputConsumer, ct)
+      _attachedStream = await _client.AttachAsync(_container.ID, _configuration.OutputConsumer, ct)
         .ConfigureAwait(false);
 
       await UnsafeStartContainerAsync(ct)
@@ -665,6 +677,8 @@ namespace DotNet.Testcontainers.Containers
 
       await _client.StopAsync(_container.ID, ct)
         .ConfigureAwait(false);
+
+      DisposeAttachedStream();
 
       try
       {
@@ -764,6 +778,25 @@ namespace DotNet.Testcontainers.Containers
     protected override bool Exists()
     {
       return ContainerHasBeenCreatedStates.HasFlag(State);
+    }
+
+    /// <summary>
+    /// Detaches from the container's stdout and stderr, closing the connection.
+    /// </summary>
+    /// <remarks>
+    /// A client that stops reading blocks the container and every other
+    /// attached client, including Docker Engine API operations such as stopping
+    /// or removing the container (see <see cref="AttachedStream" />).
+    /// </remarks>
+    private void DisposeAttachedStream()
+    {
+      if (_attachedStream == null)
+      {
+        return;
+      }
+
+      _attachedStream.Dispose();
+      _attachedStream = null;
     }
 
     /// <summary>

--- a/src/Testcontainers/Logging.cs
+++ b/src/Testcontainers/Logging.cs
@@ -60,6 +60,9 @@ namespace DotNet.Testcontainers
     [LoggerMessage(Level = LogLevel.Information, Message = "Attach {OutputConsumer} at Docker container {Id}")]
     private static partial void AttachToDockerContainerCore(ILogger logger, Type outputConsumer, TruncatedId id);
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Cannot read the stdout and stderr of Docker container {Id}")]
+    private static partial void CanNotReadDockerContainerOutputCore(ILogger logger, TruncatedId id, Exception exception);
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Connect Docker container {ContainerId} to Docker network {NetworkId}")]
     private static partial void ConnectToDockerNetworkCore(ILogger logger, TruncatedId containerId, TruncatedId networkId);
 
@@ -208,6 +211,11 @@ namespace DotNet.Testcontainers
     public static void AttachToDockerContainer(this ILogger logger, string id, Type type)
     {
       AttachToDockerContainerCore(logger, type, new TruncatedId(id));
+    }
+
+    public static void CanNotReadDockerContainerOutput(this ILogger logger, string id, Exception e)
+    {
+      CanNotReadDockerContainerOutputCore(logger, new TruncatedId(id), e);
     }
 
     public static void ConnectToDockerNetwork(this ILogger logger, string networkId, string containerId)


### PR DESCRIPTION
## What does this PR do?

`ITestcontainersClient.AttachAsync` now returns an `IDisposable` that owns the attach connection, instead of leaving the copy operation running as a fire-and-forget task. The new `AttachedStream` closes the connection when it is disposed.

`DockerContainer` holds the handle and detaches before stopping the container, before removing it, when starting again, and on dispose. The dispose path matters for `ComposeServiceContainer`, which overrides both `UnsafeStopAsync` and `UnsafeDeleteAsync` to no-ops because Docker Compose owns the container's lifecycle.

The copy operation deliberately does not take the caller's cancellation token. That token covers attaching, not the lifetime of the connection, and callers may dispose their token source right after the container has started.

## Why is it important?

The Docker daemon writes a container's stdout and stderr to every attached client synchronously. A client that stops reading blocks the container and every other attached client, including the Docker Engine API operations that stop or remove it. On top of that, the attach connection was never closed, leaking one connection per container start and leaving a stalled reader attached for the lifetime of the process.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #1753

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container output attachments can be explicitly detached and disposed by callers.
  * Attachment operations indicate when output forwarding is disabled.
  * Stream redirection now validates that provided streams are writable.

* **Bug Fixes**
  * Improved container lifecycle cleanup during shutdown, removal, restart, and disposal.
  * Prevented stalled output readers from blocking container or Compose shutdown.
  * Automatically closes completed output connections and records read failures.

* **Logging**
  * Added warning logs when container stdout or stderr cannot be read.

* **Documentation**
  * Clarified stream ownership and disposal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->