### PR TITLE
chore: Publish NuGet packages with Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -129,8 +129,8 @@ jobs:
     env:
       CODE_SIGNING_CERTIFICATE_BASE64: ${{ secrets.CODE_SIGNING_CERTIFICATE_BASE64 }}
       CODE_SIGNING_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CERTIFICATE_PASSWORD }}
-      FEED_SOURCE: https://api.nuget.org/v3/index.json
-      FEED_API_KEY: ${{ secrets.FEED_API_KEY }}
+      NUGET_SOURCE: https://api.nuget.org/v3/index.json
+      NUGET_USER: HofmeisterAn
       SONARCLOUD_URL: https://sonarcloud.io
       SONARCLOUD_ORGANIZATION: testcontainers
       SONARCLOUD_KEY: testcontainers_testcontainers-dotnet
@@ -185,9 +185,18 @@ jobs:
         run: ./build.sh --target=Sonar-End
         shell: bash
 
+      - id: nuget-login
+        name: NuGet Login
+        if: ${{ env.PUBLISH_NUGET_PACKAGE == 'true' }}
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ${{ env.NUGET_USER }}
+
       - name: Publish NuGet Package
         run: ./build.sh --target=Publish
         shell: bash
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
 
       - name: Attest
         if: ${{ env.PUBLISH_NUGET_PACKAGE == 'true' }}

--- a/build/Credentials.cs
+++ b/build/Credentials.cs
@@ -63,8 +63,8 @@ internal sealed class NuGetCredentials
     {
         return new NuGetCredentials
         (
-            context.EnvironmentVariable("FEED_SOURCE"),
-            context.EnvironmentVariable("FEED_API_KEY")
+            context.EnvironmentVariable("NUGET_SOURCE"),
+            context.EnvironmentVariable("NUGET_API_KEY")
         );
     }
 }


### PR DESCRIPTION
## What does this PR do?

Replaces the long-lived NuGet API key with [Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing). The `cd` job now uses `NuGet/login` to exchange the GitHub OIDC token for a short-lived API key (valid for 1 hour) right before publishing. It passes the key to the existing Cake `Publish` target, which still pushes the packages.

## Why is it important?

No long-lived secret to store, rotate, or leak. Only `cicd.yml` in `testcontainers/testcontainers-dotnet` running in the `production` environment can get a key, and only for `Testcontainers` and `Testcontainers.*` packages.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated NuGet package publishing to use the current source and credential configuration.
  - Added authenticated NuGet login during publishing when package publication is enabled.
  - Improved the handoff of publishing credentials to the package publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->